### PR TITLE
chore: blacklist b907 for flake8 settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 max-line-length = 80
 max-complexity = 12
 select = B,C,E,F,W,B9
-ignore = E203,E302,E501,W503,B905
+ignore = E203,E302,E501,W503,B905,B907
 per-file-ignores =
     examples/*/src/*.py:E402
 extend-exclude = .ipynb_checkpoints


### PR DESCRIPTION
Closes #134.