### PR TITLE
ci: pin pydata-sphinx-theme to 0.13.1

### DIFF
--- a/.github/pip-envs/requirements-sphinx.txt
+++ b/.github/pip-envs/requirements-sphinx.txt
@@ -8,6 +8,7 @@ marshmallow>=3.9.0,<4
 mistune<2
 multimethod>=1.5
 plantuml-markdown
+pydata-sphinx-theme==0.13.1
 pymdown-extensions
 recommonmark
 Sphinx>=4.5.0,<5


### PR DESCRIPTION
Workaround for breakage introduced in pydata-sphinx-theme 0.13.2, see the discussion at
https://github.com/executablebooks/sphinx-book-theme/issues/711.