### PR TITLE
[WIP] feat: proof-of-concept for re-using controller layer Endpoints

### DIFF
--- a/src/dioptra/restapi/v1/entrypoints/controller.py
+++ b/src/dioptra/restapi/v1/entrypoints/controller.py
@@ -27,6 +27,7 @@ from flask_restx import Namespace, Resource
 from structlog.stdlib import BoundLogger
 
 from dioptra.restapi.v1.schemas import IdStatusResponseSchema
+from dioptra.restapi.v1.tags.controller import ResourceTagEndpoint
 
 from .schema import (
     EntrypointGetQueryParameters,
@@ -38,6 +39,17 @@ from .schema import (
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
 api: Namespace = Namespace("Entrypoints", description="Entrypoints endpoint")
+
+
+@api.route("/<int:id>/tags")
+class EntrypointTagsEndpoint(ResourceTagEndpoint):
+    """Tagging functionality"""
+
+    # @inject
+    # def __init__(self, *args, entrypoint_service: QueueService, **kwargs) -> None:
+    # self._entrypoint_service = entrypoint_service
+    # self._resource_name = "Entrypoint"
+    # super().__init__(*args, **kwargs)
 
 
 @api.route("/")

--- a/src/dioptra/restapi/v1/queues/controller.py
+++ b/src/dioptra/restapi/v1/queues/controller.py
@@ -27,6 +27,7 @@ from flask_restx import Namespace, Resource
 from structlog.stdlib import BoundLogger
 
 from dioptra.restapi.v1.schemas import IdStatusResponseSchema
+from dioptra.restapi.v1.tags.controller import ResourceTagEndpoint
 
 from .schema import (
     QueueGetQueryParameters,
@@ -38,6 +39,17 @@ from .schema import (
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
 api: Namespace = Namespace("Queues", description="Queues endpoint")
+
+
+@api.route("/<int:id>/tags")
+class QueueTagsEndpoint(ResourceTagEndpoint):
+    """Tagging functionality"""
+
+    # @inject
+    # def __init__(self, *args, queue_service: QueueService, **kwargs) -> None:
+    # self._queue_service = queue_service
+    # self._resource_name = "Queue"
+    # super().__init__(*args, **kwargs)
 
 
 @api.route("/")

--- a/src/dioptra/restapi/v1/tags/controller.py
+++ b/src/dioptra/restapi/v1/tags/controller.py
@@ -41,6 +41,36 @@ LOGGER: BoundLogger = structlog.stdlib.get_logger()
 api: Namespace = Namespace("Tags", description="Tags endpoint")
 
 
+class ResourceTagEndpoint(Resource):
+    """Re-usable endpoint for adding tagging functionality to Resources"""
+
+    @login_required
+    @accepts(query_params_schema=TagGetQueryParameters, api=api)
+    @responds(schema=TagPageSchema, api=api)
+    def get(self, id: int):
+        """Gets a list of all Tags for this resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource=self._resource_name,
+            request_type="GET",
+        )
+        log.info("Request received")
+        # parsed_query_params = request.parsed_query_params  # noqa: F841
+
+    @login_required
+    @accepts(schema=TagSchema, api=api)
+    @responds(schema=TagSchema, api=api)
+    def post(self, id: int):
+        """Appends a Tag to this Resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource=self._resource_name,
+            request_type="POST",
+        )
+        log.debug("Request received")
+        # parsed_obj = request.parsed_obj  # noqa: F841
+
+
 @api.route("/")
 class TagEndpoint(Resource):
     @login_required


### PR DESCRIPTION
This is a proof-of-concept for re-using Endpoints from the controller layer to achieve common functionality across multiple root Endpoints with minimal code re-use.

The use case illustrated in this proof-of-concept is providing tagging functionality via a `/<resource>/{id}/tags` endpoint for all Dioptra Resources in the API. An Endpoint is created in `tags/controller.py` which defines the operations for tagging resource, but it is not given a route. In the other controller layers that wish to use this tagging functionality, a subclass of the Endpoint is created and the `route` decorator is applied.

Some customization can still be achieved via the constructor. For example, we can set a `resource_name` member variable can be set to customize logging messages. The correct Service object for the given resource can be provided here. We might want some kind of base ResourceService class that can handle common service layer operations like tagging.