### PR TITLE
fix: correct adversarial patch demo run parameters

### DIFF
--- a/examples/tensorflow-adversarial-patches/demo-fruits360-patches.ipynb
+++ b/examples/tensorflow-adversarial-patches/demo-fruits360-patches.ipynb
@@ -544,8 +544,8 @@
     "            f\"-P run_id={response_vgg16_patches['mlflowRunId']}\",\n",
     "            f\"-P model_name={EXPERIMENT_NAME}_vgg16\",\n",
     "            f\"-P model_version=none\",\n",
-    "            \"-P image_size=224,224,3\",\n",
     "            \"-P imagenet_preprocessing=True\",\n",
+    "            \"-P image_size=224,224,3\",\n",
     "            f\"-P data_dir={DATASET_DIR}/Training\",\n",
     "        ]\n",
     "    ),\n",
@@ -700,9 +700,8 @@
     "            f\"-P dataset_run_id_testing={response_deploy_vgg16_patches_testing['mlflowRunId']}\",\n",
     "            f\"-P dataset_run_id_training={response_deploy_vgg16_patches_training['mlflowRunId']}\",\n",
     "            \"-P batch_size=256\",\n",
-    "            f\"-P register_model_name={EXPERIMENT_NAME}_vgg16\",\n",
+    "            f\"-P register_model_name={EXPERIMENT_NAME}_adversarial_patch_vgg16\",\n",
     "            \"-P image_size=224,224,3\",\n",
-    "            \"-P imagenet_preprocessing=True\",\n",
     "            \"-P epochs=10\",\n",
     "            f\"-P data_dir_training={DATASET_DIR}/Training\",\n",
     "            f\"-P data_dir_testing={DATASET_DIR}/Test\",\n",
@@ -738,7 +737,6 @@
     "            f\"-P model_name={EXPERIMENT_NAME}_adversarial_patch_vgg16\",\n",
     "            f\"-P model_version=none\",\n",
     "            \"-P image_size=224,224,3\",\n",
-    "            \"-P imagenet_preprocessing=True\",\n",
     "            \"-P batch_size=256\",\n",
     "            \"-P adv_tar_name=adversarial_patch_dataset.tar.gz\",\n",
     "            \"-P adv_data_dir=adv_patch_dataset\",\n",
@@ -865,7 +863,7 @@
    "hash": "edee40310913f16e2ca02c1d37887bcb7f07f00399ca119bb7e27de7d632ea99"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -879,7 +877,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/examples/tensorflow-adversarial-patches/demo-imagenet-patches.ipynb
+++ b/examples/tensorflow-adversarial-patches/demo-imagenet-patches.ipynb
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,9 +190,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "make: Nothing to be done for 'workflows'.\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
     "\n",
@@ -210,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,9 +236,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'createdOn': '2022-05-15T00:54:38.372693',\n",
+       " 'name': 'howard_imagenet_adversarial_patch',\n",
+       " 'experimentId': 3,\n",
+       " 'lastModified': '2022-05-15T00:54:38.372693'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "response_experiment = restapi_client.get_experiment_by_name(name=EXPERIMENT_NAME)\n",
     "\n",
@@ -250,9 +272,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'createdOn': '2022-05-04T22:01:06.622195',\n",
+       "  'name': 'tensorflow_cpu',\n",
+       "  'queueId': 1,\n",
+       "  'lastModified': '2022-05-04T22:01:06.622195'},\n",
+       " {'createdOn': '2022-05-04T22:01:07.551981',\n",
+       "  'name': 'tensorflow_gpu',\n",
+       "  'queueId': 2,\n",
+       "  'lastModified': '2022-05-04T22:01:07.551981'},\n",
+       " {'createdOn': '2022-05-04T22:01:08.473076',\n",
+       "  'name': 'pytorch_cpu',\n",
+       "  'queueId': 3,\n",
+       "  'lastModified': '2022-05-04T22:01:08.473076'},\n",
+       " {'createdOn': '2022-05-04T22:01:09.418804',\n",
+       "  'name': 'pytorch_gpu',\n",
+       "  'queueId': 4,\n",
+       "  'lastModified': '2022-05-04T22:01:09.418804'}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "restapi_client.list_queues()"
    ]
@@ -268,9 +316,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "make: Nothing to be done for 'custom-plugins'.\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
     "\n",
@@ -289,9 +345,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'taskPluginName': 'custom_patch_plugins',\n",
+       " 'modules': ['estimators_keras_classifiers.py',\n",
+       "  'import_keras.py',\n",
+       "  'registry_art.py',\n",
+       "  '__init__.py',\n",
+       "  'defenses_image_preprocessing.py',\n",
+       "  'tensorflow.py',\n",
+       "  'data_tensorflow.py',\n",
+       "  'attacks_patch.py'],\n",
+       " 'collection': 'dioptra_custom'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "restapi_client.delete_custom_task_plugin(name=\"custom_patch_plugins\")\n",
     "response_custom_plugins = restapi_client.get_custom_task_plugin(name=\"custom_patch_plugins\")\n",
@@ -333,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,9 +479,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initialization job for ResNet50 neural network submitted\n",
+      "\n",
+      "{'createdOn': '2022-05-20T19:06:52.490501',\n",
+      " 'dependsOn': None,\n",
+      " 'entryPoint': 'init_model',\n",
+      " 'entryPointKwargs': '-P batch_size=20 -P '\n",
+      "                     'register_model_name=howard_imagenet_adversarial_patch_pretrained_resnet50 '\n",
+      "                     '-P imagenet_preprocessing=True -P image_size=224,224,3 '\n",
+      "                     '-P model_architecture=resnet50 -P '\n",
+      "                     'data_dir=/nfs/data/ImageNet-Kaggle-2017/images/ILSVRC/Data/CLS-LOC/val-sorted-1000',\n",
+      " 'experimentId': 3,\n",
+      " 'jobId': '3dfdb0e1-9acb-4758-9b25-79d1c7235ce0',\n",
+      " 'lastModified': '2022-05-20T19:06:52.490501',\n",
+      " 'mlflowRunId': None,\n",
+      " 'queueId': 2,\n",
+      " 'status': 'queued',\n",
+      " 'timeout': '1h',\n",
+      " 'workflowUri': 's3://workflow/b20ed754be304c93974388d9d9f38dac/workflows.tar.gz'}\n"
+     ]
+    }
+   ],
    "source": [
     "response_resnet50_init = restapi_client.submit_job(\n",
     "    workflows_file=WORKFLOWS_TAR_GZ,\n",
@@ -414,7 +515,7 @@
     "    entry_point_kwargs=\" \".join([\n",
     "        \"-P batch_size=20\",\n",
     "        f\"-P register_model_name={EXPERIMENT_NAME}_pretrained_resnet50\",\n",
-    "        \"-P imagenet_preprocessing=true\",\n",
+    "        \"-P imagenet_preprocessing=True\",\n",
     "        \"-P image_size=224,224,3\",\n",
     "        \"-P model_architecture=resnet50\",\n",
     "        f\"-P data_dir={DATASET_DIR}/images/ILSVRC/Data/CLS-LOC/val-sorted-1000\",\n",
@@ -425,9 +526,9 @@
     "\n",
     "print(\"Initialization job for ResNet50 neural network submitted\")\n",
     "print(\"\")\n",
-    "pprint.pprint(response_resnet50_train)\n",
+    "pprint.pprint(response_resnet50_init)\n",
     "\n",
-    "response_resnet50_train = get_run_id(response_resnet50_train)"
+    "response_resnet50_init = get_run_id(response_resnet50_init)"
    ]
   },
   {
@@ -446,9 +547,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Patch attack (ResNet50 architecture) job submitted\n",
+      "\n",
+      "{'createdOn': '2022-05-20T19:07:00.867651',\n",
+      " 'dependsOn': '3dfdb0e1-9acb-4758-9b25-79d1c7235ce0',\n",
+      " 'entryPoint': 'gen_patch',\n",
+      " 'entryPointKwargs': '-P '\n",
+      "                     'model_name=howard_imagenet_adversarial_patch_pretrained_resnet50 '\n",
+      "                     '-P model_version=none -P image_size=224,224,3 -P '\n",
+      "                     'imagenet_preprocessing=True -P '\n",
+      "                     'data_dir=/nfs/data/ImageNet-Kaggle-2017/images/ILSVRC/Data/CLS-LOC/val-sorted-5000 '\n",
+      "                     '-P num_patch_gen_samples=10 -P num_patch=1',\n",
+      " 'experimentId': 3,\n",
+      " 'jobId': '0de71551-6009-4a07-97f6-c2ef82ec6b1e',\n",
+      " 'lastModified': '2022-05-20T19:07:00.867651',\n",
+      " 'mlflowRunId': None,\n",
+      " 'queueId': 2,\n",
+      " 'status': 'queued',\n",
+      " 'timeout': '24h',\n",
+      " 'workflowUri': 's3://workflow/39fd66598b36494d92a12a20d4eaed17/workflows.tar.gz'}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Create Patches\n",
     "response_resnet50_patch = restapi_client.submit_job(\n",
@@ -467,7 +595,7 @@
     "        ]\n",
     "    ),\n",
     "    queue=\"tensorflow_gpu\",\n",
-    "    depends_on=response_resnet50_train[\"jobId\"],\n",
+    "    depends_on=response_resnet50_init[\"jobId\"],\n",
     ")\n",
     "\n",
     "print(\"Patch attack (ResNet50 architecture) job submitted\")\n",
@@ -480,9 +608,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Patch deployment (ResNet50 architecture) job submitted\n",
+      "\n",
+      "{'createdOn': '2022-05-20T19:08:17.218459',\n",
+      " 'dependsOn': '0de71551-6009-4a07-97f6-c2ef82ec6b1e',\n",
+      " 'entryPoint': 'deploy_patch',\n",
+      " 'entryPointKwargs': '-P run_id=3db65c34315641749cbe46e5ea3e9287 -P '\n",
+      "                     'model_name=howard_imagenet_adversarial_patch_pretrained_resnet50 '\n",
+      "                     '-P model_version=none -P image_size=224,224,3 -P '\n",
+      "                     'imagenet_preprocessing=True -P '\n",
+      "                     'data_dir=/nfs/data/ImageNet-Kaggle-2017/images/ILSVRC/Data/CLS-LOC/val-sorted-5000 '\n",
+      "                     '-P batch_size=500',\n",
+      " 'experimentId': 3,\n",
+      " 'jobId': '1993d04d-906c-4903-97d4-1fd264686bcf',\n",
+      " 'lastModified': '2022-05-20T19:08:17.218459',\n",
+      " 'mlflowRunId': None,\n",
+      " 'queueId': 2,\n",
+      " 'status': 'queued',\n",
+      " 'timeout': '24h',\n",
+      " 'workflowUri': 's3://workflow/87543199a34245a7906d44aca262285e/workflows.tar.gz'}\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Deploy Patch attack on test set.\n",
     "response_deploy_resnet50_patch_testing = restapi_client.submit_job(\n",
@@ -514,9 +669,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Patch evaluation (ResNet50 architecture) job submitted\n",
+      "\n",
+      "{'createdOn': '2022-05-20T19:18:07.489069',\n",
+      " 'dependsOn': '1993d04d-906c-4903-97d4-1fd264686bcf',\n",
+      " 'entryPoint': 'infer',\n",
+      " 'entryPointKwargs': '-P run_id=157f123fb1354ca09dcb76f78af95091 -P '\n",
+      "                     'model_name=howard_imagenet_adversarial_patch_pretrained_resnet50 '\n",
+      "                     '-P model_version=none -P image_size=224,224,3 -P '\n",
+      "                     'imagenet_preprocessing=True -P batch_size=100 -P '\n",
+      "                     'adv_tar_name=adversarial_patch_dataset.tar.gz -P '\n",
+      "                     'adv_data_dir=adv_patch_dataset',\n",
+      " 'experimentId': 3,\n",
+      " 'jobId': 'c0e5b0f3-5b39-4ee8-be3a-96d8c466f1c7',\n",
+      " 'lastModified': '2022-05-20T19:18:07.489069',\n",
+      " 'mlflowRunId': None,\n",
+      " 'queueId': 2,\n",
+      " 'status': 'queued',\n",
+      " 'timeout': '24h',\n",
+      " 'workflowUri': 's3://workflow/9011c4dc91e74408be358575411e8313/workflows.tar.gz'}\n",
+      "\n",
+      "{'accuracy': 0.5784000158309937,\n",
+      " 'auc': 0.9367275238037109,\n",
+      " 'loss': 1.9498850357532502,\n",
+      " 'precision': 0.7414655685424805,\n",
+      " 'recall': 0.5038999915122986}\n"
+     ]
+    }
+   ],
    "source": [
     "# Check patched dataset results   \n",
     "response_resnet50_infer_resnet50_patch = restapi_client.submit_job(\n",
@@ -567,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,9 +789,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'accuracy': 0.5784000158309937,\n",
+      " 'auc': 0.9367275238037109,\n",
+      " 'loss': 1.9498850357532502,\n",
+      " 'precision': 0.7414655685424805,\n",
+      " 'recall': 0.5038999915122986}\n"
+     ]
+    }
+   ],
    "source": [
     "pprint.pprint(run_resnet50.data.metrics)"
    ]
@@ -618,9 +817,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'adv_data_dir': 'adv_patch_dataset',\n",
+      " 'adv_tar_name': 'adversarial_patch_dataset.tar.gz',\n",
+      " 'batch_size': '100',\n",
+      " 'dataset_seed': '1986865553',\n",
+      " 'entry_point_seed': '56718301370532184666262495574641970180',\n",
+      " 'image_size': '224,224,3',\n",
+      " 'imagenet_preprocessing': 'True',\n",
+      " 'model_name': 'howard_imagenet_adversarial_patch_pretrained_resnet50',\n",
+      " 'model_version': 'none',\n",
+      " 'run_id': '157f123fb1354ca09dcb76f78af95091',\n",
+      " 'seed': '-1',\n",
+      " 'tensorflow_global_seed': '863168140'}\n"
+     ]
+    }
+   ],
    "source": [
     "pprint.pprint(run_resnet50.data.params)"
    ]
@@ -634,9 +852,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'dioptra.dependsOn': '1993d04d-906c-4903-97d4-1fd264686bcf',\n",
+      " 'dioptra.jobId': 'c0e5b0f3-5b39-4ee8-be3a-96d8c466f1c7',\n",
+      " 'dioptra.queue': 'tensorflow_gpu',\n",
+      " 'mlflow.project.backend': 'dioptra',\n",
+      " 'mlflow.project.entryPoint': 'infer',\n",
+      " 'mlflow.source.name': '/work/tmpnygso0fx',\n",
+      " 'mlflow.source.type': 'PROJECT',\n",
+      " 'mlflow.user': 'dioptra'}\n"
+     ]
+    }
+   ],
    "source": [
     "pprint.pprint(run_resnet50.data.tags)"
    ]
@@ -655,7 +888,7 @@
    "hash": "edee40310913f16e2ca02c1d37887bcb7f07f00399ca119bb7e27de7d632ea99"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -669,7 +902,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This change updates the ipython demos for adversarial patches (Fruits360, ImageNet demos). 
Correction includes an update to adversarial training for the Fruits360 demo and a bugfix for the ImageNet demo.