### PR TITLE
feat: add reloading to plugin script

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -146,6 +146,8 @@ For the full list of options, run `python ./scripts/register_task_plugins.py -h`
                                plugins]
       --api-url TEXT           The url to the Dioptra REST API.  [default:
                                http://localhost]
+      -f, --force              Remove and re-register any existing custom task
+                               plugins.
       -h, --help               Show this message and exit.
 
 ### Examples


### PR DESCRIPTION
Closes #199 
During refactoring, custom plugins frequently had to be deleted and re-uploaded manually. This adds `-f` and  `--force` flags to `/examples/scripts/register_task_plugins.py` which deletes and reuploads all custom task plugins in order to remove this pain point. 