### PR TITLE
Fix - Dependency injection broken for multiple REST API controller and service files

### DIFF
--- a/src/mitre/securingai/restapi/__init__.py
+++ b/src/mitre/securingai/restapi/__init__.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The Dioptra REST API package."""
+from __future__ import annotations
 
 from .app import create_app
 

--- a/src/mitre/securingai/restapi/app.py
+++ b/src/mitre/securingai/restapi/app.py
@@ -20,6 +20,7 @@
 :py:class:`~flask.Flask` object and wires up all the configurations and third-party
 dependencies.
 """
+from __future__ import annotations
 
 import uuid
 from typing import Any, Callable, List, Optional

--- a/src/mitre/securingai/restapi/cli/gunicorn.py
+++ b/src/mitre/securingai/restapi/cli/gunicorn.py
@@ -16,6 +16,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """A module for starting the gunicorn wsgi server."""
+from __future__ import annotations
 
 import os
 

--- a/src/mitre/securingai/restapi/config.py
+++ b/src/mitre/securingai/restapi/config.py
@@ -22,6 +22,7 @@ There are three configuration environments available,
 - **prod:** The configuration for production environments.
 - **test:** The configuration for running unit tests.
 """
+from __future__ import annotations
 
 import os
 from typing import List, Type

--- a/src/mitre/securingai/restapi/dependencies.py
+++ b/src/mitre/securingai/restapi/dependencies.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """A module for binding configurations to shared services using dependency injection."""
+from __future__ import annotations
 
 from typing import Any, Callable, List
 

--- a/src/mitre/securingai/restapi/errors.py
+++ b/src/mitre/securingai/restapi/errors.py
@@ -18,6 +18,7 @@
 
 .. |Api| replace:: :py:class:`flask_restx.Api`
 """
+from __future__ import annotations
 
 from flask_restx import Api
 

--- a/src/mitre/securingai/restapi/experiment/controller.py
+++ b/src/mitre/securingai/restapi/experiment/controller.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The module defining the experiment endpoints."""
+from __future__ import annotations
 
 import uuid
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/experiment/dependencies.py
+++ b/src/mitre/securingai/restapi/experiment/dependencies.py
@@ -15,10 +15,32 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Binding configurations to shared services using dependency injection."""
+from __future__ import annotations
 
 from typing import Any, Callable, List
 
-from injector import Binder
+from flask_injector import request
+from injector import Binder, Module, provider
+from mlflow.tracking import MlflowClient
+
+from .schema import ExperimentRegistrationFormSchema
+
+
+class ExperimentRegistrationFormSchemaModule(Module):
+    @provider
+    def provide_experiment_registration_form_schema_module(
+        self,
+    ) -> ExperimentRegistrationFormSchema:
+        return ExperimentRegistrationFormSchema()
+
+
+class MLFlowClientModule(Module):
+    @request
+    @provider
+    def provide_mlflow_client_module(
+        self,
+    ) -> MlflowClient:
+        return MlflowClient()
 
 
 def bind_dependencies(binder: Binder) -> None:
@@ -37,4 +59,5 @@ def register_providers(modules: List[Callable[..., Any]]) -> None:
         modules: A list of callables used for configuring the dependency injection
             environment.
     """
-    pass
+    modules.append(ExperimentRegistrationFormSchemaModule)
+    modules.append(MLFlowClientModule)

--- a/src/mitre/securingai/restapi/experiment/errors.py
+++ b/src/mitre/securingai/restapi/experiment/errors.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Error handlers for the experiment endpoints."""
+from __future__ import annotations
 
 from flask_restx import Api
 

--- a/src/mitre/securingai/restapi/experiment/interface.py
+++ b/src/mitre/securingai/restapi/experiment/interface.py
@@ -18,6 +18,7 @@
 
 .. |Experiment| replace:: :py:class:`~.model.Experiment`
 """
+from __future__ import annotations
 
 import datetime
 

--- a/src/mitre/securingai/restapi/experiment/model.py
+++ b/src/mitre/securingai/restapi/experiment/model.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The data models for the experiment endpoint objects."""
+from __future__ import annotations
 
 import datetime
 

--- a/src/mitre/securingai/restapi/experiment/routes.py
+++ b/src/mitre/securingai/restapi/experiment/routes.py
@@ -19,6 +19,7 @@
 .. |Api| replace:: :py:class:`flask_restx.Api`
 .. |Flask| replace:: :py:class:`flask.Flask`
 """
+from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api

--- a/src/mitre/securingai/restapi/experiment/schema.py
+++ b/src/mitre/securingai/restapi/experiment/schema.py
@@ -21,6 +21,7 @@
 .. |ExperimentRegistrationFormData| replace:: \
    :py:class:`~.model.ExperimentRegistrationFormData`
 """
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/src/mitre/securingai/restapi/experiment/service.py
+++ b/src/mitre/securingai/restapi/experiment/service.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The server-side functions that perform experiment endpoint operations."""
+from __future__ import annotations
 
 import datetime
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/job/controller.py
+++ b/src/mitre/securingai/restapi/job/controller.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The module defining the job endpoints."""
+from __future__ import annotations
 
 import uuid
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/job/dependencies.py
+++ b/src/mitre/securingai/restapi/job/dependencies.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Binding configurations to shared services using dependency injection."""
+from __future__ import annotations
 
 import os
 from dataclasses import dataclass
@@ -27,6 +28,14 @@ from injector import Binder, Module, provider
 from redis import Redis
 
 from mitre.securingai.restapi.shared.rq.service import RQService
+
+from .schema import JobFormSchema
+
+
+class JobFormSchemaModule(Module):
+    @provider
+    def provide_job_form_schema_module(self) -> JobFormSchema:
+        return JobFormSchema()
 
 
 @dataclass
@@ -83,4 +92,5 @@ def register_providers(modules: List[Callable[..., Any]]) -> None:
         modules: A list of callables used for configuring the dependency injection
             environment.
     """
+    modules.append(JobFormSchemaModule)
     modules.append(RQServiceModule)

--- a/src/mitre/securingai/restapi/job/errors.py
+++ b/src/mitre/securingai/restapi/job/errors.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Error handlers for the job endpoints."""
+from __future__ import annotations
 
 from flask_restx import Api
 

--- a/src/mitre/securingai/restapi/job/interface.py
+++ b/src/mitre/securingai/restapi/job/interface.py
@@ -18,6 +18,7 @@
 
 .. |Job| replace:: :py:class:`~.model.Job`
 """
+from __future__ import annotations
 
 import datetime
 from typing import Optional

--- a/src/mitre/securingai/restapi/job/model.py
+++ b/src/mitre/securingai/restapi/job/model.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The data models for the job endpoint objects."""
+from __future__ import annotations
 
 import datetime
 from typing import Optional

--- a/src/mitre/securingai/restapi/job/routes.py
+++ b/src/mitre/securingai/restapi/job/routes.py
@@ -19,6 +19,7 @@
 .. |Api| replace:: :py:class:`flask_restx.Api`
 .. |Flask| replace:: :py:class:`flask.Flask`
 """
+from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api

--- a/src/mitre/securingai/restapi/job/schema.py
+++ b/src/mitre/securingai/restapi/job/schema.py
@@ -20,6 +20,7 @@
 .. |JobForm| replace:: :py:class:`~.model.JobForm`
 .. |JobFormData| replace:: :py:class:`~.model.JobFormData`
 """
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/src/mitre/securingai/restapi/job/service.py
+++ b/src/mitre/securingai/restapi/job/service.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The server-side functions that perform job endpoint operations."""
+from __future__ import annotations
 
 import datetime
 import uuid

--- a/src/mitre/securingai/restapi/models.py
+++ b/src/mitre/securingai/restapi/models.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """A module of reexports of the application's data models and forms."""
+from __future__ import annotations
 
 from .experiment.model import (
     Experiment,

--- a/src/mitre/securingai/restapi/queue/controller.py
+++ b/src/mitre/securingai/restapi/queue/controller.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The module defining the queue endpoints."""
+from __future__ import annotations
 
 import uuid
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/queue/dependencies.py
+++ b/src/mitre/securingai/restapi/queue/dependencies.py
@@ -15,10 +15,21 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Binding configurations to shared services using dependency injection."""
+from __future__ import annotations
 
 from typing import Any, Callable, List
 
-from injector import Binder
+from injector import Binder, Module, provider
+
+from .schema import QueueRegistrationFormSchema
+
+
+class QueueRegistrationFormSchemaModule(Module):
+    @provider
+    def provide_queue_registration_form_schema_module(
+        self,
+    ) -> QueueRegistrationFormSchema:
+        return QueueRegistrationFormSchema()
 
 
 def bind_dependencies(binder: Binder) -> None:
@@ -37,4 +48,4 @@ def register_providers(modules: List[Callable[..., Any]]) -> None:
         modules: A list of callables used for configuring the dependency injection
             environment.
     """
-    pass
+    modules.append(QueueRegistrationFormSchemaModule)

--- a/src/mitre/securingai/restapi/queue/errors.py
+++ b/src/mitre/securingai/restapi/queue/errors.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Error handlers for the queue endpoints."""
+from __future__ import annotations
 
 from flask_restx import Api
 

--- a/src/mitre/securingai/restapi/queue/interface.py
+++ b/src/mitre/securingai/restapi/queue/interface.py
@@ -18,6 +18,7 @@
 
 .. |Queue| replace:: :py:class:`~.model.Queue`
 """
+from __future__ import annotations
 
 import datetime
 

--- a/src/mitre/securingai/restapi/queue/model.py
+++ b/src/mitre/securingai/restapi/queue/model.py
@@ -15,7 +15,6 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The data models for the queue endpoint objects."""
-
 from __future__ import annotations
 
 import datetime

--- a/src/mitre/securingai/restapi/queue/routes.py
+++ b/src/mitre/securingai/restapi/queue/routes.py
@@ -19,6 +19,7 @@
 .. |Api| replace:: :py:class:`flask_restx.Api`
 .. |Flask| replace:: :py:class:`flask.Flask`
 """
+from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api

--- a/src/mitre/securingai/restapi/queue/schema.py
+++ b/src/mitre/securingai/restapi/queue/schema.py
@@ -21,6 +21,7 @@
 .. |QueueRegistrationForm| replace:: :py:class:`~.model.QueueRegistrationForm`
 .. |QueueRegistrationFormData| replace:: :py:class:`~.model.QueueRegistrationFormData`
 """
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/src/mitre/securingai/restapi/queue/service.py
+++ b/src/mitre/securingai/restapi/queue/service.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The server-side functions that perform queue endpoint operations."""
+from __future__ import annotations
 
 import datetime
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/routes.py
+++ b/src/mitre/securingai/restapi/routes.py
@@ -19,6 +19,7 @@
 .. |Api| replace:: :py:class:`flask_restx.Api`
 .. |Flask| replace:: :py:class:`flask.Flask`
 """
+from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api

--- a/src/mitre/securingai/restapi/shared/io_file/service.py
+++ b/src/mitre/securingai/restapi/shared/io_file/service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import tarfile
 from pathlib import Path
 from tarfile import TarFile, TarInfo

--- a/src/mitre/securingai/restapi/shared/mlflow_tracking/service.py
+++ b/src/mitre/securingai/restapi/shared/mlflow_tracking/service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from typing import Optional
 
 import structlog

--- a/src/mitre/securingai/restapi/shared/rq/service.py
+++ b/src/mitre/securingai/restapi/shared/rq/service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from typing import Optional, Union
 
 import structlog

--- a/src/mitre/securingai/restapi/shared/s3/service.py
+++ b/src/mitre/securingai/restapi/shared/s3/service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Union

--- a/src/mitre/securingai/restapi/task_plugin/controller.py
+++ b/src/mitre/securingai/restapi/task_plugin/controller.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The module defining the task plugin endpoints."""
+from __future__ import annotations
 
 import uuid
 from typing import List, Optional

--- a/src/mitre/securingai/restapi/task_plugin/dependencies.py
+++ b/src/mitre/securingai/restapi/task_plugin/dependencies.py
@@ -15,10 +15,21 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Binding configurations to shared services using dependency injection."""
+from __future__ import annotations
 
 from typing import Any, Callable, List
 
-from injector import Binder
+from injector import Binder, Module, provider
+
+from .schema import TaskPluginUploadFormSchema
+
+
+class TaskPluginUploadFormSchemaModule(Module):
+    @provider
+    def provide_task_plugin_upload_form_schema_module(
+        self,
+    ) -> TaskPluginUploadFormSchema:
+        return TaskPluginUploadFormSchema()
 
 
 def bind_dependencies(binder: Binder) -> None:
@@ -37,4 +48,4 @@ def register_providers(modules: List[Callable[..., Any]]) -> None:
         modules: A list of callables used for configuring the dependency injection
             environment.
     """
-    pass
+    modules.append(TaskPluginUploadFormSchemaModule)

--- a/src/mitre/securingai/restapi/task_plugin/errors.py
+++ b/src/mitre/securingai/restapi/task_plugin/errors.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Error handlers for the task plugin endpoints."""
+from __future__ import annotations
 
 from flask_restx import Api
 

--- a/src/mitre/securingai/restapi/task_plugin/interface.py
+++ b/src/mitre/securingai/restapi/task_plugin/interface.py
@@ -18,6 +18,7 @@
 
 .. |TaskPlugin| replace:: :py:class:`~.model.TaskPlugin`
 """
+from __future__ import annotations
 
 from typing import List
 

--- a/src/mitre/securingai/restapi/task_plugin/routes.py
+++ b/src/mitre/securingai/restapi/task_plugin/routes.py
@@ -19,6 +19,7 @@
 .. |Api| replace:: :py:class:`flask_restx.Api`
 .. |Flask| replace:: :py:class:`flask.Flask`
 """
+from __future__ import annotations
 
 from flask import Flask
 from flask_restx import Api

--- a/src/mitre/securingai/restapi/task_plugin/schema.py
+++ b/src/mitre/securingai/restapi/task_plugin/schema.py
@@ -20,6 +20,7 @@
 .. |TaskPluginUploadForm| replace:: :py:class:`~.model.TaskPluginUploadForm`
 .. |TaskPluginUploadFormData| replace:: :py:class:`~.model.TaskPluginUploadFormData`
 """
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/src/mitre/securingai/restapi/task_plugin/service.py
+++ b/src/mitre/securingai/restapi/task_plugin/service.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The server-side functions that perform task plugin endpoint operations."""
+from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/src/mitre/securingai/restapi/utils.py
+++ b/src/mitre/securingai/restapi/utils.py
@@ -21,6 +21,7 @@
 .. |RequestParser| replace:: :py:class:`~flask_restx.reqparse.RequestParser`
 .. |Resource| replace:: :py:class:`~flask_restx.Resource`
 """
+from __future__ import annotations
 
 from typing import List
 

--- a/tests/unit/restapi/conftest.py
+++ b/tests/unit/restapi/conftest.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import io
 import tarfile
 from typing import Any, BinaryIO, List
@@ -83,9 +85,19 @@ def task_plugin_archive():
 
 @pytest.fixture
 def dependency_modules() -> List[Any]:
+    from mitre.securingai.restapi.experiment.dependencies import (
+        ExperimentRegistrationFormSchemaModule,
+    )
     from mitre.securingai.restapi.job.dependencies import (
+        JobFormSchemaModule,
         RQServiceConfiguration,
         RQServiceModule,
+    )
+    from mitre.securingai.restapi.queue.dependencies import (
+        QueueRegistrationFormSchemaModule,
+    )
+    from mitre.securingai.restapi.task_plugin.dependencies import (
+        TaskPluginUploadFormSchemaModule,
     )
 
     def _bind_s3_service_configuration(binder: Binder) -> None:
@@ -106,7 +118,14 @@ def dependency_modules() -> List[Any]:
         )
         _bind_s3_service_configuration(binder)
 
-    return [configure, RQServiceModule()]
+    return [
+        configure,
+        ExperimentRegistrationFormSchemaModule(),
+        JobFormSchemaModule(),
+        QueueRegistrationFormSchemaModule(),
+        RQServiceModule(),
+        TaskPluginUploadFormSchemaModule(),
+    ]
 
 
 @pytest.fixture

--- a/tests/unit/restapi/experiment/test_controller.py
+++ b/tests/unit/restapi/experiment/test_controller.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict, List
 

--- a/tests/unit/restapi/experiment/test_interface.py
+++ b/tests/unit/restapi/experiment/test_interface.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/experiment/test_model.py
+++ b/tests/unit/restapi/experiment/test_model.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/experiment/test_schema.py
+++ b/tests/unit/restapi/experiment/test_schema.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict
 

--- a/tests/unit/restapi/experiment/test_service.py
+++ b/tests/unit/restapi/experiment/test_service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import List
 

--- a/tests/unit/restapi/job/conftest.py
+++ b/tests/unit/restapi/job/conftest.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/job/test_controller.py
+++ b/tests/unit/restapi/job/test_controller.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 import uuid
 from typing import Any, BinaryIO, Dict, List

--- a/tests/unit/restapi/job/test_interface.py
+++ b/tests/unit/restapi/job/test_interface.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/job/test_model.py
+++ b/tests/unit/restapi/job/test_model.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import BinaryIO
 

--- a/tests/unit/restapi/job/test_schema.py
+++ b/tests/unit/restapi/job/test_schema.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import Any, BinaryIO, Dict
 

--- a/tests/unit/restapi/job/test_service.py
+++ b/tests/unit/restapi/job/test_service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from dataclasses import dataclass
 from typing import BinaryIO, List, Optional

--- a/tests/unit/restapi/queue/conftest.py
+++ b/tests/unit/restapi/queue/conftest.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/queue/test_controller.py
+++ b/tests/unit/restapi/queue/test_controller.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict, List
 

--- a/tests/unit/restapi/queue/test_interface.py
+++ b/tests/unit/restapi/queue/test_interface.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/queue/test_model.py
+++ b/tests/unit/restapi/queue/test_model.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/tests/unit/restapi/queue/test_schema.py
+++ b/tests/unit/restapi/queue/test_schema.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import Any, Dict
 

--- a/tests/unit/restapi/queue/test_service.py
+++ b/tests/unit/restapi/queue/test_service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import datetime
 from typing import List, Optional, Set
 

--- a/tests/unit/restapi/task_plugin/conftest.py
+++ b/tests/unit/restapi/task_plugin/conftest.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from typing import Any, BinaryIO, Dict
 
 import pytest

--- a/tests/unit/restapi/task_plugin/test_controller.py
+++ b/tests/unit/restapi/task_plugin/test_controller.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from typing import Any, BinaryIO, Dict, List
 
 import pytest

--- a/tests/unit/restapi/task_plugin/test_interface.py
+++ b/tests/unit/restapi/task_plugin/test_interface.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import structlog
 from structlog.stdlib import BoundLogger
 

--- a/tests/unit/restapi/task_plugin/test_model.py
+++ b/tests/unit/restapi/task_plugin/test_model.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 import structlog
 from structlog.stdlib import BoundLogger
 

--- a/tests/unit/restapi/task_plugin/test_schema.py
+++ b/tests/unit/restapi/task_plugin/test_schema.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from typing import Any, BinaryIO, Dict
 
 import pytest

--- a/tests/unit/restapi/task_plugin/test_service.py
+++ b/tests/unit/restapi/task_plugin/test_service.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List

--- a/tests/unit/restapi/test_app.py
+++ b/tests/unit/restapi/test_app.py
@@ -14,6 +14,8 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
 from flask import Flask, Response
 
 


### PR DESCRIPTION
Fixes the bug that appeared after the 3.15.0 update to the marshmallow package, specifically the changes introduced in marshmallow-code/marshmallow#1932. These changes made the marshmallow package compliant with PEP 563 and PEP 604, which introduced the `|` operator into the type annotations for the constructor of the `Schema` class. The `typing.get_type_hints` function did not understand how to evaluate the `|` operator in this context. The injector package uses `typing.get_type_hints` and so it raised an error when it tried to check if the `Schema` class needed any injections.

This commit resolves this issue by declaring explicit injector providers for all classes inheriting from marshmallow's `Schema` class that are known to be injected elsewhere in the code base. This change avoids the issue entirely by preventing the injector library from trying to instantiate these classes on its own. A provider is also implemented for the `mlflow.tracking.MlflowClient` class as a future-proofing measure.

See also: marshmallow-code/marshmallow#1932, alecthomas/injector#116

Closes #30 