### PR TITLE
feat: add batch permissions changes to groups

### DIFF
--- a/src/dioptra/restapi/v1/groups/controller.py
+++ b/src/dioptra/restapi/v1/groups/controller.py
@@ -129,6 +129,20 @@ class GroupIdMembersEndpoint(Resource):
         log.debug("Request received")
         parsed_obj = request.parsed_obj  # type: ignore # noqa: F841
 
+    @login_required
+    @accepts(schema=GroupMemberSchema(many=True), api=api)
+    @responds(schema=GroupMemberSchema(many=True), api=api)
+    def put(self, id: int):
+        """Modifies all Group Members' permisssions."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="GroupMember",
+            request_type="POST",
+            id=id,
+        )
+        log.debug("Request received")
+        parsed_obj = request.parsed_obj  # type: ignore # noqa: F841
+
 
 @api.route("/<int:id>/members/<int:user_id>")
 @api.param("id", "ID for the Group resource.")

--- a/src/dioptra/restapi/v1/groups/schema.py
+++ b/src/dioptra/restapi/v1/groups/schema.py
@@ -26,6 +26,7 @@ from dioptra.restapi.v1.schemas import (
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
 )
+from dioptra.restapi.v1.users.schema import UserRefSchema
 
 
 class GroupRefSchema(Schema):
@@ -104,20 +105,17 @@ GroupMemberCreateFieldsSchema = generate_group_permissions_schema(
     is_response=False, use_defaults=True
 )
 
-
 GroupMemberMutableFieldsSchema = generate_group_permissions_schema(
     is_response=False, use_defaults=False
+)
+
+GroupPermissionsResponseSchema = generate_group_permissions_schema(
+    is_response=True, use_defaults=False
 )
 
 
 class GroupMemberBaseSchema(Schema):
     """The base schema of a Group Member."""
-
-    from dioptra.restapi.v1.users.schema import UserRefSchema
-
-    GroupPermissionsResponseSchema = generate_group_permissions_schema(
-        is_response=True, use_defaults=False
-    )
 
     userId = fields.Integer(
         attribute="user_id",
@@ -178,8 +176,8 @@ class GroupSchema(GroupMutableFieldsSchema):
     members = fields.Nested(
         GroupMemberSchema,
         attribute="members",
-        metadata=dict(description="A list of GroupMembers in a Group."),
         many=True,
+        metadata=dict(description="A list of GroupMembers in a Group."),
         dump_only=True,
     )
     createdOn = fields.DateTime(


### PR DESCRIPTION
This feature adds an endpoint for updating all user permissions for a group to the v1 REST API. This is implemented via a PUT to `/groups/{id}/members`. It includes the necessary changes to the groups schema and controller layer.

This commit also includes some minor changes to the group's schema that do not change functionality. This includes moving an import nested inside of a class and a nested class definition to the top level.