### PR TITLE
chore: fix typo in getting-started/building-the-containers.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ parts/
 sdist/
 var/
 tmp/
+deployments/
 
 # ---------------------------
 # BEGIN ignore editor files

--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,6 @@ parts/
 sdist/
 var/
 tmp/
-deployments/
 
 # ---------------------------
 # BEGIN ignore editor files

--- a/docs/source/getting-started/building-the-containers.rst
+++ b/docs/source/getting-started/building-the-containers.rst
@@ -61,7 +61,7 @@ Next, use the Makefile to build the container images.
 .. code:: sh
 
    # NOTE: the PyTorch and Tensorflow images may take a while to build
-   make build-nginx build-mlflow-tracking build-restapi build-pytorch-cpu build-tensorflow2-cpu
+   make build-nginx build-mlflow-tracking build-restapi build-pytorch-cpu build-tensorflow-cpu
 
 If you are running Dioptra on a host machine that has one or more CUDA-compatible GPUs, then it is recommended that you also build the GPU-enabled images:
 

--- a/docs/source/getting-started/building-the-containers.rst
+++ b/docs/source/getting-started/building-the-containers.rst
@@ -17,7 +17,7 @@
 
 .. _getting-started-building-the-containers:
 
-Building the containers
+Building the Containers
 =======================
 
 .. include:: /_glossary_note.rst
@@ -68,7 +68,7 @@ If you are running Dioptra on a host machine that has one or more CUDA-compatibl
 .. code:: sh
 
    # NOTE: the PyTorch and Tensorflow images may take a while to build
-   make build-pytorch-gpu build-tensorflow2-gpu
+   make build-pytorch-gpu build-tensorflow-gpu
 
 Finally, run ``docker images`` to verify that the container images are now available with the ``dev`` tag.
 You should see output that looks like the following,


### PR DESCRIPTION
Small typo in the instructions for the make target to build the tensorflow worker containers. See #165 