### PR TITLE
feat: add pytest flag to run v1 REST API tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-v1", action="store_true", default=False, help="run v1 tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "v1: mark test as v1")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-v1"):
+        # --run-v1 given in cli: do not skip v1 tests
+        return
+    skip_v1 = pytest.mark.skip(reason="need --run-v1 option to run")
+    for item in items:
+        if "v1" in item.keywords:
+            item.add_marker(skip_v1)


### PR DESCRIPTION
This feature adds a `--run-v1` flag to pytest in `tests/conftest.py` to enable running of v1 API tests. To mark a test as v1, annotate the test function with `@pytest.mark.v1`.

We intend to use this feature during the development of v1 of the API. Tests are expected to fail while the service layer is not implemented so they should be excluded by default.

v1 tests should be placed in the `restapi/v1` directory.

To run only v1 tests use the command below:
```
python -m tox run -e py39-pytest -- tests/unit/restapi/v1 --run-v1
```