### PR TITLE
fix: pin the minio mc client to resolve init-minio.sh script error

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
@@ -83,7 +83,7 @@
         "mc": {
             "image": "mc",
             "namespace": "minio",
-            "tag": "latest",
+            "tag": "RELEASE.2023-01-28T20-29-38Z",
             "registry": ""
         },
         "minio": {


### PR DESCRIPTION
The MinIO mc client received a breaking change in March 2023 that deprecated and removed the `mc admin policy add` and `mc admin policy set` commands, which broke the init-minio.sh script in the cookiecutter-dioptra-deployment template. For the short term, the template will pin the minio mc image to a version before the commands were deprecated and removed. The pinning will be relaxed once a longer-term fix to use the new commands is incorporated into init-minio.sh. For additional information, see https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-policy.html.

Closes #189