### PR TITLE
Refactor experiments endpoint to breakup functionality

### DIFF
--- a/src/dioptra/restapi/experiment/controller.py
+++ b/src/dioptra/restapi/experiment/controller.py
@@ -18,23 +18,19 @@
 from __future__ import annotations
 
 import uuid
-from typing import List, Optional
+from typing import Any, cast
 
 import structlog
-from flask import jsonify, request
-from flask.wrappers import Response
+from flask import request
 from flask_accepts import accepts, responds
 from flask_login import login_required
 from flask_restx import Namespace, Resource
 from injector import inject
 from structlog.stdlib import BoundLogger
 
-from dioptra.restapi.utils import slugify
-
-from .errors import ExperimentDoesNotExistError
 from .model import Experiment
-from .schema import ExperimentSchema
-from .service import ExperimentService
+from .schema import ExperimentSchema, IdStatusResponseSchema, NameStatusResponseSchema
+from .service import ExperimentNameService, ExperimentService
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
@@ -55,7 +51,7 @@ class ExperimentResource(Resource):
 
     @login_required
     @responds(schema=ExperimentSchema(many=True), api=api)
-    def get(self) -> List[Experiment]:
+    def get(self) -> list[Experiment]:
         """Gets a list of all registered experiments."""
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="experiment", request_type="GET"
@@ -71,14 +67,9 @@ class ExperimentResource(Resource):
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="experiment", request_type="POST"
         )  # noqa: F841
-
         log.info("Request received")
-
         parsed_obj = request.parsed_obj  # type: ignore
-
-        name = slugify(str(parsed_obj["name"]))
-
-        return self._experiment_service.create(experiment_name=name, log=log)
+        return self._experiment_service.create(parsed_obj["name"], log=log)
 
 
 @api.route("/<int:experimentId>")
@@ -99,28 +90,22 @@ class ExperimentIdResource(Resource):
             request_id=str(uuid.uuid4()), resource="experimentId", request_type="GET"
         )  # noqa: F841
         log.info("Request received", experiment_id=experimentId)
-        experiment: Optional[Experiment] = self._experiment_service.get_by_id(
-            experiment_id=experimentId, log=log
+        return cast(
+            Experiment,
+            self._experiment_service.get(
+                experimentId, error_if_not_found=True, log=log
+            ),
         )
 
-        if experiment is None:
-            log.error("Experiment not found", experiment_id=experimentId)
-            raise ExperimentDoesNotExistError
-
-        return experiment
-
     @login_required
-    def delete(self, experimentId: int) -> Response:
+    @responds(schema=IdStatusResponseSchema)
+    def delete(self, experimentId: int) -> dict[str, Any]:
         """Deletes an experiment by its unique identifier."""
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="experimentId", request_type="DELETE"
         )  # noqa: F841
         log.info("Request received", experiment_id=experimentId)
-        id: List[int] = self._experiment_service.delete_experiment(
-            experiment_id=experimentId
-        )
-
-        return jsonify(dict(status="Success", id=id))
+        return self._experiment_service.delete(experimentId)
 
     @login_required
     @accepts(schema=ExperimentSchema, api=api)
@@ -130,30 +115,22 @@ class ExperimentIdResource(Resource):
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="experimentId", request_type="PUT"
         )  # noqa: F841
-        changes: dict = request.parsed_obj  # type: ignore
-        experiment: Optional[Experiment] = self._experiment_service.get_by_id(
-            experimentId, log=log
+        parsed_obj = request.parsed_obj  # type: ignore
+        return self._experiment_service.rename(
+            experimentId, new_name=parsed_obj["name"], log=log
         )
-
-        if experiment is None:
-            log.error("Experiment not found", experiment_id=experimentId)
-            raise ExperimentDoesNotExistError
-
-        experiment = self._experiment_service.rename_experiment(
-            experiment=experiment, new_name=changes["name"], log=log
-        )
-
-        return experiment
 
 
 @api.route("/name/<string:experimentName>")
 @api.param("experimentName", "The name of the experiment.")
 class ExperimentNameResource(Resource):
-    """Shows a single experiment (name reference) and lets you modify and delete it."""
+    """Shows a single experiment (name reference) and delete it."""
 
     @inject
-    def __init__(self, *args, experiment_service: ExperimentService, **kwargs) -> None:
-        self._experiment_service = experiment_service
+    def __init__(
+        self, *args, experiment_name_service: ExperimentNameService, **kwargs
+    ) -> None:
+        self._experiment_name_service = experiment_name_service
         super().__init__(*args, **kwargs)
 
     @login_required
@@ -164,18 +141,16 @@ class ExperimentNameResource(Resource):
             request_id=str(uuid.uuid4()), resource="experimentName", request_type="GET"
         )  # noqa: F841
         log.info("Request received", experiment_name=experimentName)
-        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
-            experiment_name=experimentName, log=log
+        return cast(
+            Experiment,
+            self._experiment_name_service.get(
+                experimentName, error_if_not_found=True, log=log
+            ),
         )
 
-        if experiment is None:
-            log.error("Experiment not found", experiment_name=experimentName)
-            raise ExperimentDoesNotExistError
-
-        return experiment
-
     @login_required
-    def delete(self, experimentName: str) -> Response:
+    @responds(schema=NameStatusResponseSchema)
+    def delete(self, experimentName: str) -> dict[str, Any]:
         """Deletes an experiment by its unique name."""
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()),
@@ -184,38 +159,4 @@ class ExperimentNameResource(Resource):
             request_type="DELETE",
         )  # noqa: F841
         log.info("Request received")
-        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
-            experiment_name=experimentName, log=log
-        )
-
-        if experiment is None:
-            return jsonify(dict(status="Success", id=[]))
-
-        id: List[int] = self._experiment_service.delete_experiment(
-            experiment_id=experiment.experiment_id
-        )
-
-        return jsonify(dict(status="Success", id=id))
-
-    @login_required
-    @accepts(schema=ExperimentSchema, api=api)
-    @responds(schema=ExperimentSchema, api=api)
-    def put(self, experimentName: str) -> Experiment:
-        """Modifies an experiment by its unique name."""
-        log: BoundLogger = LOGGER.new(
-            request_id=str(uuid.uuid4()), resource="experimentName", request_type="PUT"
-        )  # noqa: F841
-        changes: dict = request.parsed_obj  # type: ignore
-        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
-            experiment_name=experimentName, log=log
-        )
-
-        if experiment is None:
-            log.error("Experiment not found", experiment_name=experimentName)
-            raise ExperimentDoesNotExistError
-
-        experiment = self._experiment_service.rename_experiment(
-            experiment=experiment, new_name=changes["name"], log=log
-        )
-
-        return experiment
+        return self._experiment_name_service.delete(experimentName, log=log)

--- a/src/dioptra/restapi/experiment/schema.py
+++ b/src/dioptra/restapi/experiment/schema.py
@@ -17,9 +17,6 @@
 """The schemas for serializing/deserializing the experiment endpoint objects.
 
 .. |Experiment| replace:: :py:class:`~.model.Experiment`
-.. |ExperimentRegistrationForm| replace:: :py:class:`~.model.ExperimentRegistrationForm`
-.. |ExperimentRegistrationFormData| replace:: \
-   :py:class:`~.model.ExperimentRegistrationFormData`
 """
 from __future__ import annotations
 
@@ -27,14 +24,7 @@ from marshmallow import Schema, fields
 
 
 class ExperimentSchema(Schema):
-    """The schema for the data stored in an |Experiment| object.
-
-    Attributes:
-        experimentId: An integer identifying a registered experiment.
-        createdOn: The date and time the experiment was created.
-        lastModified: The date and time the experiment was last modified.
-        name: The name of the experiment.
-    """
+    """The schema for the data stored in an |Experiment| object."""
 
     experimentId = fields.Integer(
         attribute="experiment_id",
@@ -55,4 +45,36 @@ class ExperimentSchema(Schema):
     )
     name = fields.String(
         attribute="name", metadata=dict(description="The name of the experiment.")
+    )
+
+
+class IdStatusResponseSchema(Schema):
+    """A simple response for reporting a status for one or more objects."""
+
+    status = fields.String(
+        attribute="status",
+        metadata=dict(description="The status of the request."),
+    )
+    id = fields.List(
+        fields.Integer(),
+        attribute="id",
+        metadata=dict(
+            description="A list of integers identifying the affected object(s)."
+        ),
+    )
+
+
+class NameStatusResponseSchema(Schema):
+    """A simple response for reporting a status for one or more objects."""
+
+    status = fields.String(
+        attribute="status",
+        metadata=dict(description="The status of the request."),
+    )
+    name = fields.List(
+        fields.String(),
+        attribute="name",
+        metadata=dict(
+            description="A list of names identifying the affected object(s)."
+        ),
     )

--- a/src/dioptra/restapi/experiment/service.py
+++ b/src/dioptra/restapi/experiment/service.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import List, Optional
+from typing import Any, cast
 
 import structlog
 from injector import inject
@@ -31,6 +31,7 @@ from dioptra.restapi.utils import slugify
 
 from .errors import (
     ExperimentAlreadyExistsError,
+    ExperimentDoesNotExistError,
     ExperimentMLFlowTrackingAlreadyExistsError,
     ExperimentMLFlowTrackingDoesNotExistError,
     ExperimentMLFlowTrackingRegistrationError,
@@ -45,42 +46,52 @@ class ExperimentService(object):
     def __init__(
         self,
         mlflow_tracking_service: MLFlowTrackingService,
+        experiment_name_service: ExperimentNameService,
     ) -> None:
+        """Initialize the experiment service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            mlflow_tracking_service: The MLflow tracking service.
+            experiment_name_service: The experiment name service.
+        """
         self._mlflow_tracking_service = mlflow_tracking_service
+        self._experiment_name_service = experiment_name_service
 
     def create(
         self,
         experiment_name: str,
         **kwargs,
     ) -> Experiment:
-        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        """Create a new experiment.
 
-        if self.get_by_name(experiment_name, log=log) is not None:
+        Args:
+            experiment_name: The name of the experiment.
+
+        Returns:
+            The newly created experiment object.
+
+        Raises:
+            ExperimentAlreadyExistsError: If an experiment with the given name already
+                exists.
+            ExperimentMLFlowTrackingAlreadyExistsError: If an MLflow experiment with
+                the same name already exists.
+            ExperimentMLFlowTrackingRegistrationError: If there is an error registering
+                the experiment with MLflow.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        experiment_name = slugify(experiment_name)
+
+        if self._experiment_name_service.get(experiment_name, log=log) is not None:
             raise ExperimentAlreadyExistsError
 
         timestamp = datetime.datetime.now()
-        experiment_id: int = self.create_mlflow_experiment(experiment_name)
-        new_experiment: Experiment = Experiment(
-            experiment_id=experiment_id,
-            name=experiment_name,
-            created_on=timestamp,
-            last_modified=timestamp,
-        )
-        db.session.add(new_experiment)
-        db.session.commit()
 
-        log.info(
-            "Experiment registration successful",
-            experiment_id=new_experiment.experiment_id,
-        )
-
-        return new_experiment
-
-    def create_mlflow_experiment(self, experiment_name: str) -> int:
         try:
-            experiment_id: Optional[
-                str
-            ] = self._mlflow_tracking_service.create_experiment(experiment_name)
+            experiment_id = self._mlflow_tracking_service.create_experiment(
+                experiment_name
+            )
 
         except RestException as exc:
             raise ExperimentMLFlowTrackingRegistrationError from exc
@@ -88,65 +99,200 @@ class ExperimentService(object):
         if experiment_id is None:
             raise ExperimentMLFlowTrackingAlreadyExistsError
 
-        return int(experiment_id)
+        new_experiment = Experiment(
+            experiment_id=int(experiment_id),
+            name=experiment_name,
+            created_on=timestamp,
+            last_modified=timestamp,
+        )
+        db.session.add(new_experiment)
+        db.session.commit()
+        log.info(
+            "Experiment registration successful",
+            experiment_id=new_experiment.experiment_id,
+        )
+        return new_experiment
 
-    def delete_experiment(self, experiment_id: int, **kwargs) -> List[int]:
+    def delete(self, experiment_id: int, **kwargs) -> dict[str, Any]:
+        """Delete an experiment.
+
+        Args:
+            experiment_id: The unique identifier of the experiment.
+
+        Returns:
+            A dictionary reporting the status of the request.
+
+        Raises:
+            ExperimentMLFlowTrackingDoesNotExistError: If the experiment does not exist
+                in MLflow.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
-        experiment: Optional[Experiment] = self.get_by_id(experiment_id=experiment_id)
+        experiment = self.get(experiment_id=experiment_id)
 
         if experiment is None:
-            return []
+            return {"status": "Success", "id": []}
 
-        reply: Optional[bool] = self._mlflow_tracking_service.delete_experiment(
+        response = self._mlflow_tracking_service.delete_experiment(
             experiment_id=experiment_id
         )
 
-        if reply is None:
+        if response is None:
             raise ExperimentMLFlowTrackingDoesNotExistError
 
         experiment.update(changes={"is_deleted": True})
         db.session.commit()
+        return {"status": "Success", "id": [experiment_id]}
 
-        return [experiment_id]
+    def rename(self, experiment_id: int, new_name: str, **kwargs) -> Experiment:
+        """Rename an experiment.
 
-    def rename_experiment(
-        self, experiment: Experiment, new_name: str, **kwargs
-    ) -> Experiment:
+        Args:
+            experiment_id: The unique identifier of the experiment.
+            new_name: The new name for the experiment.
+
+        Returns:
+            The updated experiment object.
+
+        Raises:
+            ExperimentMLFlowTrackingDoesNotExistError: If the experiment does not exist
+                in MLflow.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
-
         new_name = slugify(new_name)
-        reply: Optional[bool] = self._mlflow_tracking_service.rename_experiment(
-            experiment_id=experiment.experiment_id, new_name=new_name
+        experiment = cast(
+            Experiment, self.get(experiment_id, error_if_not_found=True, log=log)
+        )
+        response = self._mlflow_tracking_service.rename_experiment(
+            experiment_id=experiment_id, new_name=new_name, log=log
         )
 
-        if reply is None:
+        if response is None:
             raise ExperimentMLFlowTrackingDoesNotExistError
 
         experiment.update(changes={"name": new_name})
         db.session.commit()
-
+        log.info("Experiment renamed", queue_id=experiment_id, new_name=new_name)
         return experiment
 
-    @staticmethod
-    def get_all(**kwargs) -> List[Experiment]:
-        log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
+    def get_all(self, **kwargs) -> list[Experiment]:
+        """Fetch the list of all experiments.
 
+        Returns:
+            A list of experiment objects.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
         return Experiment.query.filter_by(is_deleted=False).all()  # type: ignore
 
-    @staticmethod
-    def get_by_id(experiment_id: int, **kwargs) -> Optional[Experiment]:
-        log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
+    def get(
+        self, experiment_id: int, error_if_not_found: bool = False, **kwargs
+    ) -> Experiment | None:
+        """Fetch an experiment by its unique identifier.
 
-        return Experiment.query.filter_by(  # type: ignore
+        Args:
+            experiment_id: The unique identifier of the experiment.
+            error_if_not_found: If True, raise an error if the experiment is not found.
+                Defaults to False.
+
+        Returns:
+            The experiment object if found, otherwise None.
+
+        Raises:
+            ExperimentDoesNotExistError: If the experiment is not found and
+                `error_if_not_found` is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
+        experiment = Experiment.query.filter_by(
             experiment_id=experiment_id, is_deleted=False
         ).first()
 
-    @staticmethod
-    def get_by_name(experiment_name: str, **kwargs) -> Optional[Experiment]:
-        log: BoundLogger = kwargs.get("log", LOGGER.new())
-        log.info("Lookup experiment by unique name", experiment_name=experiment_name)
+        if experiment is None:
+            if error_if_not_found:
+                log.error("Experiment not found", experiment_id=experiment_id)
+                raise ExperimentDoesNotExistError
 
+            return None
+
+        return cast(Experiment, experiment)
+
+
+class ExperimentNameService(object):
+    @inject
+    def __init__(
+        self,
+        mlflow_tracking_service: MLFlowTrackingService,
+    ) -> None:
+        """Initialize the experiment name service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            mlflow_tracking_service: The MLflow tracking service.
+        """
+        self._mlflow_tracking_service = mlflow_tracking_service
+
+    def get(
+        self,
+        experiment_name: str,
+        error_if_not_found: bool = False,
+        **kwargs,
+    ) -> Experiment | None:
+        """Fetch an experiment by its name.
+
+        Args:
+            experiment_name: The name of the experiment.
+            error_if_not_found: If True, raise an error if the experiment is not found.
+                Defaults to False.
+
+        Returns:
+            The experiment object if found, otherwise None.
+
+        Raises:
+            ExperimentDoesNotExistError: If the experiment is not found and
+                `error_if_not_found` is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
         experiment_name = slugify(experiment_name)
-        return Experiment.query.filter_by(  # type: ignore
+        log.info("Get experiment by name", experiment_name=experiment_name)
+        experiment = Experiment.query.filter_by(
             name=experiment_name, is_deleted=False
         ).first()
+
+        if experiment is None:
+            if error_if_not_found:
+                log.error("Experiment not found", experiment_name=experiment_name)
+                raise ExperimentDoesNotExistError
+
+            return None
+
+        return cast(Experiment, experiment)
+
+    def delete(self, experiment_name: str, **kwargs) -> dict[str, Any]:
+        """Delete an experiment by name.
+
+        Args:
+            experiment_name: The name of the experiment.
+
+        Returns:
+            A dictionary reporting the status of the request.
+
+        Raises:
+            ExperimentMLFlowTrackingDoesNotExistError: If the experiment does not exist
+                in MLflow.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.info("Delete experiment by name", experiment_name=experiment_name)
+
+        if (experiment := self.get(experiment_name, log=log)) is None:
+            return {"status": "Success", "name": []}
+
+        response: bool | None = self._mlflow_tracking_service.delete_experiment(
+            experiment_id=experiment.experiment_id
+        )
+
+        if response is None:
+            raise ExperimentMLFlowTrackingDoesNotExistError
+
+        experiment.update(changes={"is_deleted": True})
+        db.session.commit()
+        log.info("Experiment deleted", experiment_name=experiment_name)
+        return {"status": "Success", "name": [experiment_name]}

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -31,7 +31,7 @@ from werkzeug.utils import secure_filename
 
 from dioptra.restapi.app import db
 from dioptra.restapi.experiment.errors import ExperimentDoesNotExistError
-from dioptra.restapi.experiment.service import ExperimentService
+from dioptra.restapi.experiment.service import ExperimentNameService
 from dioptra.restapi.models import Experiment, Queue
 from dioptra.restapi.queue.service import QueueNameService
 from dioptra.restapi.shared.rq.service import RQService
@@ -50,12 +50,12 @@ class JobService(object):
         self,
         rq_service: RQService,
         s3_service: S3Service,
-        experiment_service: ExperimentService,
+        experiment_name_service: ExperimentNameService,
         queue_name_service: QueueNameService,
     ) -> None:
         self._rq_service = rq_service
         self._s3_service = s3_service
-        self._experiment_service = experiment_service
+        self._experiment_name_service = experiment_name_service
         self._queue_name_service = queue_name_service
 
     @staticmethod
@@ -109,7 +109,7 @@ class JobService(object):
     ) -> Job:
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
+        experiment: Optional[Experiment] = self._experiment_name_service.get(
             experiment_name=experiment_name, log=log
         )
 
@@ -179,7 +179,7 @@ class JobService(object):
 
         log: BoundLogger = LOGGER.new()
 
-        experiment: Optional[Experiment] = self._experiment_service.get_by_name(
+        experiment: Optional[Experiment] = self._experiment_name_service.get(
             experiment_name=experiment_name, log=log
         )
 

--- a/tests/unit/restapi/test_experiment.py
+++ b/tests/unit/restapi/test_experiment.py
@@ -51,34 +51,14 @@ def register_experiment(client: FlaskClient, name: str) -> TestResponse:
     )
 
 
-def rename_experiment_with_name(
-    client: FlaskClient, name: str, new_name: str
-) -> TestResponse:
-    """Rename an experiment using the API.
-
-    Args:
-        client: The Flask test client.
-        name: The old name of the experimet to rename.
-        new_name: The new name to assign to the experiment.
-
-    Returns:
-        The response from the API.
-    """
-    return client.put(
-        f"/api/{EXPERIMENT_BASE_ROUTE}/name/{name}",
-        json={"name": new_name},
-        follow_redirects=True,
-    )
-
-
-def rename_experiment_with_id(
+def rename_experiment(
     client: FlaskClient, id: int, new_name: str
 ) -> TestResponse:
     """Rename an experiment using the API.
 
     Args:
         client: The Flask test client.
-        id: The id of the experimet to rename.
+        id: The id of the experiment to rename.
         new_name: The new name to assign to the experiment.
 
     Returns:
@@ -364,38 +344,28 @@ def test_rename_experiment(client: FlaskClient, db: SQLAlchemy) -> None:
         Scenario: Rename an Experiment
             Given I am an authorized user and an experiment exists,
             I need to be able to submit a rename request
-            in order to rename an experiment using its old name and id as identifiers.
+            in order to rename an experiment using its id as an identifier.
 
     This test validates by following these actions:
 
     - A user registers an experiment named "mnist".
     - The user is able to retrieve information about the "mnist" experiment that
       matches the information that was provided during registration.
-    - The user renames this same experiment to "imagenet" using the experiment's name as
-      an identifier.
+    - The user renames this same experiment to "imagenet".
     - The user retrieves information about the same experiment and it reflects the name
       change.
-    - The user renames this same experiment again to "fruits360" using the experiment's
-      id as an identifier.
-    - The user again retrieves information about the same experiment and it reflects
-      the name change.
     """
     start_name = "mnist"
-    update1_name = "imagenet"
-    update2_name = "fruits360"
+    update_name = "imagenet"
     experiment_json = register_experiment(client, name=start_name).get_json()
     assert_experiment_name_matches_expected_name(
         client, id=experiment_json["experimentId"], expected_name=start_name
     )
-    rename_experiment_with_name(client, name="mnist", new_name=update1_name)
-    assert_experiment_name_matches_expected_name(
-        client, id=experiment_json["experimentId"], expected_name=update1_name
-    )
-    rename_experiment_with_id(
-        client, id=experiment_json["experimentId"], new_name=update2_name
+    rename_experiment(
+        client, id=experiment_json["experimentId"], new_name=update_name
     )
     assert_experiment_name_matches_expected_name(
-        client, id=experiment_json["experimentId"], expected_name=update2_name
+        client, id=experiment_json["experimentId"], expected_name=update_name
     )
 
 


### PR DESCRIPTION
Continues the refactor for #312, breaking up the functionality of the Experiment service into different classes. 

Should be merged after PR #339 and #328, will fail unit tests and mypy checks until then. 