### PR TITLE
feat: implement v1 schemas for models

### DIFF
--- a/src/dioptra/restapi/routes.py
+++ b/src/dioptra/restapi/routes.py
@@ -38,6 +38,7 @@ V1_ENTRYPOINTS_ROUTE = "entrypoints"
 V1_EXPERIMENTS_ROUTE = "experiments"
 V1_GROUPS_ROUTE = "groups"
 V1_JOBS_ROUTE = "jobs"
+V1_MODELS_ROUTE = "models"
 V1_PLUGIN_PARAMETER_TYPES_ROUTE = "pluginParameterTypes"
 V1_PLUGINS_ROUTE = "plugins"
 V1_QUEUES_ROUTE = "queues"
@@ -87,6 +88,7 @@ def register_v1_routes(api: Api) -> None:
     from .v1.experiments.controller import api as experiments_api
     from .v1.groups.controller import api as groups_api
     from .v1.jobs.controller import api as jobs_api
+    from .v1.models.controller import api as models_api
     from .v1.plugin_parameter_types.controller import api as plugin_parameter_types_api
     from .v1.plugins.controller import api as plugins_api
     from .v1.queues.controller import api as queues_api
@@ -98,6 +100,7 @@ def register_v1_routes(api: Api) -> None:
     api.add_namespace(experiments_api, path=f"/{V1_ROOT}/{V1_EXPERIMENTS_ROUTE}")
     api.add_namespace(groups_api, path=f"/{V1_ROOT}/{V1_GROUPS_ROUTE}")
     api.add_namespace(jobs_api, path=f"/{V1_ROOT}/{V1_JOBS_ROUTE}")
+    api.add_namespace(models_api, path=f"/{V1_ROOT}/{V1_MODELS_ROUTE}")
     api.add_namespace(
         plugin_parameter_types_api, path=f"/{V1_ROOT}/{V1_PLUGIN_PARAMETER_TYPES_ROUTE}"
     )

--- a/src/dioptra/restapi/v1/models/__init__.py
+++ b/src/dioptra/restapi/v1/models/__init__.py
@@ -1,0 +1,16 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode

--- a/src/dioptra/restapi/v1/models/controller.py
+++ b/src/dioptra/restapi/v1/models/controller.py
@@ -1,0 +1,98 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The module defining the endpoints for Model resources."""
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from flask import request
+from flask_accepts import accepts, responds
+from flask_login import login_required
+from flask_restx import Namespace, Resource
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.v1.schemas import IdStatusResponseSchema
+
+from .schema import (
+    ModelGetQueryParameters,
+    ModelMutableFieldsSchema,
+    ModelPageSchema,
+    ModelSchema,
+)
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+api: Namespace = Namespace("Models", description="Models endpoint")
+
+
+@api.route("/")
+class ModelEndpoint(Resource):
+    @login_required
+    @accepts(query_params_schema=ModelGetQueryParameters, api=api)
+    @responds(schema=ModelPageSchema, api=api)
+    def get(self):
+        """Gets a list of all Model resources."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Model", request_type="GET"
+        )
+        log.debug("Request received")
+        parsed_query_params = request.parsed_query_params  # noqa: F841
+
+    @login_required
+    @accepts(schema=ModelSchema, api=api)
+    @responds(schema=ModelSchema, api=api)
+    def post(self):
+        """Creates a Model resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Model", request_type="POST"
+        )
+        log.debug("Request received")
+        parsed_obj = request.parsed_obj  # noqa: F841
+
+
+@api.route("/<int:id>")
+@api.param("id", "ID for the Model resource.")
+class ModelIdEndpoint(Resource):
+    @login_required
+    @responds(schema=ModelSchema, api=api)
+    def get(self, id: int):
+        """Gets a Model resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Model", request_type="GET", id=id
+        )
+        log.debug("Request received")
+
+    @login_required
+    @responds(schema=IdStatusResponseSchema, api=api)
+    def delete(self, id: int):
+        """Deletes a Model resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Model", request_type="DELETE", id=id
+        )
+        log.debug("Request received")
+
+    @login_required
+    @accepts(schema=ModelMutableFieldsSchema, api=api)
+    @responds(schema=ModelSchema, api=api)
+    def put(self, id: int):
+        """Modifies a Model resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Model", request_type="PUT", id=id
+        )
+        log.debug("Request received")
+        parsed_obj = request.parsed_obj  # type: ignore # noqa: F841

--- a/src/dioptra/restapi/v1/models/schema.py
+++ b/src/dioptra/restapi/v1/models/schema.py
@@ -1,0 +1,79 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The schemas for serializing/deserializing Model resources."""
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+from dioptra.restapi.v1.artifacts.schema import ArtifactRefSchema
+from dioptra.restapi.v1.schemas import (
+    BasePageSchema,
+    PagingQueryParametersSchema,
+    SearchQueryParametersSchema,
+    generate_base_resource_schema,
+)
+
+
+class ModelMutableFieldsSchema(Schema):
+    """The fields schema for the mutable data in a Model resource."""
+
+    name = fields.String(
+        attribute="name",
+        metadata=dict(description="Name of the Model resource."),
+    )
+    artifactId = fields.Integer(
+        attribute="artifact_id",
+        data_key="artifact",
+        metadata=dict(description="The artifact representing the Model."),
+        load_only=True,
+    )
+
+
+ModelBaseSchema = generate_base_resource_schema("Model", snapshot=True)
+
+
+class ModelSchema(ModelMutableFieldsSchema, ModelBaseSchema):  # type: ignore
+    """The schema for the data stored in a Model resource."""
+
+    artifact = fields.Nested(
+        ArtifactRefSchema,
+        attribute="artifact",
+        metadata=dict(description="The artifact representing the Model."),
+        dump_only=True,
+    )
+    versionNumber = fields.Integer(
+        attribute="version_number",
+        metadata=dict(description="The version number of the Model."),
+        dump_only=True,
+    )
+
+
+class ModelPageSchema(BasePageSchema):
+    """The paged schema for the data stored in a Model resource."""
+
+    data = fields.Nested(
+        ModelSchema,
+        many=True,
+        metadata=dict(description="List of Model resources in the current page."),
+    )
+
+
+class ModelGetQueryParameters(
+    PagingQueryParametersSchema,
+    SearchQueryParametersSchema,
+):
+    """The query parameters for the GET method of the /models endpoint."""


### PR DESCRIPTION
This is blocked until #410 is merged. Also include model schemas and endpoints for version endpoints that are not in the original API map. 