### PR TITLE
Refactor: Move slugify calls to service layer

### DIFF
--- a/src/dioptra/restapi/queue/schema.py
+++ b/src/dioptra/restapi/queue/schema.py
@@ -20,7 +20,11 @@
 """
 from __future__ import annotations
 
-from marshmallow import Schema, fields
+from typing import Any
+
+from marshmallow import Schema, fields, post_load
+
+from dioptra.restapi.utils import slugify
 
 
 class QueueSchema(Schema):
@@ -44,6 +48,11 @@ class QueueSchema(Schema):
     name = fields.String(
         attribute="name", metadata=dict(description="The name of the queue.")
     )
+
+    @post_load
+    def slugify_name(self, data: dict[str, Any], **kwargs) -> dict[str, Any]:
+        data["name"] = slugify(data["name"])
+        return data
 
 
 class IdStatusResponseSchema(Schema):

--- a/src/dioptra/restapi/queue/service.py
+++ b/src/dioptra/restapi/queue/service.py
@@ -267,6 +267,7 @@ class QueueNameService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.info("Get queue by name", queue_name=queue_name)
+
         queue = Queue.query.filter_by(name=queue_name, is_deleted=False).first()
 
         if queue is None:
@@ -292,7 +293,6 @@ class QueueNameService(object):
             A dictionary reporting the status of the request.
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
-
         if (queue := self.get(name, log=log)) is None:
             return {"status": "Success", "name": []}
 

--- a/tests/unit/restapi/test_queue.py
+++ b/tests/unit/restapi/test_queue.py
@@ -29,6 +29,7 @@ from flask_sqlalchemy import SQLAlchemy
 from werkzeug.test import TestResponse
 
 from dioptra.restapi.queue.routes import BASE_ROUTE as QUEUE_BASE_ROUTE
+from dioptra.restapi.utils import slugify
 
 # -- Actions ---------------------------------------------------------------------------
 
@@ -360,6 +361,25 @@ def test_queue_registration(client: FlaskClient, db: SQLAlchemy) -> None:
         client, queue_name=queue2_expected["name"], expected=queue2_expected
     )
     assert_retrieving_all_queues_works(client, expected=queue_expected_list)
+
+
+def test_queue_name_is_slugified(
+    client: FlaskClient, db: SQLAlchemy
+) -> None:
+    """Test that registering a queue name with spaces/uppercase letters is slugified.
+
+    This test validates the following sequence of actions:
+
+    - A user registers a queue named "TensorFlow CPU".
+    - The user is able to retrieve information about the queue and confirms it now has
+      a slugified name.
+    """
+    queue_name = "TensorFlow CPU"
+    response = register_queue(client, name=queue_name)
+    queue_id = response.get_json()["queueId"]
+    assert_queue_name_matches_expected_name(
+        client, queue_id=queue_id, expected_name=slugify(queue_name)
+    )
 
 
 def test_cannot_register_existing_queue_name(


### PR DESCRIPTION
There were a few stray places in the controller layer in the queue endpoint that had calls to slugify instead of being in the service layer. In addition some methods in the service layer like queue locks were not slugifying their name reference. This PR cleans that up, and slugifyies every name reference in the service layer. 