### PR TITLE
bug: logstream classes throw abstract method errors

### DIFF
--- a/src/dioptra/sdk/utilities/logging/log_stream.py
+++ b/src/dioptra/sdk/utilities/logging/log_stream.py
@@ -64,7 +64,7 @@ class StdoutLogStream(LogStream):
         self.level = logging.INFO
         self._as_json = as_json
         self._redirector = contextlib.redirect_stdout(self)  # type: ignore
-    
+
     def close(self):
         pass
 
@@ -79,7 +79,6 @@ class StderrLogStream(LogStream):
         self.level = logging.INFO
         self._as_json = as_json
         self._redirector = contextlib.redirect_stderr(self)  # type: ignore
-
 
     def close(self):
         pass

--- a/src/dioptra/sdk/utilities/logging/log_stream.py
+++ b/src/dioptra/sdk/utilities/logging/log_stream.py
@@ -64,6 +64,12 @@ class StdoutLogStream(LogStream):
         self.level = logging.INFO
         self._as_json = as_json
         self._redirector = contextlib.redirect_stdout(self)  # type: ignore
+    
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
 
 
 class StderrLogStream(LogStream):
@@ -73,3 +79,10 @@ class StderrLogStream(LogStream):
         self.level = logging.INFO
         self._as_json = as_json
         self._redirector = contextlib.redirect_stderr(self)  # type: ignore
+
+
+    def close(self):
+        pass
+
+    def flush(self):
+        pass


### PR DESCRIPTION
The classes StdoutLogStream, StderrLogStream subclassed from an abstract class without implementing all methods, causing an error when running the example notebooks. Added implementations to the classes to fix.