### PR TITLE
feat: add a logging endpoint, cookie HTTP logging handler

### DIFF
--- a/src/proto/app.py
+++ b/src/proto/app.py
@@ -3,6 +3,7 @@
 This module contains the application factory function and the application's
 configuration parameters.
 """
+
 from __future__ import annotations
 
 import os
@@ -113,7 +114,15 @@ def _register_routes(api: Api, root: str = "api") -> None:
         Registering flask-restx namespaces does the same thing as registering Flask
         blueprints.
     """
-    from .controllers import auth_api, foo_api, hello_api, test_api, user_api, world_api
+    from .controllers import (
+        auth_api,
+        foo_api,
+        hello_api,
+        logging_api,
+        test_api,
+        user_api,
+        world_api,
+    )
 
     api.add_namespace(auth_api, path=f"/{root}/auth")
     api.add_namespace(user_api, path=f"/{root}/user")
@@ -121,6 +130,7 @@ def _register_routes(api: Api, root: str = "api") -> None:
     api.add_namespace(test_api, path=f"/{root}/test")
     api.add_namespace(world_api, path=f"/{root}/world")
     api.add_namespace(foo_api, path=f"/{root}/foo")
+    api.add_namespace(logging_api, path=f"/{root}/logging")
 
 
 def _register_test_users_in_db() -> None:

--- a/src/proto/controllers.py
+++ b/src/proto/controllers.py
@@ -1,9 +1,10 @@
 """The application's REST controllers for the API."""
+
 from __future__ import annotations
 
 from typing import Any, cast
 
-from flask import request
+from flask import current_app, request
 from flask_accepts import accepts
 from flask_login import login_required
 from flask_restx import Namespace, Resource
@@ -43,7 +44,9 @@ foo_api: Namespace = Namespace(
     "Foo",
     description="Foo endpoint",
 )
-
+logging_api: Namespace = Namespace(
+    "Logging", description="Destination for logging information"
+)
 
 # -- Authentication Resources ---------------------------------------------------------
 
@@ -234,3 +237,10 @@ class FooResource(Resource):
         Must be logged in.
         """
         return SERVICES.foo.say_bar()
+
+
+@logging_api.route("/")
+class LoggingResource(Resource):
+    @login_required
+    def post(self):
+        current_app.logger.info(str(request.form))

--- a/src/proto/utils.py
+++ b/src/proto/utils.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging.handlers
+import typing
+import urllib.parse
+import urllib.request
+
+
+if typing.TYPE_CHECKING:
+    import http.cookiejar
+    import logging
+    import ssl
+
+
+class CookieHTTPHandler(logging.handlers.HTTPHandler):
+    """
+    A logging handler which can send cookies with its logging requests.  This
+    can be useful when one needs to maintain an authenticated session.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        url: str,
+        secure: bool = False,
+        cookies: http.cookiejar.CookieJar | None = None,
+        context: ssl.SSLContext | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        """
+        Initialize this logging handler.
+
+        Args:
+            host: The host to send to, as a string; a port may be included
+                using syntax <host>:<port>.
+            url: The path component of a URL to send to
+            secure: If True, connect via HTTPS, else HTTP
+            cookies: A cookie jar to be consulted for all requests
+            context: An SSLContext object to affect secure connection settings.
+                Only makes sense if secure=True.
+            user_agent: A value for a User-Agent header, to deal with
+                flask-login's "strong" session protection.  The header value
+                must be consistent for all requests using a given cookie, or
+                the server will reject it.
+        """
+        # Just pass args through, except null out credentials and fix method
+        # as POST
+        super().__init__(host, url, "POST", secure, None, context)
+
+        self.cookies = cookies
+        self.user_agent = user_agent
+
+        scheme = "https" if secure else "http"
+        self.full_url = urllib.parse.urlunparse((scheme, host, url, None, None, None))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Send the logging record to the web server.
+
+        Args:
+            record: The logging record to send
+        """
+        data = urllib.parse.urlencode(self.mapLogRecord(record))
+
+        headers = {}
+        if self.user_agent:
+            headers["User-Agent"] = self.user_agent
+
+        req = urllib.request.Request(
+            url=self.full_url, data=data.encode("utf-8"), headers=headers
+        )
+
+        if self.cookies:
+            self.cookies.add_cookie_header(req)
+
+        with urllib.request.urlopen(req, context=self.context) as resp:
+            # Discard response content
+            resp.read()


### PR DESCRIPTION
This PR updates the prototype branch to add a protected endpoint for receiving logging data, and a logging handler design which is able to send requests to that endpoint.  See src/proto/utils.py.

The handler has a general design which can send cookies with requests.  That could include session cookies, but is not a requirement.  With respect to the flask prototype though, it must include an authenticated session cookie since the endpoint is protected.  If "strong" session protection is in use, one must also be careful to always use the same User-Agent header value, otherwise flask-login will reject the cookie.  For that reason, the handler accepts a user_agent argument.

With respect to prototype authentication, it is up to the user of the logging handler to establish a login session.  Any cookie(s) from that must be passed to the handler when it is set up (and possibly a correct user agent value too).  The handler itself is agnostic to where the cookies come from.

The implementation uses only standard library APIs.  That makes it simple to incorporate into other codebases (which is not the plan here, but still a nice thing to think about when designing software components).