### PR TITLE
Use explicit chaining when transforming an exception

### DIFF
--- a/src/mitre/securingai/generics_plugins/estimator_predict/tf_keras_model.py
+++ b/src/mitre/securingai/generics_plugins/estimator_predict/tf_keras_model.py
@@ -62,13 +62,13 @@ def _(estimator: Model, x: Any, pred_type: str, **kwargs) -> np.ndarray:
             **kwargs,
         )
 
-    except EstimatorPredictGenericPredTypeError:
+    except EstimatorPredictGenericPredTypeError as exc:
         LOGGER.exception(
             "Unknown pred_type argument for estimator_predict function.",
             estimator="tensorflow.keras.Model",
             pred_type=pred_type,
         )
-        raise EstimatorPredictGenericPredTypeError
+        raise exc
 
     return prediction
 

--- a/src/mitre/securingai/pyplugs/_plugins.py
+++ b/src/mitre/securingai/pyplugs/_plugins.py
@@ -223,22 +223,22 @@ def info(package: str, plugin: str, func: Optional[str] = None) -> PluginInfo:
     try:
         plugin_info = _PLUGINS[package][plugin]
 
-    except KeyError:
+    except KeyError as exc:
         raise UnknownPluginError(
             f"Could not find any plug-in named {plugin!r} inside {package!r}. "
             "Use pyplugs.register to register functions as plug-ins"
-        )
+        ) from exc
 
     func = next(iter(plugin_info.keys())) if func is None else func
 
     try:
         return plugin_info[func]
 
-    except KeyError:
+    except KeyError as exc:
         raise UnknownPluginFunctionError(
             f"Could not find any function named {func!r} inside '{package}.{plugin}'. "
             "Use pyplugs.register to register plug-in functions"
-        )
+        ) from exc
 
 
 @expose

--- a/src/mitre/securingai/restapi/experiment/service.py
+++ b/src/mitre/securingai/restapi/experiment/service.py
@@ -90,8 +90,8 @@ class ExperimentService(object):
                 str
             ] = self._mlflow_tracking_service.create_experiment(experiment_name)
 
-        except RestException:
-            raise ExperimentMLFlowTrackingRegistrationError
+        except RestException as exc:
+            raise ExperimentMLFlowTrackingRegistrationError from exc
 
         if experiment_id is None:
             raise ExperimentMLFlowTrackingAlreadyExistsError

--- a/src/mitre/securingai/sdk/cryptography/verify.py
+++ b/src/mitre/securingai/sdk/cryptography/verify.py
@@ -85,7 +85,9 @@ def verify_payload(payload: bytes, signature: bytes, public_key: RSAPublicKey) -
         )
 
     except InvalidSignature:
-        raise InvalidSignature("Payload and/or signature files failed verification")
+        raise InvalidSignature(
+            "Payload and/or signature files failed verification"
+        ) from None
 
     return True
 


### PR DESCRIPTION
## Summary

Satisfy the new B904 rule (https://github.com/PyCQA/flake8-bugbear/pull/181) from `flake8-bugbear`
by using explicit exception chaining whenever an exception is being transformed.

## Changelog

### Refactor

- use explicit exception chaining