### PR TITLE
refactor: move imports to body of generate_base_resource_schema to avoid circular imports

### DIFF
--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 from marshmallow import Schema, fields
 
-from dioptra.restapi.v1.groups.schema import GroupRefSchema
-from dioptra.restapi.v1.tags.schema import TagRefSchema
-from dioptra.restapi.v1.users.schema import UserRefSchema
+
 
 
 def generate_base_resource_schema(name: str) -> type[Schema]:
     """Generates the base schema for a Resource."""
+    from dioptra.restapi.v1.groups.schema import GroupRefSchema
+    from dioptra.restapi.v1.tags.schema import TagRefSchema
+    from dioptra.restapi.v1.users.schema import UserRefSchema
 
     return Schema.from_dict(
         {

--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 from marshmallow import Schema, fields
 
 
-
-
 def generate_base_resource_schema(name: str) -> type[Schema]:
     """Generates the base schema for a Resource."""
     from dioptra.restapi.v1.groups.schema import GroupRefSchema


### PR DESCRIPTION
The body of `generate_base_resource_schema` now imports reference schemas in the body of the function. All schemas will typically import from the base schema, and the base schema imports some reference schemas. This can result in a circular import if done at the top of the file. Moving to the body of the relevant function resolves this issue.