### PR TITLE
Install missing libgl1 dependency in the Tensorflow and PyTorch images

### DIFF
--- a/docker/pytorch-cpu/Dockerfile
+++ b/docker/pytorch-cpu/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && \
     git \
     gosu \
     libbz2-1.0 \
+    libgl1 \
     liblz4-1 \
     liblzma5 \
     libsnappy1v5 \

--- a/docker/pytorch-gpu/Dockerfile
+++ b/docker/pytorch-gpu/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && \
     git \
     gosu \
     libbz2-1.0 \
+    libgl1 \
     liblz4-1 \
     liblzma5 \
     libsnappy1v5 \

--- a/docker/tensorflow2-cpu/Dockerfile
+++ b/docker/tensorflow2-cpu/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && \
     git \
     gosu \
     libbz2-1.0 \
+    libgl1 \
     liblz4-1 \
     liblzma5 \
     libsnappy1v5 \

--- a/docker/tensorflow2-gpu/Dockerfile
+++ b/docker/tensorflow2-gpu/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && \
     git \
     gosu \
     libbz2-1.0 \
+    libgl1 \
     liblz4-1 \
     liblzma5 \
     libsnappy1v5 \


### PR DESCRIPTION
## Changelog

### Build

- **docker:** install libgl1 in tensorflow and pytorch images