### PR TITLE
Refactor jobs restapi to split up id and name functionality

### DIFF
--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -141,7 +141,7 @@ class JobIdResource(Resource):
 
 
 @api.route("/newTaskEngine")
-class TaskEngineResource(Resource):
+class JobNewTaskEngineResource(Resource):
     """Lets you POST to create new jobs using the new declarative task engine."""
 
     @inject

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import List, cast
+from typing import cast
 
 import structlog
 from flask import request
@@ -63,7 +63,7 @@ class JobResource(Resource):
 
     @login_required
     @responds(schema=JobSchema(many=True), api=api)
-    def get(self) -> List[Job]:
+    def get(self) -> list[Job]:
         """Gets a list of all submitted jobs."""
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="job", request_type="GET"

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -145,6 +145,7 @@ class JobIdResource(Resource):
 
 @api.route("/newTaskEngine")
 class TaskEngineResource(Resource):
+    """Lets you POST to create new jobs using the new declarative task engine."""
     @inject
     def __init__(
         self, job_new_task_engine_service: JobNewTaskEngineService, *args, **kwargs
@@ -155,6 +156,7 @@ class TaskEngineResource(Resource):
     @accepts(schema=JobNewTaskEngineSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def post(self) -> Job:
+        """Creates a new job using the new declarative task engine."""
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()),
             resource="job/newTaskEngine",

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -133,6 +133,7 @@ class JobIdResource(Resource):
 
         parsed_obj = request.parsed_obj  # type: ignore
 
+        log.info("Request received", job_id=jobId, status=parsed_obj["status"])
         return cast(
             Job,
             self._job_service.change_status(
@@ -154,6 +155,12 @@ class TaskEngineResource(Resource):
     @accepts(schema=JobNewTaskEngineSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def post(self) -> Job:
+        log: BoundLogger = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="job/newTaskEngine",
+            request_type="POST",
+        )  # noqa: F841
+        log.info("Request received")
         parsed_obj = request.parsed_obj  # type: ignore
 
         return self._job_new_task_engine_service.create(

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -117,9 +117,10 @@ class JobIdResource(Resource):
             request_id=str(uuid.uuid4()), resource="jobId", request_type="GET"
         )  # noqa: F841
         log.info("Request received", job_id=jobId)
-        job = self._job_service.get(jobId, error_if_not_found=True, log=log)
-
-        return cast(Job, job)
+        return cast(
+            Job,
+            self._job_service.get(jobId, error_if_not_found=True, log=log),
+        )
 
     @login_required
     @accepts(schema=JobMutableFieldsSchema, api=api)
@@ -132,11 +133,13 @@ class JobIdResource(Resource):
 
         parsed_obj = request.parsed_obj  # type: ignore
 
-        job = self._job_service.change_status(
-            jobId, status=parsed_obj["status"], error_if_not_found=True, log=log
+        return cast(
+            Job,
+            self._job_service.change_status(
+                jobId, status=parsed_obj["status"], error_if_not_found=True, log=log
+            ),
         )
 
-        return cast(Job, job)
 
 
 @api.route("/newTaskEngine")

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -34,8 +34,8 @@ from .model import Job
 from .schema import (
     JobBaseSchema,
     JobMutableFieldsSchema,
+    JobNewTaskEngineSchema,
     JobSchema,
-    TaskEngineSubmission,
 )
 from .service import JobService
 
@@ -142,16 +142,18 @@ class JobIdResource(Resource):
 @api.route("/newTaskEngine")
 class TaskEngineResource(Resource):
     @inject
-    def __init__(self, job_service: JobService, *args, **kwargs):
+    def __init__(
+        self, job_new_task_engine_service: JobNewTaskEngineService, *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
-        self._job_service = job_service
+        self._job_new_task_engine_service = job_new_task_engine_service
 
-    @accepts(schema=TaskEngineSubmission, api=api)
+    @accepts(schema=JobNewTaskEngineSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def post(self) -> Job:
         parsed_obj = request.parsed_obj  # type: ignore
 
-        new_job = self._job_service.submit_task_engine(
+        return self._job_new_task_engine_service.create(
             queue_name=parsed_obj["queue"],
             experiment_name=parsed_obj["experimentName"],
             experiment_description=parsed_obj["experimentDescription"],
@@ -159,5 +161,3 @@ class TaskEngineResource(Resource):
             timeout=parsed_obj.get("timeout"),
             depends_on=parsed_obj.get("dependsOn"),
         )
-
-        return new_job

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -161,8 +161,8 @@ class TaskEngineResource(Resource):
             resource="job/newTaskEngine",
             request_type="POST",
         )  # noqa: F841
-        log.info("Request received")
         parsed_obj = request.parsed_obj  # type: ignore
+        log.info("Request received")
         return self._job_new_task_engine_service.create(
             queue_name=parsed_obj["queue"],
             experiment_name=parsed_obj["experimentName"],

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -18,9 +18,8 @@
 from __future__ import annotations
 
 import uuid
-from typing import List, Optional
+from typing import List, cast
 
-import flask
 import structlog
 from flask import request
 from flask_accepts import accepts, responds
@@ -31,7 +30,6 @@ from structlog.stdlib import BoundLogger
 
 from dioptra.restapi.utils import as_api_parser, as_parameters_schema_list
 
-from .errors import JobDoesNotExistError
 from .model import Job
 from .schema import JobSchema, TaskEngineSubmission
 from .service import JobService
@@ -116,7 +114,7 @@ class JobIdResource(Resource):
         log.info("Request received", job_id=jobId)
         job = self._job_service.get(jobId, error_if_not_found=True, log=log)
 
-        return job
+        return cast(Job,job)
 
     @login_required
     @accepts(schema=JobSchema, api=api)
@@ -133,7 +131,7 @@ class JobIdResource(Resource):
             jobId, status=parsed_obj["status"], error_if_not_found=True, log=log
         )
 
-        return job
+        return cast(Job,job)
 
 
 @api.route("/newTaskEngine")

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -114,7 +114,7 @@ class JobIdResource(Resource):
         log.info("Request received", job_id=jobId)
         job = self._job_service.get(jobId, error_if_not_found=True, log=log)
 
-        return cast(Job,job)
+        return cast(Job, job)
 
     @login_required
     @accepts(schema=JobSchema, api=api)
@@ -131,7 +131,7 @@ class JobIdResource(Resource):
             jobId, status=parsed_obj["status"], error_if_not_found=True, log=log
         )
 
-        return cast(Job,job)
+        return cast(Job, job)
 
 
 @api.route("/newTaskEngine")

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -31,7 +31,12 @@ from structlog.stdlib import BoundLogger
 from dioptra.restapi.utils import as_api_parser, as_parameters_schema_list
 
 from .model import Job
-from .schema import JobSchema, TaskEngineSubmission
+from .schema import (
+    JobBaseSchema,
+    JobMutableFieldsSchema,
+    JobSchema,
+    TaskEngineSubmission,
+)
 from .service import JobService
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
@@ -70,10 +75,10 @@ class JobResource(Resource):
     @api.expect(
         as_api_parser(
             api,
-            as_parameters_schema_list(JobSchema, operation="load", location="form"),
+            as_parameters_schema_list(JobBaseSchema, operation="load", location="form"),
         )
     )
-    @accepts(form_schema=JobSchema, api=api)
+    @accepts(form_schema=JobBaseSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def post(self) -> Job:
         """Creates a new job via a job submission form with an attached file."""
@@ -117,7 +122,7 @@ class JobIdResource(Resource):
         return cast(Job, job)
 
     @login_required
-    @accepts(schema=JobSchema, api=api)
+    @accepts(schema=JobMutableFieldsSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def put(self, jobId: str) -> Job:
         """Updates a job's status by its unique identifier."""

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -37,7 +37,7 @@ from .schema import (
     JobNewTaskEngineSchema,
     JobSchema,
 )
-from .service import JobService
+from .service import JobNewTaskEngineService, JobService
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
@@ -130,9 +130,7 @@ class JobIdResource(Resource):
         log: BoundLogger = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="jobId", request_type="PUT"
         )  # noqa: F841
-
         parsed_obj = request.parsed_obj  # type: ignore
-
         log.info("Request received", job_id=jobId, status=parsed_obj["status"])
         return cast(
             Job,
@@ -142,10 +140,10 @@ class JobIdResource(Resource):
         )
 
 
-
 @api.route("/newTaskEngine")
 class TaskEngineResource(Resource):
     """Lets you POST to create new jobs using the new declarative task engine."""
+
     @inject
     def __init__(
         self, job_new_task_engine_service: JobNewTaskEngineService, *args, **kwargs
@@ -165,7 +163,6 @@ class TaskEngineResource(Resource):
         )  # noqa: F841
         log.info("Request received")
         parsed_obj = request.parsed_obj  # type: ignore
-
         return self._job_new_task_engine_service.create(
             queue_name=parsed_obj["queue"],
             experiment_name=parsed_obj["experimentName"],
@@ -173,4 +170,5 @@ class TaskEngineResource(Resource):
             global_parameters=parsed_obj.get("globalParameters"),
             timeout=parsed_obj.get("timeout"),
             depends_on=parsed_obj.get("dependsOn"),
+            log=log,
         )

--- a/src/dioptra/restapi/job/controller.py
+++ b/src/dioptra/restapi/job/controller.py
@@ -153,6 +153,7 @@ class TaskEngineResource(Resource):
         super().__init__(*args, **kwargs)
         self._job_new_task_engine_service = job_new_task_engine_service
 
+    @login_required
     @accepts(schema=JobNewTaskEngineSchema, api=api)
     @responds(schema=JobSchema, api=api)
     def post(self) -> Job:

--- a/src/dioptra/restapi/job/errors.py
+++ b/src/dioptra/restapi/job/errors.py
@@ -73,5 +73,6 @@ def register_error_handlers(api: Api) -> None:
     @api.errorhandler(JobStatusIncorrectError)
     def handle_job_status_incorrect_error(error):
         return {
-            "message": "The job status is invalid! Must be one of ['queued', 'started', 'deferred', 'finished', 'failed']"
+            "message": "The job status is invalid! Must be one of"
+            "['queued', 'started', 'deferred', 'finished', 'failed']"
         }, 400

--- a/src/dioptra/restapi/job/errors.py
+++ b/src/dioptra/restapi/job/errors.py
@@ -32,10 +32,6 @@ class JobWorkflowUploadError(Exception):
     """The service for storing the uploaded workfile file is unavailable."""
 
 
-class JobStatusIncorrectError(Exception):
-    """The job status failed validation."""
-
-
 class InvalidExperimentDescriptionError(Exception):
     """The experiment description failed validation."""
 
@@ -69,10 +65,3 @@ def register_error_handlers(api: Api) -> None:
     @api.errorhandler(InvalidExperimentDescriptionError)
     def handle_invalid_experiment_description_error(error):
         return {"message": "The experiment description is invalid!"}, 400
-
-    @api.errorhandler(JobStatusIncorrectError)
-    def handle_job_status_incorrect_error(error):
-        return {
-            "message": "The job status is invalid! Must be one of"
-            "['queued', 'started', 'deferred', 'finished', 'failed']"
-        }, 400

--- a/src/dioptra/restapi/job/errors.py
+++ b/src/dioptra/restapi/job/errors.py
@@ -32,6 +32,10 @@ class JobWorkflowUploadError(Exception):
     """The service for storing the uploaded workfile file is unavailable."""
 
 
+class JobStatusIncorrectError(Exception):
+    """The job status failed validation."""
+
+
 class InvalidExperimentDescriptionError(Exception):
     """The experiment description failed validation."""
 
@@ -65,3 +69,9 @@ def register_error_handlers(api: Api) -> None:
     @api.errorhandler(InvalidExperimentDescriptionError)
     def handle_invalid_experiment_description_error(error):
         return {"message": "The experiment description is invalid!"}, 400
+
+    @api.errorhandler(JobStatusIncorrectError)
+    def handle_job_status_incorrect_error(error):
+        return {
+            "message": "The job status is invalid! Must be one of ['queued', 'started', 'deferred', 'finished', 'failed']"
+        }, 400

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -128,7 +128,7 @@ class JobSchema(Schema):
             description="The current status of the job. The allowed values are: "
             "queued, started, deferred, finished, failed.",
         ),
-        dump_only=True,
+        #dump_only=True,
     )
 
 

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -139,28 +139,24 @@ class JobSchema(JobMutableFieldsSchema, JobBaseSchema):
     """The schema for the data stored in a |Job| object."""
 
 
-class TaskEngineSubmission(Schema):
+class JobNewTaskEngineSchema(Schema):
     queue = fields.String(
         required=True,
         metadata={"description": "The name of an active queue"},
     )
-
     experimentName = fields.String(
         required=True,
         metadata={"description": "The name of a registered experiment."},
     )
-
     experimentDescription = fields.Dict(
         keys=fields.String(),
         required=True,
         metadata={"description": "A declarative experiment description."},
     )
-
     globalParameters = fields.Dict(
         keys=fields.String(),
         metadata={"description": "Global parameters for this task engine job."},
     )
-
     timeout = fields.String(
         metadata={
             "description": "The maximum alloted time for a job before it times"
@@ -168,7 +164,6 @@ class TaskEngineSubmission(Schema):
             " will default to 24 hours.",
         },
     )
-
     dependsOn = fields.String(
         metadata={
             "description": "A job UUID to set as a dependency for this new job."

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -27,6 +27,7 @@ from dioptra.restapi.custom_schema_fields import FileUpload
 
 class JobBaseSchema(Schema):
     """The base schema for the data stored in a |Job| object."""
+
     jobId = fields.String(
         attribute="job_id",
         metadata=dict(description="A UUID that identifies the job."),

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -128,7 +128,7 @@ class JobSchema(Schema):
             description="The current status of the job. The allowed values are: "
             "queued, started, deferred, finished, failed.",
         ),
-        #dump_only=True,
+        # dump_only=True,
     )
 
 

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -25,9 +25,8 @@ from marshmallow import Schema, fields, validate
 from dioptra.restapi.custom_schema_fields import FileUpload
 
 
-class JobSchema(Schema):
-    """The schema for the data stored in a |Job| object."""
-
+class JobBaseSchema(Schema):
+    """The base schema for the data stored in a |Job| object."""
     jobId = fields.String(
         attribute="job_id",
         metadata=dict(description="A UUID that identifies the job."),
@@ -120,6 +119,11 @@ class JobSchema(Schema):
             "the new job will start as soon as computing resources are available.",
         ),
     )
+
+
+class JobMutableFieldsSchema(Schema):
+    """The fields schema for the mutable data in a |Job| object."""
+
     status = fields.String(
         validate=validate.OneOf(
             ["queued", "started", "deferred", "finished", "failed"],
@@ -129,6 +133,10 @@ class JobSchema(Schema):
             "queued, started, deferred, finished, failed.",
         ),
     )
+
+
+class JobSchema(JobMutableFieldsSchema, JobBaseSchema):
+    """The schema for the data stored in a |Job| object."""
 
 
 class TaskEngineSubmission(Schema):

--- a/src/dioptra/restapi/job/schema.py
+++ b/src/dioptra/restapi/job/schema.py
@@ -128,7 +128,6 @@ class JobSchema(Schema):
             description="The current status of the job. The allowed values are: "
             "queued, started, deferred, finished, failed.",
         ),
-        # dump_only=True,
     )
 
 

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -38,7 +38,12 @@ from dioptra.restapi.shared.rq.service import RQService
 from dioptra.restapi.shared.s3.service import S3Service
 from dioptra.task_engine.validation import is_valid
 
-from .errors import InvalidExperimentDescriptionError, JobWorkflowUploadError
+from .errors import (
+    InvalidExperimentDescriptionError,
+    JobWorkflowUploadError,
+    JobDoesNotExistError,
+    JobStatusIncorrectError,
+)
 from .model import Job
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
@@ -53,50 +58,60 @@ class JobService(object):
         experiment_name_service: ExperimentNameService,
         queue_name_service: QueueNameService,
     ) -> None:
+        """Initialize the job service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            rq_service: The RQ service.
+            s3_service: The S3 service.
+            experiment_name_service: The experiment name service.
+            queue_name_service: The queue name service.
+        """
         self._rq_service = rq_service
         self._s3_service = s3_service
         self._experiment_name_service = experiment_name_service
         self._queue_name_service = queue_name_service
 
-    @staticmethod
-    def create(
-        experiment_id: int,
-        queue_id: int,
-        timeout: str,
-        entry_point: str,
-        entry_point_kwargs: str,
-        depends_on: str,
-        **kwargs,
-    ) -> Job:
-        log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
-        job_id = str(uuid.uuid4())
-        timestamp = datetime.datetime.now()
+    def get_all(self, **kwargs) -> List[Job]:
+        """Fetch the list of all jobs.
 
-        return Job(
-            job_id=job_id,
-            experiment_id=experiment_id,
-            queue_id=queue_id,
-            created_on=timestamp,
-            last_modified=timestamp,
-            timeout=timeout,
-            entry_point=entry_point,
-            entry_point_kwargs=entry_point_kwargs,
-            depends_on=depends_on,
-        )
-
-    @staticmethod
-    def get_all(**kwargs) -> List[Job]:
+        Returns:
+            A list of job objects.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
 
         return Job.query.all()  # type: ignore
 
-    @staticmethod
-    def get_by_id(job_id: str, **kwargs) -> Job:
+    def get(
+        self, job_id: str, error_if_not_found: bool = False, **kwargs
+    ) -> Job | None:
+        """Fetch a job by its unique identifier.
+
+        Args:
+            job_id: The unique identifier of the job.
+            error_if_not_found: If True, raise an error if the job is not found.
+                Defaults to False.
+
+        Returns:
+            The job object if found, otherwise None.
+
+        Raises:
+            JobDoesNotExistError: If the job is not found and `error_if_not_found` is True.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
 
-        return Job.query.get(job_id)  # type: ignore
+        job = Job.query.filter_by(job_id=job_id).first()
 
-    def submit(
+        if job is None:
+            if error_if_not_found:
+                log.error("Job not found", job_id=job_id)
+                raise JobDoesNotExistError
+            return None
+
+        return cast(Job, job)
+
+    def create(
         self,
         queue_name: str,
         experiment_name: str,
@@ -107,10 +122,29 @@ class JobService(object):
         workflow: FileStorage,
         **kwargs,
     ) -> Job:
+        """Create a new job.
+
+        Args:
+            queue_name: The name of the queue to which the job belongs.
+            experiment_name: The name of the experiment associated with the job.
+            timeout: The maximum execution time for the job.
+            entry_point: The entry point for the job.
+            entry_point_kwargs: The keyword arguments for the entry point.
+            depends_on: A comma-separated string of job dependencies.
+            workflow: The workflow file to be associated with the job.
+
+        Returns:
+            The newly created job object.
+
+        Raises:
+            ExperimentDoesNotExistError: If experiment is not found.
+            QueueDoesNotExistError: If the queue is not found.
+            JobWorkflowUploadError: If there is an error uploading the workflow to the backend storage.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        experiment: Optional[Experiment] = self._experiment_name_service.get(
-            experiment_name=experiment_name, log=log
+        experiment: Experiment | None = self._experiment_name_service.get(
+            experiment_name=experiment_name, error_if_not_found=True, log=log
         )
 
         if experiment is None:
@@ -135,14 +169,19 @@ class JobService(object):
             )
             raise JobWorkflowUploadError
 
-        new_job: Job = self.create(
-            queue_id=queue.queue_id,
+        job_id = str(uuid.uuid4())
+        timestamp = datetime.datetime.now()
+
+        new_job = Job(
+            job_id=job_id,
             experiment_id=experiment.experiment_id,
+            queue_id=queue.queue_id,
+            created_on=timestamp,
+            last_modified=timestamp,
             timeout=timeout,
             entry_point=entry_point,
             entry_point_kwargs=entry_point_kwargs,
             depends_on=depends_on,
-            log=log,
         )
 
         new_job.workflow_uri = workflow_uri
@@ -166,20 +205,66 @@ class JobService(object):
 
         return new_job
 
+    def change_status(self, job_id: str, status: str, **kwargs) -> Job:
+        """Change the status of a job.
+
+        Args:
+            job_id: The unique identifier of the job.
+            status: The new status for the job. Must be one of ["queued", "started", "deferred", "finished", "failed"].
+
+        Returns:
+            The updated job object.
+
+        Raises:
+            JobStatusIncorrectError: If the provided status is not valid.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        job = self.get(job_id=job_id, error_if_not_found=True)
+
+        if status not in ["queued", "started", "deferred", "finished", "failed"]:
+            raise JobStatusIncorrectError
+
+        job.update({"status": status})
+
+        db.session.commit()
+
+        log.info("Job update successful", job_id=job.job_id, status=status)
+
+        return job
+
     def submit_task_engine(
         self,
         queue_name: str,
         experiment_name: str,
         experiment_description: Mapping[str, Any],
-        global_parameters: Optional[Mapping[str, Any]] = None,
-        timeout: Optional[str] = None,
-        depends_on: Optional[str] = None,
+        global_parameters: Mapping[str, Any] | None = None,
+        timeout: str | None = None,
+        depends_on: str | None = None,
     ) -> Job:
+        """Submit a task engine job.
+
+        Args:
+            queue_name: The name of the queue to which the job belongs.
+            experiment_name: The name of the experiment associated with the job.
+            experiment_description: A mapping representing the experiment description.
+            global_parameters: A mapping of global parameters for the job. Defaults to None.
+            timeout: The maximum execution time for the job. Defaults to None.
+            depends_on: A comma-separated string of job dependencies. Defaults to None.
+
+        Returns:
+            The newly created job object.
+
+        Raises:
+            ExperimentDoesNotExistError: If experiment is not found.
+            QueueDoesNotExistError: If queue is not found.
+            InvalidExperimentDescriptionError: If the experiment description is invalid.
+        """
         from dioptra.restapi.models import Experiment, Queue
 
         log: BoundLogger = LOGGER.new()
 
-        experiment: Optional[Experiment] = self._experiment_name_service.get(
+        experiment = self._experiment_name_service.get(
             experiment_name=experiment_name, log=log
         )
 
@@ -229,13 +314,13 @@ class JobService(object):
 
         return new_job
 
-    def _upload_workflow(self, workflow: FileStorage, **kwargs) -> Optional[str]:
+    def _upload_workflow(self, workflow: FileStorage, **kwargs) -> str | None:
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
         upload_dir = Path(uuid.uuid4().hex)
         workflow_filename = upload_dir / secure_filename(workflow.filename or "")
 
-        workflow_uri: Optional[str] = self._s3_service.upload(
+        workflow_uri = self._s3_service.upload(
             fileobj=workflow,
             bucket="workflow",
             key=str(workflow_filename),

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -40,9 +40,9 @@ from dioptra.task_engine.validation import is_valid
 
 from .errors import (
     InvalidExperimentDescriptionError,
-    JobWorkflowUploadError,
     JobDoesNotExistError,
     JobStatusIncorrectError,
+    JobWorkflowUploadError,
 )
 from .model import Job
 
@@ -97,7 +97,8 @@ class JobService(object):
             The job object if found, otherwise None.
 
         Raises:
-            JobDoesNotExistError: If the job is not found and `error_if_not_found` is True.
+            JobDoesNotExistError: If the job is not found and `error_if_not_found`
+                is True.
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())  # noqa: F841
 
@@ -139,7 +140,8 @@ class JobService(object):
         Raises:
             ExperimentDoesNotExistError: If experiment is not found.
             QueueDoesNotExistError: If the queue is not found.
-            JobWorkflowUploadError: If there is an error uploading the workflow to the backend storage.
+            JobWorkflowUploadError: If there is an error uploading the workflow to
+                the backend storage.
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
@@ -160,7 +162,7 @@ class JobService(object):
             ),
         )
 
-        workflow_uri: Optional[str] = self._upload_workflow(workflow=workflow, log=log)
+        workflow_uri= self._upload_workflow(workflow=workflow, log=log)
 
         if workflow_uri is None:
             log.error(
@@ -205,12 +207,13 @@ class JobService(object):
 
         return new_job
 
-    def change_status(self, job_id: str, status: str, **kwargs) -> Job:
+    def change_status(self, job_id: str, status: str, **kwargs) -> Job | None:
         """Change the status of a job.
 
         Args:
             job_id: The unique identifier of the job.
-            status: The new status for the job. Must be one of ["queued", "started", "deferred", "finished", "failed"].
+            status: The new status for the job. Must be one of ["queued",
+                "started", "deferred", "finished", "failed"].
 
         Returns:
             The updated job object.
@@ -220,7 +223,7 @@ class JobService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        job = self.get(job_id=job_id, error_if_not_found=True)
+        job = cast (Job, self.get(job_id=job_id, error_if_not_found=True, log=log) )
 
         if status not in ["queued", "started", "deferred", "finished", "failed"]:
             raise JobStatusIncorrectError
@@ -248,7 +251,8 @@ class JobService(object):
             queue_name: The name of the queue to which the job belongs.
             experiment_name: The name of the experiment associated with the job.
             experiment_description: A mapping representing the experiment description.
-            global_parameters: A mapping of global parameters for the job. Defaults to None.
+            global_parameters: A mapping of global parameters for the job. Defaults to
+                None.
             timeout: The maximum execution time for the job. Defaults to None.
             depends_on: A comma-separated string of job dependencies. Defaults to None.
 
@@ -260,7 +264,7 @@ class JobService(object):
             QueueDoesNotExistError: If queue is not found.
             InvalidExperimentDescriptionError: If the experiment description is invalid.
         """
-        from dioptra.restapi.models import Experiment, Queue
+        from dioptra.restapi.models import Queue
 
         log: BoundLogger = LOGGER.new()
 

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -144,8 +144,11 @@ class JobService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        experiment = self._experiment_name_service.get(
-            experiment_name=experiment_name, error_if_not_found=True, log=log
+        experiment = cast(
+            Experiment,
+            self._experiment_name_service.get(
+                experiment_name=experiment_name, error_if_not_found=True, log=log
+            )
         )
 
         if experiment is None:

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -21,7 +21,7 @@ import datetime
 import json
 import uuid
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, cast
+from typing import Any, List, Mapping, cast
 
 import structlog
 from injector import inject
@@ -162,7 +162,7 @@ class JobService(object):
             ),
         )
 
-        workflow_uri= self._upload_workflow(workflow=workflow, log=log)
+        workflow_uri = self._upload_workflow(workflow=workflow, log=log)
 
         if workflow_uri is None:
             log.error(
@@ -223,7 +223,7 @@ class JobService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        job = cast (Job, self.get(job_id=job_id, error_if_not_found=True, log=log) )
+        job = cast(Job, self.get(job_id=job_id, error_if_not_found=True, log=log))
 
         if status not in ["queued", "started", "deferred", "finished", "failed"]:
             raise JobStatusIncorrectError

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -145,7 +145,7 @@ class JobService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        experiment: Experiment | None = self._experiment_name_service.get(
+        experiment = self._experiment_name_service.get(
             experiment_name=experiment_name, error_if_not_found=True, log=log
         )
 

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -32,7 +32,7 @@ from werkzeug.utils import secure_filename
 from dioptra.restapi.db import db
 from dioptra.restapi.experiment.errors import ExperimentDoesNotExistError
 from dioptra.restapi.experiment.service import ExperimentNameService
-from dioptra.restapi.models import Experiment, Queue
+from dioptra.restapi.models import Queue
 from dioptra.restapi.queue.service import QueueNameService
 from dioptra.restapi.shared.rq.service import RQService
 from dioptra.restapi.shared.s3.service import S3Service

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -41,7 +41,6 @@ from dioptra.task_engine.validation import is_valid
 from .errors import (
     InvalidExperimentDescriptionError,
     JobDoesNotExistError,
-    JobStatusIncorrectError,
     JobWorkflowUploadError,
 )
 from .model import Job
@@ -222,18 +221,10 @@ class JobService(object):
             JobStatusIncorrectError: If the provided status is not valid.
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
-
         job = cast(Job, self.get(job_id=job_id, error_if_not_found=True, log=log))
-
-        if status not in ["queued", "started", "deferred", "finished", "failed"]:
-            raise JobStatusIncorrectError
-
         job.update({"status": status})
-
         db.session.commit()
-
         log.info("Job update successful", job_id=job.job_id, status=status)
-
         return job
 
     def submit_task_engine(

--- a/src/dioptra/restapi/job/service.py
+++ b/src/dioptra/restapi/job/service.py
@@ -21,7 +21,7 @@ import datetime
 import json
 import uuid
 from pathlib import Path
-from typing import Any, List, Mapping, cast
+from typing import Any, Mapping, cast
 
 import structlog
 from injector import inject
@@ -72,7 +72,7 @@ class JobService(object):
         self._experiment_name_service = experiment_name_service
         self._queue_name_service = queue_name_service
 
-    def get_all(self, **kwargs) -> List[Job]:
+    def get_all(self, **kwargs) -> list[Job]:
         """Fetch the list of all jobs.
 
         Returns:

--- a/tests/unit/restapi/job/test_controller.py
+++ b/tests/unit/restapi/job/test_controller.py
@@ -115,7 +115,7 @@ def test_job_resource_post(
     def mockuuid4() -> uuid.UUID:
         return uuid.UUID("3db40500-01b1-45a4-ae18-64e7d1bc7e9a")
 
-    def mocksubmit(*args, **kwargs) -> Job:
+    def mockcreate(*args, **kwargs) -> Job:
         LOGGER.info("Mocking JobService.submit()")
         timestamp = datetime.datetime.now()
         return Job(
@@ -141,7 +141,7 @@ def test_job_resource_post(
         )
         return S3Service.as_uri(bucket=bucket, key=key)
 
-    monkeypatch.setattr(JobService, "submit", mocksubmit)
+    monkeypatch.setattr(JobService, "create", mockcreate)
     monkeypatch.setattr(uuid, "uuid4", mockuuid4)
     monkeypatch.setattr(S3Service, "upload", mockupload)
 
@@ -181,7 +181,7 @@ def test_job_id_resource_get(
     app: Flask,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    def mockgetbyid(self, job_id: str, *args, **kwargs) -> Job:
+    def mockget(self, job_id: str, *args, **kwargs) -> Job:
         LOGGER.info("Mocking JobService.get_by_id()")
         job: Job = Job(
             job_id=job_id,
@@ -198,7 +198,7 @@ def test_job_id_resource_get(
         )
         return job
 
-    monkeypatch.setattr(JobService, "get_by_id", mockgetbyid)
+    monkeypatch.setattr(JobService, "get", mockget)
     job_id: str = "4520511d-678b-4966-953e-af2d0edcea32"
 
     with app.test_client() as client:

--- a/tests/unit/restapi/job/test_service.py
+++ b/tests/unit/restapi/job/test_service.py
@@ -105,15 +105,15 @@ def job_service(dependency_injector) -> JobService:
     return dependency_injector.get(JobService)
 
 
-def test_create(job_service: JobService, job_create_data: dict[str, Any]):
-    job: Job = job_service.create(**job_create_data)
+# def test_create(job_service: JobService, job_create_data: dict[str, Any]):
+#     job: Job = job_service.create(**job_create_data)
 
-    assert job.experiment_id == 1
-    assert job.queue_id == 1
-    assert job.timeout == "12h"
-    assert job.entry_point == "main"
-    assert job.entry_point_kwargs == "-P var1=testing"
-    assert job.depends_on is None
+#     assert job.experiment_id == 1
+#     assert job.queue_id == 1
+#     assert job.timeout == "12h"
+#     assert job.entry_point == "main"
+#     assert job.entry_point_kwargs == "-P var1=testing"
+#     assert job.depends_on is None
 
 
 @freeze_time("2020-08-17T18:46:28.717559")
@@ -182,7 +182,7 @@ def test_submit(
     monkeypatch.setattr(RQService, "submit_mlflow_job", mocksubmit)
     monkeypatch.setattr(S3Service, "upload", mockupload)
 
-    job_service.submit(**job_submission_data)
+    job_service.create(**job_submission_data)
     results: List[Job] = Job.query.all()
 
     assert len(results) == 1

--- a/tests/unit/restapi/job/test_service.py
+++ b/tests/unit/restapi/job/test_service.py
@@ -89,31 +89,8 @@ def job_submission_data(app: Flask, workflow_tar_gz: BinaryIO) -> dict[str, Any]
 
 
 @pytest.fixture
-def job_create_data(app: Flask) -> dict[str, Any]:
-    return {
-        "experiment_id": 1,
-        "queue_id": 1,
-        "timeout": "12h",
-        "entry_point": "main",
-        "entry_point_kwargs": "-P var1=testing",
-        "depends_on": None,
-    }
-
-
-@pytest.fixture
 def job_service(dependency_injector) -> JobService:
     return dependency_injector.get(JobService)
-
-
-# def test_create(job_service: JobService, job_create_data: dict[str, Any]):
-#     job: Job = job_service.create(**job_create_data)
-
-#     assert job.experiment_id == 1
-#     assert job.queue_id == 1
-#     assert job.timeout == "12h"
-#     assert job.entry_point == "main"
-#     assert job.entry_point_kwargs == "-P var1=testing"
-#     assert job.depends_on is None
 
 
 @freeze_time("2020-08-17T18:46:28.717559")

--- a/tests/unit/restapi/test_experiment.py
+++ b/tests/unit/restapi/test_experiment.py
@@ -51,9 +51,7 @@ def register_experiment(client: FlaskClient, name: str) -> TestResponse:
     )
 
 
-def rename_experiment(
-    client: FlaskClient, id: int, new_name: str
-) -> TestResponse:
+def rename_experiment(client: FlaskClient, id: int, new_name: str) -> TestResponse:
     """Rename an experiment using the API.
 
     Args:
@@ -361,9 +359,7 @@ def test_rename_experiment(client: FlaskClient, db: SQLAlchemy) -> None:
     assert_experiment_name_matches_expected_name(
         client, id=experiment_json["experimentId"], expected_name=start_name
     )
-    rename_experiment(
-        client, id=experiment_json["experimentId"], new_name=update_name
-    )
+    rename_experiment(client, id=experiment_json["experimentId"], new_name=update_name)
     assert_experiment_name_matches_expected_name(
         client, id=experiment_json["experimentId"], expected_name=update_name
     )


### PR DESCRIPTION
Refactors the job endpoint to split up functionality of name and id requests. Includes minor changes to the unit tests to reflect those changes.  Resolves #313 

# Changes
- split by name functionality into a sperate service class
- merge submit and create into one function called create
- remove inline type annotations
- add docstrings to service class
- remove and unit tests for deprecated functions