### PR TITLE
fix: Platform specific prefixes

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -68,9 +68,10 @@ jobs:
         run: python3 -m tox run -e ${{ matrix.tox-testenv }}
 
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: ["ubuntu-20.04", "windows-latest"]
         python-version: ["3.9", "3.10"]
         tox-testenv:
           - "clean,py39-pytest-cov,report"
@@ -91,6 +92,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install English words dictionary
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: sudo apt install -y wamerican
 
       - name: setup python ${{ matrix.python-version }}
@@ -104,10 +106,17 @@ jobs:
           python3 -m pip install --upgrade pip
 
       - name: get pip cache dir
+        if: ${{ matrix.os != 'windows-latest' }}
         id: pip-cache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
+      - name: get pip cache dir (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        id: pip-cache-win
+        run: echo "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
+
       - name: cache dependencies
+        if: ${{ matrix.os != 'windows-latest' }}
         uses: actions/cache@v3.3.2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
@@ -115,8 +124,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: cache dependencies (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: actions/cache@v3.3.2
+        with:
+          path: ${{ steps.pip-cache-win.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml', '**/tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: install dependencies
-        run: python3 -m pip install tox
+        run: python3 -m pip install --upgrade tox
 
       - name: run tox
         run: python3 -m tox run -e ${{ matrix.tox-testenv }}

--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/hooks/post_gen_project.py
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/hooks/post_gen_project.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import shutil
+import string
 import unicodedata
 from pathlib import Path
 
@@ -166,6 +167,17 @@ def _generate_random_password(
 def _populate_words(words_file, source_encoding="utf-8", unicode_normalize_form="NFKD"):
     words = set()
 
+    # if dictionary file does not exist, fall back to random words
+    if not Path(words_file).exists():
+        chars = list(string.ascii_lowercase)
+        for _ in range(int(10000)):
+            length = random.randint(4, 8)
+            word = "".join(random.choices(chars, k=length))
+
+            words.add(word)
+
+        return list(words)
+
     with open(words_file, "rb") as f:
         for line in f:
             normalized_line: str = unicodedata.normalize(
@@ -173,7 +185,9 @@ def _populate_words(words_file, source_encoding="utf-8", unicode_normalize_form=
                 line.decode(source_encoding).lower().strip(),
             )
 
-            is_ascii: bool = all([0 <= ord(char) <= 127 for char in normalized_line])
+            is_ascii: bool = all(
+                [0 <= ord(char) <= 127 for char in normalized_line]
+            )
             is_not_plural: bool = not normalized_line.endswith("'s")
             is_not_short: bool = len(normalized_line) >= 4
 

--- a/src/dioptra/restapi/task_plugin/service.py
+++ b/src/dioptra/restapi/task_plugin/service.py
@@ -78,7 +78,7 @@ class TaskPluginService(object):
             plugin_uri_list: Optional[List[str]] = self._s3_service.upload_directory(
                 directory=tmpdir,
                 bucket=bucket,
-                prefix=str(prefix),
+                prefix=prefix.as_posix(),
                 include_suffixes=[".py"],
                 log=log,
             )
@@ -114,7 +114,11 @@ class TaskPluginService(object):
             return []
 
         prefix: Path = Path(collection) / task_plugin_name
-        self._s3_service.delete_prefix(bucket=bucket, prefix=str(prefix), log=log)
+        self._s3_service.delete_prefix(
+            bucket=bucket,
+            prefix=prefix.as_posix(),
+            log=log,
+        )
 
         log.info(
             "TaskPlugin deleted",
@@ -175,7 +179,7 @@ class TaskPluginService(object):
             task_plugin_name=task_plugin_name,
         )
 
-        prefix = Path(collection) / task_plugin_name
+        prefix: Path = Path(collection) / task_plugin_name
         modules: List[str] = self._s3_service.list_objects(
             bucket=bucket,
             prefix=self._s3_service.normalize_prefix(str(prefix), log=log),

--- a/tests/cookiecutter_dioptra_deployment/test_create_template.py
+++ b/tests/cookiecutter_dioptra_deployment/test_create_template.py
@@ -32,7 +32,7 @@ def check_paths(paths):
         if is_binary(str(path)):
             continue
 
-        for line in path.open("r"):
+        for line in path.open("r", encoding="utf-8"):
             match = RE_OBJ.search(line)
             assert match is None, f"cookiecutter variable not replaced in {path}"
 

--- a/tests/unit/task_plugins/dioptra_builtins/artifacts/test_mlflow.py
+++ b/tests/unit/task_plugins/dioptra_builtins/artifacts/test_mlflow.py
@@ -16,7 +16,6 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode
 from __future__ import annotations
 
-import os
 import uuid
 from copy import deepcopy
 from pathlib import Path
@@ -48,7 +47,7 @@ class MockMLFlowClient(object):
     ) -> str:
         if dst_path is None:
             dst_path = "tmp_unit_test"
-        dst_path = os.path.abspath(dst_path)
+        dst_path = str(Path(dst_path).absolute())
         dst_local_path = dst_path
         return dst_local_path
 
@@ -73,7 +72,7 @@ class MockMLFlowClient(object):
         if not run_name_tag:
             tags.append(RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         run_uuid = uuid.uuid4().hex
-        artifact_uri = os.path.join("/path/to/artifacts/", run_uuid, "artifacts")
+        artifact_uri = Path("/path/to/artifacts/") / run_uuid / "artifacts"
 
         run_info = RunInfo(
             run_uuid=run_uuid,
@@ -157,7 +156,7 @@ def test_download_all_artifacts_in_run(
 
     dst_path = download_all_artifacts_in_run(run_id, artifact_path, destination_path)
     assert isinstance(dst_path, str)
-    assert destination_path == os.path.relpath(dst_path)
+    assert Path(destination_path) == Path(dst_path).relative_to(Path.cwd())
 
 
 @pytest.mark.parametrize(
@@ -199,10 +198,8 @@ def test_upload_data_frame_artifact(
 
     upload_data_frame_artifact(data_frame, file_name, file_format, None, working_dir)
 
-    pwd = "." if working_dir is None else working_dir
-    assert os.path.isfile(
-        Path(os.path.abspath(pwd)) / Path(file_name).with_suffix("." + output)
-    )
+    pwd = Path("." if working_dir is None else working_dir).absolute()
+    assert (pwd / Path(file_name).with_suffix(f".{output}")).is_file()
 
 
 @pytest.mark.parametrize(
@@ -235,8 +232,8 @@ def test_upload_directory_as_tarball_artifact(
     upload_directory_as_tarball_artifact(
         source_dir, tarball_filename, tarball_write_mode, working_dir
     )
-    pwd = "." if working_dir is None else working_dir
-    assert os.path.isfile(Path(os.path.abspath(pwd)) / Path(tarball_filename))
+    pwd = Path("." if working_dir is None else working_dir).absolute()
+    assert (pwd / tarball_filename).is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixes #248 

This PR addresses an issue where S3 key prefixes followed the platform's path conventions causing tests that validate S3 URIs to fail. The fix is to normalize S3 prefixes to follow POSIX path conventions using `Path.as_posix()` from `pathlib`.

This PR also adds a github action for unit tests on a `windows-2022` image. `test_mlflow.py` was updated to use `pathlib` instead of `os.path` to fix cross-platform issues with the tests.

The cookiecutter tests are disabled for the `windows-2022` runner because those tests depend on a english words file for generating random passwords that does not exist on windows systems. Consider opening a new issue to address this.

