### PR TITLE
fix(restapi): change service.py to slugify db queries

### DIFF
--- a/src/dioptra/restapi/experiment/model.py
+++ b/src/dioptra/restapi/experiment/model.py
@@ -25,6 +25,7 @@ from wtforms.fields import StringField
 from wtforms.validators import InputRequired, ValidationError
 
 from dioptra.restapi.app import db
+from dioptra.restapi.utils import slugify
 
 from .interface import ExperimentUpdateInterface
 
@@ -82,9 +83,6 @@ class ExperimentRegistrationForm(FlaskForm):
         Args:
             field: The form field for `name`.
         """
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         standardized_name: str = slugify(field.data)
 

--- a/src/dioptra/restapi/experiment/schema.py
+++ b/src/dioptra/restapi/experiment/schema.py
@@ -27,6 +27,8 @@ from typing import Any, Dict
 
 from marshmallow import Schema, fields, post_dump, pre_dump
 
+from dioptra.restapi.utils import slugify
+
 from .model import (
     Experiment,
     ExperimentRegistrationForm,
@@ -100,9 +102,6 @@ class ExperimentRegistrationFormSchema(Schema):
         self, data: ExperimentRegistrationForm, many: bool, **kwargs
     ) -> Dict[str, Any]:
         """Extracts data from the |ExperimentRegistrationForm| for validation."""
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         return {"name": slugify(data.name.data)}
 

--- a/src/dioptra/restapi/experiment/service.py
+++ b/src/dioptra/restapi/experiment/service.py
@@ -27,6 +27,7 @@ from structlog.stdlib import BoundLogger
 
 from dioptra.restapi.app import db
 from dioptra.restapi.shared.mlflow_tracking.service import MLFlowTrackingService
+from dioptra.restapi.utils import slugify
 
 from .errors import (
     ExperimentAlreadyExistsError,
@@ -120,6 +121,8 @@ class ExperimentService(object):
         self, experiment: Experiment, new_name: str, **kwargs
     ) -> Experiment:
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
+
+        new_name = slugify(new_name)
         reply: Optional[bool] = self._mlflow_tracking_service.rename_experiment(
             experiment_id=experiment.experiment_id, new_name=new_name
         )
@@ -151,6 +154,7 @@ class ExperimentService(object):
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.info("Lookup experiment by unique name", experiment_name=experiment_name)
 
+        experiment_name = slugify(experiment_name)
         return Experiment.query.filter_by(  # type: ignore
             name=experiment_name, is_deleted=False
         ).first()

--- a/src/dioptra/restapi/job/model.py
+++ b/src/dioptra/restapi/job/model.py
@@ -30,6 +30,7 @@ from wtforms.validators import Optional as OptionalField
 from wtforms.validators import Regexp, ValidationError
 
 from dioptra.restapi.app import db
+from dioptra.restapi.utils import slugify
 
 from .interface import JobUpdateInterface
 
@@ -174,9 +175,6 @@ class JobForm(FlaskForm):
         """
         from dioptra.restapi.models import Experiment
 
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
-
         standardized_name: str = slugify(field.data)
 
         if (
@@ -195,9 +193,6 @@ class JobForm(FlaskForm):
             field: The form field for `queue`.
         """
         from dioptra.restapi.models import Queue, QueueLock
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         standardized_name: str = slugify(field.data)
         queue: Optional[Queue] = (

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -27,6 +27,8 @@ from typing import Any, Dict
 from marshmallow import Schema, fields, post_dump, post_load, pre_dump, validate
 from werkzeug.datastructures import FileStorage
 
+from dioptra.restapi.utils import slugify
+
 from .model import Job, JobForm, JobFormData
 
 
@@ -206,9 +208,6 @@ class JobFormSchema(Schema):
         self, data: JobForm, many: bool, **kwargs
     ) -> Dict[str, Any]:
         """Extracts data from the |JobForm| for validation."""
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         return {
             "experiment_name": slugify(data.experiment_name.data),

--- a/src/dioptra/restapi/queue/model.py
+++ b/src/dioptra/restapi/queue/model.py
@@ -26,6 +26,7 @@ from wtforms.fields import StringField
 from wtforms.validators import InputRequired, ValidationError
 
 from dioptra.restapi.app import db
+from dioptra.restapi.utils import slugify
 
 from .interface import QueueUpdateInterface
 
@@ -118,9 +119,6 @@ class QueueRegistrationForm(FlaskForm):
         Args:
             field: The form field for `name`.
         """
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         standardized_name: str = slugify(field.data)
 

--- a/src/dioptra/restapi/queue/schema.py
+++ b/src/dioptra/restapi/queue/schema.py
@@ -27,6 +27,8 @@ from typing import Any, Dict
 
 from marshmallow import Schema, fields, post_dump, pre_dump
 
+from dioptra.restapi.utils import slugify
+
 from .model import Queue, QueueLock, QueueRegistrationForm, QueueRegistrationFormData
 
 
@@ -114,9 +116,6 @@ class QueueRegistrationFormSchema(Schema):
         self, data: QueueRegistrationForm, many: bool, **kwargs
     ) -> Dict[str, Any]:
         """Extracts data from the |QueueRegistrationForm| for validation."""
-
-        def slugify(text: str) -> str:
-            return text.lower().strip().replace(" ", "-")
 
         return {"name": slugify(data.name.data)}
 

--- a/src/dioptra/restapi/utils.py
+++ b/src/dioptra/restapi/utils.py
@@ -62,3 +62,19 @@ def as_api_parser(
         parser.add_argument(**form_kwargs)
 
     return parser
+
+
+def slugify(text: str) -> str:
+    """Slugify a string.
+
+    A "slugified" string is a string that has been lowercased and had all of its
+    spaces replaced with hyphens.
+
+    Args:
+        text: The text to slugifiy.
+
+    Returns:
+        A slugified string
+    """
+
+    return text.lower().strip().replace(" ", "-")

--- a/tests/unit/restapi/experiment/test_service.py
+++ b/tests/unit/restapi/experiment/test_service.py
@@ -157,3 +157,32 @@ def test_extract_data_from_form(
     )
 
     assert experiment_registration_form_data["name"] == "mnist"
+
+
+@freeze_time("2020-08-17T18:46:28.717559")
+@pytest.mark.parametrize(
+    "slugified_name,requested_name",
+    [
+        ("mnist", "MNIST"),
+        ("my-experiment", "My Experiment"),
+        ("abc_my-experiment", "ABc_My Experiment"),
+    ],
+)
+def test_get_by_name_slugification(
+    db: SQLAlchemy,
+    experiment_service: ExperimentService,
+    slugified_name: str,
+    requested_name: str,
+):
+    timestamp: datetime.datetime = datetime.datetime.now()
+
+    new_experiment: Experiment = Experiment(
+        name=slugified_name, created_on=timestamp, last_modified=timestamp
+    )
+
+    db.session.add(new_experiment)
+    db.session.commit()
+
+    experiment: Experiment = experiment_service.get_by_name(requested_name)
+
+    assert experiment == new_experiment


### PR DESCRIPTION
Add the slugifiy helper function and use it on strings passed to the database to prevent misses since all names are slugified on registration.

Closes #71