### PR TITLE
feat: add schema and controller stubs for Authentication endpoint

### DIFF
--- a/src/dioptra/restapi/routes.py
+++ b/src/dioptra/restapi/routes.py
@@ -33,6 +33,7 @@ TASK_PLUGIN_ROUTE = "taskPlugin"
 USER_ROUTE = "user"
 
 V1_ARTIFACTS_ROUTE = "artifacts"
+V1_AUTH_ROUTE = "auth"
 V1_ENTRYPOINTS_ROUTE = "entrypoints"
 V1_EXPERIMENTS_ROUTE = "experiments"
 V1_JOBS_ROUTE = "jobs"
@@ -81,6 +82,7 @@ def register_v1_routes(api: Api) -> None:
         api: The main REST |Api| object.
     """
     from .v1.artifacts.controller import api as artifacts_api
+    from .v1.auth.controller import api as auth_api
     from .v1.entrypoints.controller import api as entrypoints_api
     from .v1.experiments.controller import api as experiments_api
     from .v1.jobs.controller import api as jobs_api
@@ -90,6 +92,7 @@ def register_v1_routes(api: Api) -> None:
     from .v1.queues.controller import api as queues_api
     from .v1.tags.controller import api as tags_api
 
+    api.add_namespace(auth_api, path=f"/{V1_ROOT}/{V1_AUTH_ROUTE}")
     api.add_namespace(artifacts_api, path=f"/{V1_ROOT}/{V1_ARTIFACTS_ROUTE}")
     api.add_namespace(entrypoints_api, path=f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}")
     api.add_namespace(experiments_api, path=f"/{V1_ROOT}/{V1_EXPERIMENTS_ROUTE}")

--- a/src/dioptra/restapi/v1/auth/__init__.py
+++ b/src/dioptra/restapi/v1/auth/__init__.py
@@ -1,0 +1,17 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The auth endpoint subpackage."""

--- a/src/dioptra/restapi/v1/auth/controller.py
+++ b/src/dioptra/restapi/v1/auth/controller.py
@@ -1,0 +1,75 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The module defining the auth endpoints."""
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from flask import request
+from flask_accepts import accepts, responds
+from flask_login import login_required
+from flask_restx import Namespace, Resource
+from structlog.stdlib import BoundLogger
+
+from .schema import LoginSchema, LogoutSchema
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+api: Namespace = Namespace(
+    "Authentication",
+    description="Authentication endpoint",
+)
+
+
+@api.route("/login")
+class LoginResource(Resource):
+    """Methods for the /auth/login endpoint."""
+
+    @accepts(schema=LoginSchema, api=api)
+    @responds(schema=LoginSchema, api=api)
+    def post(self):
+        """Login to a registered user account."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="auth/login", request_type="POST"
+        )
+        log.debug("Request received")
+        parsed_query_params = request.parsed_query_params  # noqa: F841
+        # username = str(parsed_obj["username"])
+        # password = str(parsed_obj["password"])
+        # return self._auth_service.login(username=username, password=password, log=log)
+
+
+@api.route("/logout")
+class LogoutResource(Resource):
+    """Methods for the /auth/logout endpoint."""
+
+    @login_required
+    @accepts(query_params_schema=LogoutSchema, api=api)
+    @responds(schema=LogoutSchema, api=api)
+    def post(self):
+        """Logout the current user.
+
+        Must be logged in.
+        """
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="auth/logout", request_type="POST"
+        )
+        log.debug("Request received")
+        parsed_query_params = request.parsed_query_params  # noqa: F841
+        # everywhere = bool(parsed_query_params["everywhere"])
+        # return self._auth_service.logout(everywhere=everywhere, log=log)

--- a/src/dioptra/restapi/v1/auth/schema.py
+++ b/src/dioptra/restapi/v1/auth/schema.py
@@ -1,0 +1,59 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The schemas for serializing/deserializing the auth endpoint objects."""
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+
+class LoginSchema(Schema):
+    """The request and response fields used when logging into an account."""
+
+    username = fields.String(
+        attribute="username",
+        metadata=dict(description="The account username."),
+    )
+    password = fields.String(
+        attribute="password",
+        metadata=dict(description="The account password."),
+        load_only=True,
+    )
+    status = fields.String(
+        attribute="status",
+        metadata=dict(description="The status of the login request."),
+        dump_only=True,
+    )
+
+
+class LogoutSchema(Schema):
+    """The request and response fields used when logging out of an account."""
+
+    username = fields.String(
+        attribute="username",
+        metadata=dict(description="The account username."),
+        dump_only=True,
+    )
+    everywhere = fields.Bool(
+        attribute="everywhere",
+        metadata=dict(description="Logout on all devices."),
+        load_default=lambda: False,
+    )
+    status = fields.String(
+        attribute="status",
+        metadata=dict(description="The status of the logout request."),
+        dump_only=True,
+    )


### PR DESCRIPTION
This feature adds the request and response marshmallow schemas for the `/auth` resource. It also includes stub functions for the controller layer that defines the `/auth` endpoints as well as register these routes in the v1 API namespace.