### PR TITLE
Disable GPU image builds in GitHub Actions

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -43,9 +43,9 @@ jobs:
           - mlflow-tracking
           - restapi
           - pytorch-cpu
-          - pytorch-gpu
+#         - pytorch-gpu
           - tensorflow2-cpu
-          - tensorflow2-gpu
+#         - tensorflow2-gpu
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The amount of storage space provided in the GitHub Action runners has been reduced by about 10G. As a result, the GPU Docker image builds are no longer viable on GitHub Actions and so they need to be disabled.