### PR TITLE
fix: Add Host header setting to nginx config for minio.

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/config/nginx/http_minio.conf
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/config/nginx/http_minio.conf
@@ -20,6 +20,7 @@ server {
 
     proxy_http_version 1.1;
     proxy_set_header Connection "";
+    proxy_set_header Host            $http_host;
 
     location ^~ / {
         proxy_pass http://container-minio-api/;

--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/config/nginx/https_minio.conf
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/config/nginx/https_minio.conf
@@ -20,6 +20,7 @@ server {
 
     proxy_http_version 1.1;
     proxy_set_header Connection "";
+    proxy_set_header Host            $http_host;
 
     location ^~ / {
         proxy_pass http://container-minio-api/;


### PR DESCRIPTION
Fixes #346 .

I think that the reason for the error is that both client and server (minio in our case) create a signature from a http request, based on certain request headers.  The client's signature is transmitted to the server in yet another header.  The server computes its own signature based on the request it received and compares to the signature received from the client.  If they don't match, the request is rejected.

This means that certain headers are critical for S3 to work: if nginx alters them as it proxies, it alters the resulting signature and causes minio to reject the request.  The problematic header in this case seems to be the `Host` header.  The fix in this PR alters the nginx config for minio to pass along the Host header.  It seems to work for me in the non-TLS case (I have not tested anything with TLS enabled, but included the fix there too because it seems likely to be necessary).