### PR TITLE
Unregister the inactivate restapi user endpoint

### DIFF
--- a/docs/source/user-guide/api-reference-restapi.rst
+++ b/docs/source/user-guide/api-reference-restapi.rst
@@ -269,61 +269,61 @@ The following error handlers are registered to the task plugin endpoints.
 
 .. autoexception:: dioptra.restapi.task_plugin.errors.TaskPluginUploadError
 
-User
-----
+.. User
+.. ----
 
-User accounts.
+.. User accounts.
 
-Endpoints
-^^^^^^^^^
+.. Endpoints
+.. ^^^^^^^^^
 
-The following is the list of endpoints under the ``/api/user/`` namespace.
+.. The following is the list of endpoints under the ``/api/user/`` namespace.
 
-.. http:get:: /api/user/
+.. .. http:get:: /api/user/
 
-   **Gets a list of all registered users**
+..    **Gets a list of all registered users**
 
-   :status 200: Success
-   :reqheader X-Fields: An optional fields mask
-   :>json string [].createdOn: The date and time the user account was created.
-   :>json string [].emailAddress: The email address associated with the user account.
-   :>json string [].lastLoginOn: The date and time the user last logged into their account.
-   :>json string [].lastModifiedOn: The date and time the user account was last modified.
-   :>json string [].passwordExpireOn: The date and time the user's password is set to expire.
-   :>json string [].userExpireOn: The date and time the user account is set to expire.
-   :>json integer [].userId: An integer identifying a registered user account.
-   :>json string [].username: The username for logging into the user account.
+..    :status 200: Success
+..    :reqheader X-Fields: An optional fields mask
+..    :>json string [].createdOn: The date and time the user account was created.
+..    :>json string [].emailAddress: The email address associated with the user account.
+..    :>json string [].lastLoginOn: The date and time the user last logged into their account.
+..    :>json string [].lastModifiedOn: The date and time the user account was last modified.
+..    :>json string [].passwordExpireOn: The date and time the user's password is set to expire.
+..    :>json string [].userExpireOn: The date and time the user account is set to expire.
+..    :>json integer [].userId: An integer identifying a registered user account.
+..    :>json string [].username: The username for logging into the user account.
 
-.. http:post:: /api/user/
+.. .. http:post:: /api/user/
 
-   **Creates a new user via an user registration form**
+..    **Creates a new user via an user registration form**
 
-   :status 200: Success
-   :reqheader X-Fields: An optional fields mask
-   :form username: *(required)* The username for logging into the user account. Must be unique.
-   :form password: *(required)* The password used for authenticating the user account.
-   :form password_confirm: *(required)* The password confirmation field, this should exactly match the value in password.
-   :form email_address: *(required)* The email address associated with the user account.
-   :>json string createdOn: The date and time the user account was created.
-   :>json string emailAddress: The email address associated with the user account.
-   :>json string lastLoginOn: The date and time the user last logged into their account.
-   :>json string lastModifiedOn: The date and time the user account was last modified.
-   :>json string passwordExpireOn: The date and time the user's password is set to expire.
-   :>json string userExpireOn: The date and time the user account is set to expire.
-   :>json integer userId: An integer identifying a registered user account.
-   :>json string username: The username for logging into the user account.
+..    :status 200: Success
+..    :reqheader X-Fields: An optional fields mask
+..    :form username: *(required)* The username for logging into the user account. Must be unique.
+..    :form password: *(required)* The password used for authenticating the user account.
+..    :form password_confirm: *(required)* The password confirmation field, this should exactly match the value in password.
+..    :form email_address: *(required)* The email address associated with the user account.
+..    :>json string createdOn: The date and time the user account was created.
+..    :>json string emailAddress: The email address associated with the user account.
+..    :>json string lastLoginOn: The date and time the user last logged into their account.
+..    :>json string lastModifiedOn: The date and time the user account was last modified.
+..    :>json string passwordExpireOn: The date and time the user's password is set to expire.
+..    :>json string userExpireOn: The date and time the user account is set to expire.
+..    :>json integer userId: An integer identifying a registered user account.
+..    :>json string username: The username for logging into the user account.
 
-.. openapi:: api-restapi/openapi.yml
-   :include:
-     /api/user/{.*
+.. .. openapi:: api-restapi/openapi.yml
+..    :include:
+..      /api/user/{.*
 
-Error Messages
-^^^^^^^^^^^^^^
+.. Error Messages
+.. ^^^^^^^^^^^^^^
 
-The following error handlers are registered to the user endpoints.
+.. The following error handlers are registered to the user endpoints.
 
-.. autoexception:: dioptra.restapi.user.errors.UsernameNotAvailableError
+.. .. autoexception:: dioptra.restapi.user.errors.UsernameNotAvailableError
 
-.. autoexception:: dioptra.restapi.user.errors.UserDoesNotExistError
+.. .. autoexception:: dioptra.restapi.user.errors.UserDoesNotExistError
 
-.. autoexception:: dioptra.restapi.user.errors.UserRegistrationError
+.. .. autoexception:: dioptra.restapi.user.errors.UserRegistrationError

--- a/src/dioptra/restapi/routes.py
+++ b/src/dioptra/restapi/routes.py
@@ -36,11 +36,9 @@ def register_routes(api: Api, app: Flask) -> None:
     from .job import register_routes as attach_job
     from .queue import register_routes as attach_job_queue
     from .task_plugin import register_routes as attach_task_plugin
-    from .user import register_routes as attach_user
 
     # Add routes
     attach_experiment(api, app)
     attach_job(api, app)
     attach_job_queue(api, app)
     attach_task_plugin(api, app)
-    attach_user(api, app)


### PR DESCRIPTION
The user endpoint will support authorization and access controls that are planned for development. The user accounts managed via this endpoint have no functionality at present and so they are being unregistered to avoid confusion.