### PR TITLE
Refactor get_all task plugins function to require fewer S3 permissions

### DIFF
--- a/src/dioptra/restapi/task_plugin/controller.py
+++ b/src/dioptra/restapi/task_plugin/controller.py
@@ -60,7 +60,9 @@ class TaskPluginResource(Resource):
         )
         log.info("Request received")
         return self._task_plugin_service.get_all(
-            bucket=current_app.config["DIOPTRA_PLUGINS_BUCKET"], log=log
+            s3_collections_list=["dioptra_builtins", "dioptra_custom"],
+            bucket=current_app.config["DIOPTRA_PLUGINS_BUCKET"],
+            log=log,
         )
 
     @api.expect(as_api_parser(api, TaskPluginUploadSchema))

--- a/src/dioptra/restapi/task_plugin/service.py
+++ b/src/dioptra/restapi/task_plugin/service.py
@@ -116,20 +116,19 @@ class TaskPluginService(object):
 
         return [task_plugin]
 
-    def get_all(self, bucket: str = "plugins", **kwargs) -> List[TaskPlugin]:
+    def get_all(
+        self, s3_collections_list: List[str], bucket: str = "plugins", **kwargs
+    ) -> List[TaskPlugin]:
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
         log.info("Get all task plugins")
 
-        s3_collections_list: List[str] = self._s3_service.list_directories(
-            bucket=bucket,
-            prefix=self._s3_service.normalize_prefix("/", log=log),
-            log=log,
-        )
-
         task_plugins: List[TaskPlugin] = []
+
         for collection in s3_collections_list:
-            task_plugins.extend(self.get_all_in_collection(collection, log=log))
+            task_plugins.extend(
+                self.get_all_in_collection(collection, bucket=bucket, log=log)
+            )
 
         return task_plugins
 

--- a/tests/unit/restapi/task_plugin/conftest.py
+++ b/tests/unit/restapi/task_plugin/conftest.py
@@ -84,23 +84,6 @@ def task_plugin_upload_form_data(
 
 
 @pytest.fixture
-def list_objects_v2_collections() -> Dict[str, Any]:
-    return {
-        "IsTruncated": False,
-        "Name": "plugins",
-        "Prefix": "/",
-        "Delimiter": "/",
-        "MaxKeys": 4500,
-        "CommonPrefixes": [
-            {"Prefix": "dioptra_builtins/"},
-            {"Prefix": "dioptra_custom/"},
-        ],
-        "EncodingType": "url",
-        "KeyCount": 2,
-    }
-
-
-@pytest.fixture
 def list_objects_v2_builtins() -> Dict[str, Any]:
     return {
         "IsTruncated": False,

--- a/tests/unit/restapi/task_plugin/test_service.py
+++ b/tests/unit/restapi/task_plugin/test_service.py
@@ -141,43 +141,36 @@ def test_delete_prefix(
 def test_get_all(
     s3_service: S3Service,
     task_plugin_service: TaskPluginService,
-    list_objects_v2_collections: Dict[str, Any],
     list_objects_v2_builtins: Dict[str, Any],
     list_objects_v2_custom: Dict[str, Any],
     list_objects_v2_builtins_artifacts: Dict[str, Any],
     list_objects_v2_builtins_attacks: Dict[str, Any],
     list_objects_v2_custom_new_plugin_one: Dict[str, Any],
     list_objects_v2_custom_new_plugin_two: Dict[str, Any],
-    monkeypatch: MonkeyPatch,
 ) -> None:
     list_objects_v2_expected_params1: Dict[str, Any] = {
         "Bucket": "plugins",
         "Delimiter": "/",
-        "Prefix": "/",
+        "Prefix": "dioptra_builtins/",
     }
     list_objects_v2_expected_params2: Dict[str, Any] = {
         "Bucket": "plugins",
-        "Delimiter": "/",
-        "Prefix": "dioptra_builtins/",
+        "Prefix": "dioptra_builtins/artifacts/",
     }
     list_objects_v2_expected_params3: Dict[str, Any] = {
         "Bucket": "plugins",
-        "Prefix": "dioptra_builtins/artifacts/",
-    }
-    list_objects_v2_expected_params4: Dict[str, Any] = {
-        "Bucket": "plugins",
         "Prefix": "dioptra_builtins/attacks/",
     }
-    list_objects_v2_expected_params5: Dict[str, Any] = {
+    list_objects_v2_expected_params4: Dict[str, Any] = {
         "Bucket": "plugins",
         "Delimiter": "/",
         "Prefix": "dioptra_custom/",
     }
-    list_objects_v2_expected_params6: Dict[str, Any] = {
+    list_objects_v2_expected_params5: Dict[str, Any] = {
         "Bucket": "plugins",
         "Prefix": "dioptra_custom/new_plugin_one/",
     }
-    list_objects_v2_expected_params7: Dict[str, Any] = {
+    list_objects_v2_expected_params6: Dict[str, Any] = {
         "Bucket": "plugins",
         "Prefix": "dioptra_custom/new_plugin_two/",
     }
@@ -185,40 +178,36 @@ def test_get_all(
     with Stubber(s3_service._client) as stubber:
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_collections,
+            list_objects_v2_builtins,
             list_objects_v2_expected_params1,
         )
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_builtins,
+            list_objects_v2_builtins_artifacts,
             list_objects_v2_expected_params2,
         )
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_builtins_artifacts,
+            list_objects_v2_builtins_attacks,
             list_objects_v2_expected_params3,
         )
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_builtins_attacks,
+            list_objects_v2_custom,
             list_objects_v2_expected_params4,
         )
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_custom,
+            list_objects_v2_custom_new_plugin_one,
             list_objects_v2_expected_params5,
         )
         stubber.add_response(
             "list_objects_v2",
-            list_objects_v2_custom_new_plugin_one,
+            list_objects_v2_custom_new_plugin_two,
             list_objects_v2_expected_params6,
         )
-        stubber.add_response(
-            "list_objects_v2",
-            list_objects_v2_custom_new_plugin_two,
-            list_objects_v2_expected_params7,
-        )
         response_task_plugin: List[TaskPlugin] = task_plugin_service.get_all(
+            s3_collections_list=["dioptra_builtins", "dioptra_custom"],
             bucket="plugins"
         )
         stubber.assert_no_pending_responses()


### PR DESCRIPTION
## Summary

There are only two namespaces for the task plugins, `dioptra_builtins` and `dioptra_custom`. By
passing these explicitly, the service no longer needs to fetch a full list of directories for the Dioptra plugins bucket before fetching the list of plugin files. This allows the service to operate without needing full ListBucket permissions.

This commit also updates the associated `get_all` unit test to reflect the change and removes the stubbed S3 response that is no longer used.