### PR TITLE
Pin the upper version limit of the cookiecutter package

### DIFF
--- a/examples/scripts/venvs/examples-setup-requirements.txt
+++ b/examples/scripts/venvs/examples-setup-requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.8.0
 Click>=8.0.0,<9
-cookiecutter>=2.0.0
+cookiecutter>=2.0.0,<2.2.0
 ipykernel>=6.22.0
 ipython>=8.12.0
 jupyter>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dioptra = "dioptra.mlflow_plugins.dioptra_backend:DioptraProjectBackend"
 
 [project.optional-dependencies]
 cookiecutter = [
-    "cookiecutter>=2.0.0",
+    "cookiecutter>=2.0.0,<2.2.0",
 ]
 examples = [
     "aiohttp>=3.8.0",

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ commands = python -m pytest {posargs:"{tox_root}{/}tests{/}containers"}
 deps =
     {[pytest]deps}
     binaryornot>=0.4.0
-    cookiecutter>=2.0.0
+    cookiecutter>=2.0.0,<2.2.0
     pytest-cookies
 skip_install = true
 commands = python -m pytest {posargs:--template="{tox_root}{/}cookiecutter-templates{/}cookiecutter-dioptra-deployment" "{tox_root}{/}tests{/}cookiecutter_dioptra_deployment"}


### PR DESCRIPTION
Cookiecutter 2.2.0 is resulting in breakage. This is a temporary measure until a fix is found.