### PR TITLE
Task engine integration into worker containers

### DIFF
--- a/docker/shellscripts/entrypoint-worker.m4
+++ b/docker/shellscripts/entrypoint-worker.m4
@@ -85,7 +85,7 @@ start_rq() {
   ${job_queues}"
 
   cd ${dioptra_workdir}
-  python -m ${rq_worker_module} worker\
+  PYTHONPATH="${DIOPTRA_PLUGIN_DIR}" python -m ${rq_worker_module} worker\
     --url ${rq_redis_uri}\
     --results-ttl ${rq_results_ttl}\
     ${job_queues}

--- a/src/dioptra/mlflow_plugins/dioptra_clients.py
+++ b/src/dioptra/mlflow_plugins/dioptra_clients.py
@@ -51,8 +51,11 @@ class DioptraDatabaseClient(object):
         if self.job_id is None:
             return None
 
+        return self.get_job(self.job_id)
+
+    def get_job(self, job_id) -> Dict[str, Any]:
         with self.app.app_context():
-            job: Job = Job.query.get(self.job_id)
+            job: Job = Job.query.get(job_id)
             return {
                 "job_id": job.job_id,
                 "queue": job.queue.name,
@@ -68,8 +71,7 @@ class DioptraDatabaseClient(object):
 
     def update_job_status(self, job_id: str, status: str) -> None:
         LOGGER.info(
-            f"=== Updating job status for job with ID '{self.job_id}' to "
-            f"{status} ==="
+            f"=== Updating job status for job with ID '{job_id}' to {status} ==="
         )
 
         with self.app.app_context():
@@ -90,9 +92,11 @@ class DioptraDatabaseClient(object):
             return None
 
         LOGGER.info("=== Setting MLFlow run ID in the Dioptra database ===")
+        self.set_mlflow_run_id_for_job(run_id, self.job_id)
 
+    def set_mlflow_run_id_for_job(self, run_id: str, job_id: str) -> None:
         with self.app.app_context():
-            job = Job.query.get(self.job_id)
+            job = Job.query.get(job_id)
             job.update(changes={"mlflow_run_id": run_id})
 
             try:

--- a/src/dioptra/restapi/job/dependencies.py
+++ b/src/dioptra/restapi/job/dependencies.py
@@ -42,6 +42,7 @@ class JobFormSchemaModule(Module):
 class RQServiceConfiguration(object):
     redis: Redis
     run_mlflow: str
+    run_task_engine: str
 
 
 class RQServiceModule(Module):
@@ -50,16 +51,20 @@ class RQServiceModule(Module):
     def provide_rq_service_module(
         self, configuration: RQServiceConfiguration
     ) -> RQService:
-        return RQService(redis=configuration.redis, run_mlflow=configuration.run_mlflow)
+        return RQService(
+            redis=configuration.redis,
+            run_mlflow=configuration.run_mlflow,
+            run_task_engine=configuration.run_task_engine,
+        )
 
 
 def _bind_rq_service_configuration(binder: Binder):
     redis_conn: Redis = Redis.from_url(os.getenv("RQ_REDIS_URI", "redis://"))
     run_mlflow: str = "dioptra.rq.tasks.run_mlflow_task"
+    run_task_engine: str = "dioptra.rq.tasks.run_task_engine_task"
 
     configuration: RQServiceConfiguration = RQServiceConfiguration(
-        redis=redis_conn,
-        run_mlflow=run_mlflow,
+        redis=redis_conn, run_mlflow=run_mlflow, run_task_engine=run_task_engine
     )
 
     binder.bind(RQServiceConfiguration, to=configuration, scope=request)

--- a/src/dioptra/restapi/job/errors.py
+++ b/src/dioptra/restapi/job/errors.py
@@ -32,6 +32,10 @@ class JobWorkflowUploadError(Exception):
     """The service for storing the uploaded workfile file is unavailable."""
 
 
+class InvalidExperimentDescriptionError(Exception):
+    """The experiment description failed validation."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(JobDoesNotExistError)
     def handle_job_does_not_exist_error(error):
@@ -57,3 +61,7 @@ def register_error_handlers(api: Api) -> None:
             },
             503,
         )
+
+    @api.errorhandler(InvalidExperimentDescriptionError)
+    def handle_invalid_experiment_description_error(error):
+        return {"message": "The experiment description is invalid!"}, 400

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -227,6 +227,47 @@ class JobFormSchema(Schema):
         return self.__model__(**data)
 
 
+class TaskEngineSubmission(Schema):
+    queue = fields.String(
+        required=True,
+        metadata={"description": "The name of an active queue"},
+    )
+
+    experimentName = fields.String(
+        required=True,
+        metadata={"description": "The name of a registered experiment."},
+    )
+
+    experimentDescription = fields.Dict(
+        keys=fields.String(),
+        required=True,
+        metadata={"description": "A declarative experiment description."},
+    )
+
+    globalParameters = fields.Dict(
+        keys=fields.String(),
+        metadata={"description": "Global parameters for this task engine job."},
+    )
+
+    timeout = fields.String(
+        metadata={
+            "description": "The maximum alloted time for a job before it times"
+            " out and is stopped. If omitted, the job timeout"
+            " will default to 24 hours.",
+        },
+    )
+
+    dependsOn = fields.String(
+        metadata={
+            "description": "A job UUID to set as a dependency for this new job."
+            " The new job will not run until this job completes"
+            " successfully. If omitted, then the new job will"
+            " start as soon as computing resources are"
+            " available.",
+        },
+    )
+
+
 job_submit_form_schema: list[ParametersSchema] = [
     dict(
         name="experiment_name",

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -18,9 +18,10 @@
 from __future__ import annotations
 
 import datetime
+import json
 import uuid
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import Any, List, Mapping, Optional, cast
 
 import structlog
 from injector import inject
@@ -34,8 +35,9 @@ from dioptra.restapi.experiment.service import ExperimentService
 from dioptra.restapi.queue.service import QueueNameService
 from dioptra.restapi.shared.rq.service import RQService
 from dioptra.restapi.shared.s3.service import S3Service
+from dioptra.task_engine.validation import is_valid
 
-from .errors import JobWorkflowUploadError
+from .errors import InvalidExperimentDescriptionError, JobWorkflowUploadError
 from .model import Job, JobForm, JobFormData
 from .schema import JobFormSchema
 
@@ -149,6 +151,69 @@ class JobService(object):
         db.session.commit()
 
         log.info("Job submission successful", job_id=new_job.job_id)
+
+        return new_job
+
+    def submit_task_engine(
+        self,
+        queue_name: str,
+        experiment_name: str,
+        experiment_description: Mapping[str, Any],
+        global_parameters: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[str] = None,
+        depends_on: Optional[str] = None,
+    ) -> Job:
+        from dioptra.restapi.models import Experiment, Queue
+
+        log: BoundLogger = LOGGER.new()
+
+        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
+            experiment_name=experiment_name, log=log
+        )
+
+        if experiment is None:
+            raise ExperimentDoesNotExistError
+
+        queue = cast(
+            Queue,
+            self._queue_name_service.get(
+                queue_name, unlocked_only=True, error_if_not_found=True, log=log
+            ),
+        )
+
+        if not is_valid(experiment_description):
+            raise InvalidExperimentDescriptionError
+
+        job_id = str(uuid.uuid4())
+        timestamp = datetime.datetime.now()
+
+        new_job = Job(
+            job_id=job_id,
+            experiment_id=experiment.experiment_id,
+            queue_id=queue.queue_id,
+            created_on=timestamp,
+            last_modified=timestamp,
+            timeout=timeout,
+            depends_on=depends_on,
+        )
+
+        if global_parameters is not None:
+            new_job.entry_point_kwargs = json.dumps(global_parameters)
+
+        db.session.add(new_job)
+        db.session.commit()
+
+        self._rq_service.submit_task_engine_job(
+            job_id=job_id,
+            queue=queue_name,
+            experiment_id=experiment.experiment_id,
+            experiment_description=experiment_description,
+            global_parameters=global_parameters,
+            depends_on=depends_on,
+            timeout=timeout,
+        )
+
+        log.info("Job submission successful", job_id=job_id)
 
         return new_job
 

--- a/src/dioptra/restapi/shared/rq/service.py
+++ b/src/dioptra/restapi/shared/rq/service.py
@@ -16,7 +16,7 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import structlog
 from redis import Redis
@@ -32,9 +32,10 @@ LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
 
 class RQService(object):
-    def __init__(self, redis: Redis, run_mlflow: str) -> None:
+    def __init__(self, redis: Redis, run_mlflow: str, run_task_engine: str) -> None:
         self._redis = redis
         self._run_mlflow = run_mlflow
+        self._run_task_engine = run_task_engine
 
     def get_job_status(self, job: Job, **kwargs) -> str:
         log: BoundLogger = kwargs.get("log", LOGGER.new())
@@ -105,3 +106,46 @@ class RQService(object):
         )
 
         return result
+
+    def submit_task_engine_job(
+        self,
+        job_id: str,
+        queue: str,
+        experiment_id: int,
+        experiment_description: Mapping[str, Any],
+        global_parameters: Optional[Mapping[str, Any]] = None,
+        depends_on: Optional[str] = None,
+        timeout: Optional[str] = None,
+    ):
+        log: BoundLogger = LOGGER.new()
+
+        job_dependency: Optional[RQJob] = None
+        if depends_on is not None:
+            job_dependency = self.get_rq_job(depends_on)
+
+        if global_parameters is None:
+            global_parameters = {}
+
+        cmd_kwargs = {
+            "experiment_id": experiment_id,
+            "experiment_desc": experiment_description,
+            "global_parameters": global_parameters,
+        }
+
+        log.info(
+            "Enqueuing job",
+            function=self._run_task_engine,
+            job_id=job_id,
+            cmd_kwargs=cmd_kwargs,
+            timeout=timeout,
+            depends_on=job_dependency,
+        )
+
+        q: RQQueue = RQQueue(queue, default_timeout=24 * 3600, connection=self._redis)
+        q.enqueue(
+            self._run_task_engine,
+            job_id=job_id,
+            kwargs=cmd_kwargs,
+            timeout=timeout,
+            depends_on=job_dependency,
+        )

--- a/src/dioptra/rq/tasks/__init__.py
+++ b/src/dioptra/rq/tasks/__init__.py
@@ -15,5 +15,6 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 from .run_mlflow import run_mlflow_task
+from .run_task_engine import run_task_engine_task
 
-__all__ = ["run_mlflow_task"]
+__all__ = ["run_mlflow_task", "run_task_engine_task"]

--- a/src/dioptra/rq/tasks/run_task_engine.py
+++ b/src/dioptra/rq/tasks/run_task_engine.py
@@ -1,0 +1,152 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import os
+from typing import Any, Mapping, MutableMapping, Optional
+
+import boto3
+import mlflow
+import structlog
+from botocore.client import BaseClient
+from rq.job import get_current_job
+
+from dioptra.mlflow_plugins.dioptra_clients import DioptraDatabaseClient
+from dioptra.mlflow_plugins.dioptra_tags import (
+    DIOPTRA_DEPENDS_ON,
+    DIOPTRA_JOB_ID,
+    DIOPTRA_QUEUE,
+)
+from dioptra.task_engine.task_engine import run_experiment
+from dioptra.task_engine.validation import is_valid
+from dioptra.worker.setup_task_plugins import setup_task_plugins
+
+
+def _get_logger() -> Any:
+    """
+    Get a logger for this module.
+
+    Returns:
+        A logger object
+    """
+    return structlog.get_logger(__name__)
+
+
+def run_task_engine_task(
+    experiment_id: int,
+    experiment_desc: Mapping[str, Any],
+    global_parameters: MutableMapping[str, Any],
+    s3: Optional[BaseClient] = None,
+):
+    """
+    Run an experiment via the task engine.
+
+    Args:
+        experiment_id: The ID of the experiment to use for this run
+        experiment_desc: A declarative experiment description, as a mapping
+        global_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+        s3: An optional boto3 S3 client object to use.  If not given, construct
+            one according to environment variables.  This argument is not
+            normally used, but useful in unit tests when you need a specially
+            configured object with stubbed responses.
+    """
+    rq_job = get_current_job()
+    rq_job_id = rq_job.get_id() if rq_job else None
+
+    with structlog.contextvars.bound_contextvars(rq_job_id=rq_job_id):
+        log = _get_logger()
+
+        mlflow_s3_endpoint_url = os.getenv("MLFLOW_S3_ENDPOINT_URL")
+        dioptra_plugins_s3_uri = os.getenv("DIOPTRA_PLUGINS_S3_URI")
+        dioptra_custom_plugins_s3_uri = os.getenv("DIOPTRA_CUSTOM_PLUGINS_S3_URI")
+        dioptra_plugin_dir = os.getenv("DIOPTRA_PLUGIN_DIR")
+
+        # For mypy; assume correct environment variables
+        assert mlflow_s3_endpoint_url
+        assert dioptra_plugins_s3_uri
+        assert dioptra_custom_plugins_s3_uri
+        assert dioptra_plugin_dir
+
+        if not s3:
+            s3 = boto3.client("s3", endpoint_url=mlflow_s3_endpoint_url)
+
+        if is_valid(experiment_desc):
+            setup_task_plugins(
+                s3,
+                dioptra_plugin_dir,
+                dioptra_plugins_s3_uri,
+                dioptra_custom_plugins_s3_uri,
+            )
+
+            _run_experiment(
+                rq_job_id, experiment_id, experiment_desc, global_parameters
+            )
+        else:
+            log.error("Experiment description was invalid!")
+
+
+def _run_experiment(
+    rq_job_id: str,
+    experiment_id: int,
+    experiment_desc: Mapping[str, Any],
+    global_parameters: MutableMapping[str, Any],
+):
+    """
+    Run the given experiment, doing some bookkeeping related to the Dioptra job
+    and Mlflow.
+
+    Args:
+        rq_job_id: The redis queue job ID for this job, which is also the
+            Dioptra job ID
+        experiment_id: The ID of the experiment to use for this run
+        experiment_desc: A declarative experiment description, as a mapping
+        global_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+    """
+    log = _get_logger()
+    db_client = None
+
+    mlflow.set_experiment(experiment_id=str(experiment_id))
+    run = mlflow.start_run()
+
+    try:
+        db_client = DioptraDatabaseClient()
+        job = db_client.get_job(rq_job_id)
+
+        db_client.set_mlflow_run_id_for_job(run.info.run_id, rq_job_id)
+
+        mlflow.set_tag(DIOPTRA_JOB_ID, rq_job_id)
+        mlflow.set_tag(DIOPTRA_QUEUE, job.get("queue", ""))
+        mlflow.set_tag(DIOPTRA_DEPENDS_ON, job.get("depends_on", ""))
+
+        mlflow.log_dict(experiment_desc, "experiment.yaml")
+        mlflow.log_params(global_parameters)
+
+        db_client.update_job_status(rq_job_id, "started")
+
+        run_experiment(experiment_desc, global_parameters)
+
+        log.info("=== Run succeeded ===")
+        mlflow.end_run()
+        db_client.update_job_status(rq_job_id, "finished")
+
+    except Exception:
+        mlflow.end_run("FAILED")
+
+        if db_client:
+            db_client.update_job_status(rq_job_id, "failed")
+
+        raise

--- a/src/dioptra/sdk/utilities/paths/clear_dir.py
+++ b/src/dioptra/sdk/utilities/paths/clear_dir.py
@@ -14,7 +14,29 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
-from ._set_path_ext import set_path_ext
-from .clear_dir import clear_directory
+import shutil
+from pathlib import Path
+from typing import Union
 
-__all__ = ["set_path_ext", "clear_directory"]
+
+def clear_directory(dir_: Union[str, Path]):
+    """
+    Remove all subdirectories and files from the given directory.
+
+    Args:
+        dir_: A string or Path object referring to a directory
+    """
+
+    if isinstance(dir_, str):
+        dir_ = Path(dir_)
+
+    if dir_.is_dir():
+        # Perhaps better to not modify the directory while you are iterating
+        # over its entries?
+        entries = list(dir_.iterdir())
+
+        for entry in entries:
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()

--- a/src/dioptra/sdk/utilities/s3/__init__.py
+++ b/src/dioptra/sdk/utilities/s3/__init__.py
@@ -14,7 +14,13 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
-from ._set_path_ext import set_path_ext
-from .clear_dir import clear_directory
 
-__all__ = ["set_path_ext", "clear_directory"]
+from .download import download_files, download_files_uri, get_s3_keys
+from .uri import s3_uri_to_bucket_prefix
+
+__all__ = [
+    "s3_uri_to_bucket_prefix",
+    "get_s3_keys",
+    "download_files_uri",
+    "download_files",
+]

--- a/src/dioptra/sdk/utilities/s3/download.py
+++ b/src/dioptra/sdk/utilities/s3/download.py
@@ -1,0 +1,114 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from pathlib import Path
+from typing import Any, Iterator, Optional, Union
+
+import structlog
+from botocore.client import BaseClient
+
+from dioptra.sdk.utilities.s3.uri import s3_uri_to_bucket_prefix
+
+
+def _get_logger() -> Any:
+    """
+    Get a logger for this module.
+
+    Returns:
+        A logger object
+    """
+    return structlog.get_logger(__name__)
+
+
+def get_s3_keys(
+    s3: BaseClient, bucket: str, prefix: Optional[str] = None
+) -> Iterator[str]:
+    """
+    Generate all keys in the given S3 bucket, having the given prefix.
+
+    Args:
+        s3: A boto3 S3 client object
+        bucket: An S3 bucket name
+        prefix: An optional key prefix
+
+    Yields:
+        Key names
+    """
+
+    resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+
+    for obj_info in resp.get("Contents", []):
+        yield obj_info["Key"]
+
+    while resp["IsTruncated"]:
+        resp = s3.list_objects_v2(
+            Bucket=bucket,
+            Prefix=prefix,
+            ContinuationToken=resp["NextContinuationToken"],
+        )
+
+        for obj_info in resp.get("Contents", []):
+            yield obj_info["Key"]
+
+
+def download_files_uri(s3: BaseClient, dest_dir: Path, s3_uri: str):
+    """
+    Download all files from the given S3 URI to the given directory.
+
+    Args:
+        s3: A boto3 S3 client object
+        dest_dir: A string or Path object referring to the directory where
+            files will be downloaded to
+        s3_uri: An S3 URI in the form "s3://<bucket>/<key_prefix>"
+    """
+
+    bucket, prefix = s3_uri_to_bucket_prefix(s3_uri)
+
+    if not bucket:
+        raise ValueError("S3 URIs must include a bucket: " + s3_uri)
+
+    download_files(s3, dest_dir, bucket, prefix)
+
+
+def download_files(
+    s3: BaseClient,
+    dest_dir: Union[str, Path],
+    bucket: str,
+    prefix: Optional[str] = None,
+):
+    """
+    Download all files from the given S3 bucket to the given directory, whose
+    keys match the given prefix.
+
+    Args:
+        s3: A boto3 S3 client object
+        dest_dir: A string or Path object referring to the directory where
+            files will be downloaded to
+        bucket: The name of an S3 bucket
+        prefix: An optional S3 key prefix, used to limit what is downloaded
+    """
+
+    log = _get_logger()
+
+    if isinstance(dest_dir, str):
+        dest_dir = Path(dest_dir)
+
+    for key in get_s3_keys(s3, bucket, prefix):
+        key_path = dest_dir / key
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+
+        log.debug("Downloading s3 key %s -> %s", key, str(key_path))
+        s3.download_file(bucket, key, str(key_path))

--- a/src/dioptra/sdk/utilities/s3/uri.py
+++ b/src/dioptra/sdk/utilities/s3/uri.py
@@ -14,7 +14,26 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
-from ._set_path_ext import set_path_ext
-from .clear_dir import clear_directory
+import urllib.parse
+from typing import Optional
 
-__all__ = ["set_path_ext", "clear_directory"]
+
+def s3_uri_to_bucket_prefix(s3_uri: str) -> tuple[Optional[str], str]:
+    """
+    Given an S3 URI in the form:
+
+        s3://<bucket>/<key_prefix>
+
+    extract the bucket and key prefix parts, and return them.
+
+    Args:
+        s3_uri: An S3 URI
+
+    Returns:
+        A bucket, prefix 2-tuple.
+    """
+    uri_parts = urllib.parse.urlparse(s3_uri)
+    bucket = uri_parts.hostname
+    prefix = uri_parts.path.lstrip("/")
+
+    return bucket, prefix

--- a/src/dioptra/task_engine/run_experiment.py
+++ b/src/dioptra/task_engine/run_experiment.py
@@ -31,10 +31,6 @@ def _parse_args() -> argparse.Namespace:
     """
     arg_parser = argparse.ArgumentParser(
         description="Read/process declarative experiment description",
-        epilog="""
-        By default, if neither --no-run nor --run-id are given, an experiment
-        runs in the context of a new MLflow run.
-        """,
     )
 
     arg_parser.add_argument(
@@ -64,26 +60,6 @@ def _parse_args() -> argparse.Namespace:
         """,
         choices=["all", "debug", "info", "warning", "error", "critical"],
         default="info",
-    )
-
-    run_group = arg_parser.add_mutually_exclusive_group()
-
-    run_group.add_argument(
-        "--run-id",
-        help="""
-        Resume the given MLflow run, for this experiment.
-        """,
-    )
-
-    run_group.add_argument(
-        "--no-run",
-        help="""
-        Do not run the experiment in the context of a MLflow run.
-        """,
-        # This is a "negative" option, i.e. its presence turns something off,
-        # but I'd prefer to keep it positive in the resulting args object.
-        dest="use_run",
-        action="store_false",
     )
 
     return arg_parser.parse_args()
@@ -181,13 +157,7 @@ def main() -> None:
     experiment_desc = yaml.safe_load(args.file)
     global_parameters = _cmdline_params_to_map(args.P)
 
-    mlflow_run = args.use_run
-    if mlflow_run and args.run_id:
-        mlflow_run = args.run_id
-
-    dioptra.task_engine.task_engine.run_experiment(
-        experiment_desc, global_parameters, mlflow_run
-    )
+    dioptra.task_engine.task_engine.run_experiment(experiment_desc, global_parameters)
 
 
 if __name__ == "__main__":

--- a/src/dioptra/task_engine/task_engine.py
+++ b/src/dioptra/task_engine/task_engine.py
@@ -20,8 +20,6 @@ import logging
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import Any, Union
 
-import mlflow
-
 import dioptra.pyplugs
 from dioptra.sdk.exceptions.task_engine import (
     IllegalOutputReferenceError,
@@ -440,7 +438,7 @@ def _run_step(
     return output
 
 
-def _run_experiment(
+def run_experiment(
     experiment_desc: Mapping[str, Any], global_parameters: MutableMapping[str, Any]
 ) -> None:
     """
@@ -507,42 +505,3 @@ def _run_experiment(
             if not e.context_step_name:
                 e.context_step_name = step_name
             raise
-
-
-def run_experiment(
-    experiment_desc: Mapping[str, Any],
-    global_parameters: MutableMapping[str, Any],
-    mlflow_run: Any = True,
-):
-    """
-    Run an experiment via a declarative experiment description.
-
-    Args:
-        experiment_desc: The experiment description, as parsed YAML or
-            equivalent
-        global_parameters: External parameter values to use in the
-            experiment, as a dict
-        mlflow_run: Whether and how to use an MLflow run.  If falsey, don't
-            use a run.  If truthy and this parameter is a string, treat it as a
-            run ID, and resume that run.  If truthy but not a string (e.g.
-            True), start a new run.
-    """
-
-    # Establish mlflow contextual things first, if needed
-    if mlflow_run:
-        if isinstance(mlflow_run, str):
-            mlflow.start_run(run_id=mlflow_run)
-        else:
-            mlflow.start_run()
-
-    try:
-        _run_experiment(experiment_desc, global_parameters)
-
-        if mlflow_run:
-            mlflow.end_run()
-
-    except Exception:
-        if mlflow_run:
-            mlflow.end_run("FAILED")
-
-        raise

--- a/src/dioptra/worker/__init__.py
+++ b/src/dioptra/worker/__init__.py
@@ -14,7 +14,3 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
-from ._set_path_ext import set_path_ext
-from .clear_dir import clear_directory
-
-__all__ = ["set_path_ext", "clear_directory"]

--- a/src/dioptra/worker/setup_task_plugins.py
+++ b/src/dioptra/worker/setup_task_plugins.py
@@ -1,0 +1,94 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from pathlib import Path
+from typing import Any, Union
+
+import structlog
+from botocore.client import BaseClient
+
+from dioptra.sdk.utilities.paths import clear_directory
+from dioptra.sdk.utilities.s3 import download_files, s3_uri_to_bucket_prefix
+
+
+def _get_logger() -> Any:
+    """
+    Get a logger for this module.
+
+    Returns:
+        A logger object
+    """
+    return structlog.get_logger(__name__)
+
+
+def _normalize_s3_prefix(prefix: str) -> str:
+    """
+    Allow a little wiggle room with S3 key prefixes, to ensure they are
+    compatible with security policy.  Policy is defined with key prefix
+    patterns which look like "foo/*".  This makes the slash a required
+    character.  E.g. listing keys with prefix "foo" will not work, but "foo/"
+    will work.
+
+    This function ensures that a prefix which is a bare word gets a trailing
+    slash.  E.g. "foo" becomes "foo/", but "foo/bar" is left alone.
+
+    Args:
+        prefix: An S3 key prefix
+
+    Returns:
+        A normalized S3 key prefix
+    """
+    if "/" not in prefix:
+        prefix = prefix + "/"
+
+    return prefix
+
+
+def setup_task_plugins(
+    s3: BaseClient, dioptra_plugin_dir: Union[str, Path], *s3_uris: str
+):
+    """
+    Establish the given plugins directory, by downloading from the given
+    S3 buckets.
+
+    Args:
+        s3: A boto3 S3 client object
+        dioptra_plugin_dir: The directory to download to
+        s3_uris: S3 URIs to download task plugins from.
+    """
+    log = _get_logger()
+
+    bucket_info = []
+    for s3_uri in s3_uris:
+        bucket, prefix = s3_uri_to_bucket_prefix(s3_uri)
+
+        if not bucket:
+            raise ValueError("S3 URIs must include a bucket: " + s3_uri)
+
+        prefix = _normalize_s3_prefix(prefix)
+
+        bucket_info.append((bucket, prefix))
+
+    # Make sure the plugins dir exists!
+    plugin_dir_path = Path(dioptra_plugin_dir)
+    plugin_dir_path.mkdir(parents=True, exist_ok=True)
+
+    log.info("Clearing directory: %s", dioptra_plugin_dir)
+    clear_directory(plugin_dir_path)
+
+    for s3_uri, (bucket, prefix) in zip(s3_uris, bucket_info):
+        log.info("Downloading plugins: %s", s3_uri)
+        download_files(s3, plugin_dir_path, bucket, prefix)

--- a/src/dioptra/worker/setup_task_plugins_cli.py
+++ b/src/dioptra/worker/setup_task_plugins_cli.py
@@ -1,0 +1,114 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import argparse
+import logging
+import logging.config
+from typing import Union
+
+import boto3
+
+from dioptra.sdk.utilities.logging import (
+    attach_stdout_stream_handler,
+    configure_structlog,
+)
+from dioptra.worker.setup_task_plugins import setup_task_plugins
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="""
+        Setup a task plugins directory, with content downloaded from S3.
+        """
+    )
+
+    parser.add_argument(
+        "-e",
+        "--endpoint-url",
+        help="""
+        URL of an S3 endpoint to connect to
+        """,
+        required=True,
+    )
+
+    parser.add_argument(
+        "-d",
+        "--dest-dir",
+        help="""
+        The directory to download to
+        """,
+        required=True,
+    )
+
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="""
+        Set the logging level.  "all" is a special setting which causes logging
+        from all modules to display at the debug level, in addition to this
+        application.  This can result in a lot of logging noise.
+        Default: %(default)s
+        """,
+        choices=["all", "debug", "info", "warning", "error", "critical"],
+        default="info",
+    )
+
+    parser.add_argument(
+        "s3_uri",
+        help="""
+        S3 URI(s) to download from
+        """,
+        nargs="+",
+    )
+
+    return parser.parse_args()
+
+
+def _setup_logging(log_level: Union[int, str] = logging.INFO) -> None:
+    """
+    Set up logging.
+
+    Args:
+        log_level: The logging level to use.  May be one of the integer log
+            level constants or names recognized by the logging module, or
+            "all".
+    """
+    if isinstance(log_level, str):
+        log_level = log_level.upper()
+
+    configure_structlog()
+
+    if log_level == "ALL":
+        log = logging.getLogger()
+        log.setLevel(logging.DEBUG)
+    else:
+        log = logging.getLogger("dioptra")
+        log.setLevel(log_level)
+
+    attach_stdout_stream_handler(False, log)
+
+
+def main() -> None:
+    args = parse_args()
+    _setup_logging(args.log_level)
+
+    s3 = boto3.client("s3", endpoint_url=args.endpoint_url)
+
+    setup_task_plugins(s3, args.dest_dir, *args.s3_uri)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/restapi/conftest.py
+++ b/tests/unit/restapi/conftest.py
@@ -114,6 +114,7 @@ def dependency_modules() -> List[Any]:
         configuration: RQServiceConfiguration = RQServiceConfiguration(
             redis=Redis.from_url("redis://"),
             run_mlflow="dioptra.rq.tasks.run_mlflow_task",
+            run_task_engine="dioptra.rq.tasks.run_task_engine_task",
         )
 
         binder.bind(

--- a/tests/unit/rq/tasks/test_run_task_engine.py
+++ b/tests/unit/rq/tasks/test_run_task_engine.py
@@ -1,0 +1,276 @@
+import io
+
+import boto3
+import mlflow
+import mlflow.entities
+import rq.job
+from botocore.stub import Stubber
+
+import dioptra.pyplugs
+import dioptra.rq.tasks.run_task_engine
+from dioptra.mlflow_plugins.dioptra_clients import DioptraDatabaseClient
+from dioptra.mlflow_plugins.dioptra_tags import (
+    DIOPTRA_DEPENDS_ON,
+    DIOPTRA_JOB_ID,
+    DIOPTRA_QUEUE,
+)
+
+
+@dioptra.pyplugs.register
+def silly_plugin():
+    pass
+
+
+def test_run_task_engine(monkeypatch, tmp_path):
+    mlflow_tags = {}
+    mlflow_params = {}
+    mlflow_artifacts = {}
+    mlflow_run_status = None
+    mlflow_experiment_id = None
+
+    mlflow_run_info = mlflow.entities.RunInfo(
+        None, "exp1", "user1", "happy", "now", None, None, run_id="run_123"
+    )
+    mlflow_run = mlflow.entities.Run(mlflow_run_info, None)
+
+    rq_job = rq.job.Job.create(
+        func=lambda: 0,  # dummy function
+        id="job0",
+        # hopefully this "connection" is never actually used
+        connection="dummy_connection",
+    )
+
+    dioptra_job = {
+        "job_id": rq_job.id,
+        "queue": "worker_queue",
+        "depends_on": "a_different_job",
+        "timeout": "tomorrow",
+    }
+
+    global_experiment_params = {"param1": 123, "param2": "foo"}
+
+    def mlflow_set_tag(k, v):
+        mlflow_tags[k] = v
+
+    def mlflow_set_params(params):
+        mlflow_params.update(params)
+
+    def mlflow_add_artifact(artifact, name):
+        mlflow_artifacts[name] = artifact
+
+    def mlflow_end_run(status="FINISHED"):
+        nonlocal mlflow_run_status
+        mlflow_run_status = status
+
+    def mlflow_set_experiment(experiment_id):
+        nonlocal mlflow_experiment_id
+        mlflow_experiment_id = experiment_id
+
+    def dioptra_set_job_status(self, job_id, status):
+        dioptra_job["status"] = status
+
+    def dioptra_set_run_id_for_job(self, run_id, job_id):
+        dioptra_job["mlflow_run_id"] = run_id
+
+    monkeypatch.setattr(mlflow, "start_run", lambda: mlflow_run)
+    monkeypatch.setattr(mlflow, "end_run", mlflow_end_run)
+    monkeypatch.setattr(mlflow, "set_tag", mlflow_set_tag)
+    monkeypatch.setattr(mlflow, "log_dict", mlflow_add_artifact)
+    monkeypatch.setattr(mlflow, "log_params", mlflow_set_params)
+    monkeypatch.setattr(mlflow, "set_experiment", mlflow_set_experiment)
+    monkeypatch.setattr(
+        DioptraDatabaseClient, "get_job", lambda self, job_id: dioptra_job
+    )
+    monkeypatch.setattr(
+        DioptraDatabaseClient, "set_mlflow_run_id_for_job", dioptra_set_run_id_for_job
+    )
+    monkeypatch.setattr(
+        DioptraDatabaseClient, "update_job_status", dioptra_set_job_status
+    )
+    # Patching rq would be pointless here.  The run_task_engine module uses
+    # a "from X import get_current_job" style import, which has already defined
+    # a local symbol it will use by the time this code is executing.  So we
+    # must either patch that symbol, or change the import style.  I chose the
+    # former, for now.
+    monkeypatch.setattr(
+        dioptra.rq.tasks.run_task_engine, "get_current_job", lambda: rq_job
+    )
+
+    # silly experiment which calls a function which does nothing
+    silly_experiment = {
+        # Match these up with global_experiment_params above
+        "parameters": {
+            "param1": {"type": "integer"},
+            "param2": {"type": "string"}
+        },
+        "tasks": {
+            "silly": {
+                "plugin": "tests.unit.rq.tasks.test_run_task_engine.silly_plugin"
+            }
+        },
+        "graph": {
+            "step1": {
+                "silly": []
+            }
+        }
+    }
+
+    # Split the builtins plugins listing into two pages, to test paging.
+    builtins_keys_response_trunc = {
+        "IsTruncated": True,
+        "Contents": [{"Key": "dioptra_builtins/file1.dat"}],
+        "NextContinuationToken": "next",
+    }
+
+    builtins_keys_response_cont = {
+        "IsTruncated": False,
+        "Contents": [{"Key": "dioptra_builtins/file2.dat"}],
+    }
+
+    custom_keys_response = {
+        "IsTruncated": False,
+        "Contents": [
+            {"Key": "dioptra_custom/file3.dat"},
+            {"Key": "dioptra_custom/file4.dat"},
+        ],
+    }
+
+    file1_content = b"\x00\x01\x02"
+    file2_content = b"\x03\x04\x05"
+    file3_content = b"\x06\x07\x08"
+    file4_content = b"\x09\x0a\x0b"
+
+    file1_content_stream = io.BytesIO(file1_content)
+    file2_content_stream = io.BytesIO(file2_content)
+    file3_content_stream = io.BytesIO(file3_content)
+    file4_content_stream = io.BytesIO(file4_content)
+
+    # This ought to work for all files, since all are the same size.
+    head_object_response = {"ContentType": "binary/octet-stream", "ContentLength": 3}
+
+    file1_get_object_response = {"Body": file1_content_stream}
+
+    file2_get_object_response = {"Body": file2_content_stream}
+
+    file3_get_object_response = {"Body": file3_content_stream}
+
+    file4_get_object_response = {"Body": file4_content_stream}
+
+    monkeypatch.setenv("DIOPTRA_PLUGIN_DIR", str(tmp_path))
+    monkeypatch.setenv("DIOPTRA_PLUGINS_S3_URI", "s3://plugins/dioptra_builtins")
+    monkeypatch.setenv("DIOPTRA_CUSTOM_PLUGINS_S3_URI", "s3://plugins/dioptra_custom")
+    monkeypatch.setenv("MLFLOW_S3_ENDPOINT_URL", "http://example.org/")
+
+    s3 = boto3.client("s3", endpoint_url="http://example.org/")
+    with Stubber(s3) as stubber:
+        # The run_task_engine() function we're testing uses a boto3 convenience
+        # API function, download_file(), to download files.  But we can only
+        # mock up actual AWS responses.  The actual sequence of requests that
+        # download_file() makes to download its files, is not documented
+        # anywhere.  So we have no good way of knowing which responses we need
+        # to mock up!  It's a lot of trial and error...
+
+        # Page 1 of dioptra_builtins keys:
+        stubber.add_response(
+            "list_objects_v2",
+            builtins_keys_response_trunc,
+            {"Bucket": "plugins", "Prefix": "dioptra_builtins/"},
+        )
+
+        # I think the downloader does this because it wants the file size.
+        stubber.add_response(
+            "head_object",
+            head_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_builtins/file1.dat"},
+        )
+
+        stubber.add_response(
+            "get_object",
+            file1_get_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_builtins/file1.dat"},
+        )
+
+        # Page 2 of dioptra_builtins keys:
+        stubber.add_response(
+            "list_objects_v2",
+            builtins_keys_response_cont,
+            {
+                "Bucket": "plugins",
+                "Prefix": "dioptra_builtins/",
+                "ContinuationToken": "next",
+            },
+        )
+
+        stubber.add_response(
+            "head_object",
+            head_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_builtins/file2.dat"},
+        )
+
+        stubber.add_response(
+            "get_object",
+            file2_get_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_builtins/file2.dat"},
+        )
+
+        # dioptra_custom keys (1 page, 2 files):
+        stubber.add_response(
+            "list_objects_v2",
+            custom_keys_response,
+            {"Bucket": "plugins", "Prefix": "dioptra_custom/"},
+        )
+
+        stubber.add_response(
+            "head_object",
+            head_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_custom/file3.dat"},
+        )
+
+        stubber.add_response(
+            "get_object",
+            file3_get_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_custom/file3.dat"},
+        )
+
+        stubber.add_response(
+            "head_object",
+            head_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_custom/file4.dat"},
+        )
+
+        stubber.add_response(
+            "get_object",
+            file4_get_object_response,
+            {"Bucket": "plugins", "Key": "dioptra_custom/file4.dat"},
+        )
+
+        dioptra.rq.tasks.run_task_engine.run_task_engine_task(
+            1, silly_experiment, global_experiment_params, s3
+        )
+
+    file1 = tmp_path / "dioptra_builtins/file1.dat"
+    file2 = tmp_path / "dioptra_builtins/file2.dat"
+    file3 = tmp_path / "dioptra_custom/file3.dat"
+    file4 = tmp_path / "dioptra_custom/file4.dat"
+
+    assert file1.exists()
+    assert file2.exists()
+    assert file3.exists()
+    assert file4.exists()
+
+    assert file1.read_bytes() == file1_content
+    assert file2.read_bytes() == file2_content
+    assert file3.read_bytes() == file3_content
+    assert file4.read_bytes() == file4_content
+
+    assert dioptra_job["status"] == "finished"
+    assert dioptra_job["mlflow_run_id"] == mlflow_run.info.run_id
+    assert mlflow_experiment_id == "1"
+    assert mlflow_run_status == "FINISHED"
+    assert mlflow_tags == {
+        DIOPTRA_JOB_ID: dioptra_job["job_id"],
+        DIOPTRA_QUEUE: dioptra_job["queue"],
+        DIOPTRA_DEPENDS_ON: dioptra_job["depends_on"],
+    }
+    assert mlflow_artifacts == {"experiment.yaml": silly_experiment}
+    assert mlflow_params == global_experiment_params

--- a/tests/unit/sdk/utilities/paths/test_clear_directory.py
+++ b/tests/unit/sdk/utilities/paths/test_clear_directory.py
@@ -1,0 +1,24 @@
+from dioptra.sdk.utilities.paths import clear_directory
+
+
+def test_clear_directory(tmp_path):
+    files = [
+        "file1",
+        "dir1/file2",
+        "dir1/dir2/file3"
+    ]
+
+    # Make some files
+    for f in files:
+        # Ensure we're not trying to create files in the root directory!
+        f = f.lstrip("/")
+        pathobj = tmp_path / f
+        pathobj.parent.mkdir(parents=True, exist_ok=True)
+        pathobj.touch()
+
+    # Test the function
+    clear_directory(tmp_path)
+
+    # Ensure the directory is now clear!
+    test_files = list(tmp_path.iterdir())
+    assert len(test_files) == 0

--- a/tests/unit/task_engine/test_task_engine.py
+++ b/tests/unit/task_engine/test_task_engine.py
@@ -171,7 +171,7 @@ def test_single_call_positional() -> None:
         "graph": {"add": {"add": [1, 1]}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 2
 
@@ -185,7 +185,7 @@ def test_single_call_positional_nolist() -> None:
         "graph": {"step1": {"square": 2}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 4
 
@@ -197,7 +197,7 @@ def test_single_call_keyword() -> None:
         "graph": {"step1": {"add": {"a": 1, "b": 1}}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 2
 
@@ -209,7 +209,7 @@ def test_single_call_mixed_positional_keyword() -> None:
         "graph": {"step1": {"task": "add", "args": 1, "kwargs": {"b": 1}}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 2
 
@@ -221,7 +221,7 @@ def test_single_call_no_args_positional() -> None:
         "graph": {"step1": {"hello": []}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == "hello"
 
@@ -233,7 +233,7 @@ def test_single_call_no_args_keyword() -> None:
         "graph": {"step1": {"hello": {}}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == "hello"
 
@@ -245,7 +245,7 @@ def test_single_call_no_args_mixed() -> None:
         "graph": {"step1": {"task": "hello"}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == "hello"
 
@@ -259,13 +259,13 @@ def test_globals_dict_nodefault() -> None:
     }
 
     dioptra.task_engine.task_engine.run_experiment(
-        desc, {"global_in": 2}, mlflow_run=None
+        desc, {"global_in": 2}
     )
 
     assert _output == 3
 
     with pytest.raises(MissingGlobalParametersError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert "global_in" in e.value.parameter_names
 
@@ -279,12 +279,12 @@ def test_globals_dict_default() -> None:
     }
 
     dioptra.task_engine.task_engine.run_experiment(
-        desc, {"global_in": 2}, mlflow_run=None
+        desc, {"global_in": 2}
     )
 
     assert _output == 3
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 2
 
@@ -301,7 +301,7 @@ def test_task_nonlist_output() -> None:
         "graph": {"step1": {"addsub": [1, 2]}},
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == (3, -1)
 
@@ -329,7 +329,7 @@ def test_task_list_output() -> None:
         },
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     # (a+b) + (a-b) = 2a
     assert _output == 2
@@ -363,7 +363,7 @@ def test_task_dependencies_ambig() -> None:
         },
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 7
 
@@ -395,7 +395,7 @@ def test_task_task_ambig() -> None:
         },
     }
 
-    dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+    dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert _output == 7
 
@@ -417,7 +417,7 @@ def test_step_missing_plugin_name() -> None:
     }
 
     with pytest.raises(MissingTaskPluginNameError):
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
 
 @require_plugins(add, square)
@@ -434,7 +434,7 @@ def test_step_cycle() -> None:
     }
 
     with pytest.raises(StepReferenceCycleError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert "step1" in e.value.cycle
     assert "step2" in e.value.cycle
@@ -447,7 +447,7 @@ def test_step_not_found_reference() -> None:
     }
 
     with pytest.raises(UnresolvableReferenceError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.reference_name == "foo"
 
@@ -460,7 +460,7 @@ def test_step_not_found_dependency() -> None:
     }
 
     with pytest.raises(StepNotFoundError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.step_name == "foo"
 
@@ -479,7 +479,7 @@ def test_output_not_found_explicit() -> None:
     }
 
     with pytest.raises(OutputNotFoundError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.step_name == "step1"
     assert e.value.output_name == "foo"
@@ -502,7 +502,7 @@ def test_output_not_found_implicit() -> None:
     }
 
     with pytest.raises(UnresolvableReferenceError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.reference_name == "step1"
 
@@ -528,7 +528,7 @@ def test_output_reference_ambig() -> None:
     }
 
     with pytest.raises(IllegalOutputReferenceError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.context_step_name == "step2"
     assert e.value.step_name == "step1"
@@ -549,7 +549,7 @@ def test_output_not_iterable() -> None:
     }
 
     with pytest.raises(NonIterableTaskOutputError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.value == 3
 
@@ -558,6 +558,6 @@ def test_illegal_plugin_name() -> None:
     desc = {"tasks": {"add": {"plugin": "foo"}}, "graph": {"step1": {"add": [1, 2]}}}
 
     with pytest.raises(IllegalPluginNameError) as e:
-        dioptra.task_engine.task_engine.run_experiment(desc, {}, mlflow_run=None)
+        dioptra.task_engine.task_engine.run_experiment(desc, {})
 
     assert e.value.plugin_name == "foo"


### PR DESCRIPTION
Partially addresses #213 .

This PR adds a function which can be called through redis queue, to cause an experiment to run via the task engine.  In that way, it achieves task engine integration with a worker: you just have to queue the job up a bit differently.

The REST API and UI/frontend aspects of the issue are not addressed here.