### PR TITLE
feat: entrypoints service layer

### DIFF
--- a/src/dioptra/restapi/errors.py
+++ b/src/dioptra/restapi/errors.py
@@ -132,6 +132,7 @@ def register_v1_error_handlers(api: Api) -> None:
     register_base_v1_error_handlers(api)
     v1.experiments.errors.register_error_handlers(api)
     v1.groups.errors.register_error_handlers(api)
+    v1.entrypoints.errors.register_error_handlers(api)
     v1.plugins.errors.register_error_handlers(api)
     v1.plugin_parameter_types.errors.register_error_handlers(api)
     v1.queues.errors.register_error_handlers(api)

--- a/src/dioptra/restapi/v1/entrypoints/controller.py
+++ b/src/dioptra/restapi/v1/entrypoints/controller.py
@@ -235,7 +235,7 @@ class EntrypointIdPluginsEndpoint(Resource):
         log = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
         )
-        plugins = self._entrypoint_id_plugins_service.get(id, log=log)["plugins"]
+        plugins = self._entrypoint_id_plugins_service.get(id, log=log)
         return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
 
     @login_required
@@ -249,7 +249,7 @@ class EntrypointIdPluginsEndpoint(Resource):
         parsed_obj = request.parsed_obj  # type: ignore
         plugins = self._entrypoint_id_plugins_service.append(
             id, plugin_ids=parsed_obj["plugin_ids"], log=log
-        )["plugins"]
+        )
         return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
 
 
@@ -281,12 +281,7 @@ class EntrypointIdPluginsIdEndpoint(Resource):
         log = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
         )
-        plugin = cast(
-            utils.PluginWithFilesDict,
-            self._entrypoint_id_plugins_id_service.get(
-                id, plugin_id=pluginId, error_if_not_found=True, log=log
-            ),
-        )
+        plugin = self._entrypoint_id_plugins_id_service.get(id, pluginId, log=log)
         return utils.build_entrypoint_plugin(plugin)
 
     @login_required
@@ -299,10 +294,7 @@ class EntrypointIdPluginsIdEndpoint(Resource):
             request_type="DELETE",
             id=id,
         )
-        plugins = cast(
-            utils.EntrypointDict,
-            self._entrypoint_id_plugins_id_service.delete(id, pluginId, log=log),
-        )["plugins"]
+        plugins = self._entrypoint_id_plugins_id_service.delete(id, pluginId, log=log)
         return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
 
 

--- a/src/dioptra/restapi/v1/entrypoints/controller.py
+++ b/src/dioptra/restapi/v1/entrypoints/controller.py
@@ -18,21 +18,49 @@
 from __future__ import annotations
 
 import uuid
+from typing import cast
 
 import structlog
 from flask import request
 from flask_accepts import accepts, responds
 from flask_login import login_required
 from flask_restx import Namespace, Resource
+from injector import inject
 from structlog.stdlib import BoundLogger
 
+from dioptra.restapi.db import models
+from dioptra.restapi.routes import V1_ENTRYPOINTS_ROUTE
+from dioptra.restapi.v1 import utils
 from dioptra.restapi.v1.schemas import IdStatusResponseSchema
+from dioptra.restapi.v1.shared.drafts.controller import (
+    generate_resource_drafts_endpoint,
+    generate_resource_drafts_id_endpoint,
+    generate_resource_id_draft_endpoint,
+)
+from dioptra.restapi.v1.shared.snapshots.controller import (
+    generate_resource_snapshots_endpoint,
+    generate_resource_snapshots_id_endpoint,
+)
+from dioptra.restapi.v1.shared.tags.controller import (
+    generate_resource_tags_endpoint,
+    generate_resource_tags_id_endpoint,
+)
 
 from .schema import (
     EntrypointGetQueryParameters,
     EntrypointMutableFieldsSchema,
     EntrypointPageSchema,
+    EntrypointPluginMutableFieldsSchema,
+    EntrypointPluginSchema,
     EntrypointSchema,
+)
+from .service import (
+    RESOURCE_TYPE,
+    SEARCHABLE_FIELDS,
+    EntrypointIdPluginsIdService,
+    EntrypointIdPluginsService,
+    EntrypointIdService,
+    EntrypointService,
 )
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
@@ -42,6 +70,18 @@ api: Namespace = Namespace("Entrypoints", description="Entrypoints endpoint")
 
 @api.route("/")
 class EntrypointEndpoint(Resource):
+    @inject
+    def __init__(self, entrypoint_service: EntrypointService, *args, **kwargs) -> None:
+        """Initialize the entrypoint resource.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_service: A EntrypointService object.
+        """
+        self._entrypoint_service = entrypoint_service
+        super().__init__(*args, **kwargs)
+
     @login_required
     @accepts(query_params_schema=EntrypointGetQueryParameters, api=api)
     @responds(schema=EntrypointPageSchema, api=api)
@@ -50,24 +90,31 @@ class EntrypointEndpoint(Resource):
         log = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="GET"
         )
-        log.debug("Request received")
-        """
-        index = request.args.get("index", 0, type=int)
-        page_length = request.args.get("pageLength", 20, type=int)
 
-        data = self._entrypoint_service.get_page(
-            index=index, page_length=page_length, log=log
-        )
+        parsed_query_params = request.parsed_query_params  # noqa: F841
+        group_id = parsed_query_params["group_id"]
+        search_string = parsed_query_params["search"]
+        page_index = parsed_query_params["index"]
+        page_length = parsed_query_params["page_length"]
 
-        is_complete = True if Entrypoint.query.count() <= index + page_length else False
-
-        return Page(
-            data=data,
-            index=index,
-            is_complete=is_complete,
-            endpoint="v1/entrypoint",
+        entrypoints, total_num_entrypoints = self._entrypoint_service.get(
+            group_id=group_id,
+            search_string=search_string,
+            page_index=page_index,
             page_length=page_length,
-        )"""
+            log=log,
+        )
+        return utils.build_paging_envelope(
+            "entrypoints",
+            build_fn=utils.build_entrypoint,
+            data=entrypoints,
+            group_id=group_id,
+            draft_type=None,
+            query=search_string,
+            index=page_index,
+            length=page_length,
+            total_num_elements=total_num_entrypoints,
+        )
 
     @login_required
     @accepts(schema=EntrypointSchema, api=api)
@@ -77,44 +124,36 @@ class EntrypointEndpoint(Resource):
         log = LOGGER.new(
             request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
         )
-        log.debug("Request received")
         parsed_obj = request.parsed_obj  # noqa: F841
-        # return self._entrypoint_service.create(
-        #    parsed_obj["name"],
-        #    parsed_obj["task_graph"],
-        #    parsed_obj["parameters"],
-        #    log=log,
-        # )
+        entrypoint = self._entrypoint_service.create(
+            name=parsed_obj["name"],
+            description=parsed_obj["description"],
+            task_graph=parsed_obj["task_graph"],
+            parameters=parsed_obj["parameters"],
+            plugin_ids=parsed_obj["plugin_ids"],
+            queue_ids=parsed_obj["queue_ids"],
+            group_id=int(parsed_obj["group_id"]),
+            log=log,
+        )
+        return utils.build_entrypoint(entrypoint)
 
 
 @api.route("/<int:id>")
 @api.param("id", "ID for the Entrypoint resource.")
 class EntrypointIdEndpoint(Resource):
-    @login_required
-    @responds(schema=EntrypointSchema, api=api)
-    def get(self, id: int):
-        """Gets an Entrypoint resource by its unique ID."""
-        log = LOGGER.new(
-            request_id=str(uuid.uuid4()),
-            resource="Entrypoint",
-            request_type="GET",
-            id=id,
-        )
-        log.debug("Request received")
-        # return self._entrypoint_service.get(id, error_if_not_found=True, log=log)
+    @inject
+    def __init__(
+        self, entrypoint_id_service: EntrypointIdService, *args, **kwargs
+    ) -> None:
+        """Initialize the entrypoint resource.
 
-    @login_required
-    @responds(schema=IdStatusResponseSchema, api=api)
-    def delete(self, id: int):
-        """Deletes an Entrypoint resource by its unique ID."""
-        log = LOGGER.new(
-            request_id=str(uuid.uuid4()),
-            resource="Entrypoint",
-            request_type="DELETE",
-            id=id,
-        )
-        log.debug("Request received")
-        # return self._entrypoint_service.delete(id)
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_id_service: A EntrypointIdService object.
+        """
+        self._entrypoint_id_service = entrypoint_id_service
+        super().__init__(*args, **kwargs)
 
     @login_required
     @accepts(schema=EntrypointMutableFieldsSchema, api=api)
@@ -127,11 +166,185 @@ class EntrypointIdEndpoint(Resource):
             request_type="PUT",
             id=id,
         )
-        log.debug("Request received")
         parsed_obj = request.parsed_obj  # type: ignore # noqa: F841
-        # return self._entrypoint_service.edit(
-        #    parsed_obj["name"],
-        #    parsed_obj["task_graph"],
-        #    parsed_obj["parameters"],)
-        #    log=log,
-        # )
+        entrypoint = cast(
+            models.EntryPoint,
+            self._entrypoint_id_service.modify(
+                id,
+                name=parsed_obj["name"],
+                description=parsed_obj["description"],
+                task_graph=parsed_obj["task_graph"],
+                parameters=parsed_obj["parameters"],
+                queue_ids=parsed_obj["queue_ids"],
+                error_if_not_found=True,
+                log=log,
+            ),
+        )
+        return utils.build_entrypoint(entrypoint)
+
+    @login_required
+    @responds(schema=EntrypointSchema, api=api)
+    def get(self, id: int):
+        """Gets an Entrypoint resource by its unique ID."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="Entrypoint",
+            request_type="GET",
+            id=id,
+        )
+        entrypoint = cast(
+            models.EntryPoint,
+            self._entrypoint_id_service.get(id, error_if_not_found=True, log=log),
+        )
+        return utils.build_entrypoint(entrypoint)
+
+    @login_required
+    @responds(schema=IdStatusResponseSchema, api=api)
+    def delete(self, id: int):
+        """Deletes an Entrypoint resource by its unique ID."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="Entrypoint",
+            request_type="DELETE",
+            id=id,
+        )
+        return self._entrypoint_id_service.delete(entrypoint_id=id, log=log)
+
+
+@api.route("/<int:id>/plugins")
+@api.param("id", "ID for the Entrypoint resource.")
+class EntrypointIdPluginsEndpoint(Resource):
+    @inject
+    def __init__(
+        self, entrypoint_id_plugins_service: EntrypointIdPluginsService, *args, **kwargs
+    ) -> None:
+        """Initialize the entrypoint resource.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_id_plugins_service: A EntrypointIdPluginsService object.
+        """
+        self._entrypoint_id_plugins_service = entrypoint_id_plugins_service
+        super().__init__(*args, **kwargs)
+
+    @login_required
+    @responds(schema=EntrypointPluginSchema(many=True), api=api)
+    def get(self, id: int):
+        """Retrieves the plugin snapshots for an entrypoint resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
+        )
+        plugins = self._entrypoint_id_plugins_service.get(id, log=log)["plugins"]
+        return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
+
+    @login_required
+    @accepts(schema=EntrypointPluginMutableFieldsSchema, api=api)
+    @responds(schema=EntrypointPluginSchema(many=True), api=api)
+    def post(self, id: int):
+        """Appends plugins to an entrypoint resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
+        )
+        parsed_obj = request.parsed_obj  # type: ignore
+        plugins = self._entrypoint_id_plugins_service.append(
+            id, plugin_ids=parsed_obj["plugin_ids"], log=log
+        )["plugins"]
+        return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
+
+
+@api.route("/<int:id>/plugins/<int:pluginId>")
+@api.param("id", "ID for the Entrypoint resource.")
+@api.param("pluginId", "ID for the Plugin resource.")
+class EntrypointIdPluginsIdEndpoint(Resource):
+    @inject
+    def __init__(
+        self,
+        entrypoint_id_plugins_id_service: EntrypointIdPluginsIdService,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Initialize the entrypoint resource.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_id_plugins_id_service: A EntrypointIdPluginsService object.
+        """
+        self._entrypoint_id_plugins_id_service = entrypoint_id_plugins_id_service
+        super().__init__(*args, **kwargs)
+
+    @login_required
+    @responds(schema=EntrypointPluginSchema, api=api)
+    def get(self, id: int, pluginId: int):
+        """Retrieves a plugin snapshot for an entrypoint resource."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()), resource="Entrypoint", request_type="POST"
+        )
+        plugin = cast(
+            utils.PluginWithFilesDict,
+            self._entrypoint_id_plugins_id_service.get(
+                id, plugin_id=pluginId, error_if_not_found=True, log=log
+            ),
+        )
+        return utils.build_entrypoint_plugin(plugin)
+
+    @login_required
+    @responds(schema=EntrypointPluginSchema(many=True), api=api)
+    def delete(self, id: int, pluginId: int):
+        """Removes a plugin from an entrypoint by ID."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="Entrypoint",
+            request_type="DELETE",
+            id=id,
+        )
+        plugins = cast(
+            utils.EntrypointDict,
+            self._entrypoint_id_plugins_id_service.delete(id, pluginId, log=log),
+        )["plugins"]
+        return [utils.build_entrypoint_plugin(plugin) for plugin in plugins]
+
+
+EntrypointDraftResource = generate_resource_drafts_endpoint(
+    api,
+    resource_name=RESOURCE_TYPE,
+    route_prefix=V1_ENTRYPOINTS_ROUTE,
+    request_schema=EntrypointSchema,
+)
+EntrypointDraftIdResource = generate_resource_drafts_id_endpoint(
+    api,
+    resource_name=RESOURCE_TYPE,
+    request_schema=EntrypointSchema,
+)
+EntrypointIdDraftResource = generate_resource_id_draft_endpoint(
+    api,
+    resource_name=RESOURCE_TYPE,
+    request_schema=EntrypointSchema,
+)
+
+EntrypointSnapshotsResource = generate_resource_snapshots_endpoint(
+    api=api,
+    resource_model=models.EntryPoint,
+    resource_name=RESOURCE_TYPE,
+    route_prefix=V1_ENTRYPOINTS_ROUTE,
+    searchable_fields=SEARCHABLE_FIELDS,
+    page_schema=EntrypointPageSchema,
+    build_fn=utils.build_entrypoint,
+)
+EntrypointSnapshotsIdResource = generate_resource_snapshots_id_endpoint(
+    api=api,
+    resource_model=models.EntryPoint,
+    resource_name=RESOURCE_TYPE,
+    response_schema=EntrypointSchema,
+    build_fn=utils.build_entrypoint,
+)
+
+EntrypointTagsResource = generate_resource_tags_endpoint(
+    api=api,
+    resource_name=RESOURCE_TYPE,
+)
+EntrypointTagsIdResource = generate_resource_tags_id_endpoint(
+    api=api,
+    resource_name=RESOURCE_TYPE,
+)

--- a/src/dioptra/restapi/v1/entrypoints/errors.py
+++ b/src/dioptra/restapi/v1/entrypoints/errors.py
@@ -1,0 +1,66 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""Error handlers for the entrypoint endpoints."""
+from __future__ import annotations
+
+from flask_restx import Api
+
+
+class EntrypointAlreadyExistsError(Exception):
+    """The entrypoint name already exists."""
+
+
+class EntrypointDoesNotExistError(Exception):
+    """The requested entrypoint does not exist."""
+
+
+class EntrypointPluginDoesNotExistError(Exception):
+    """The requested plugin does not exist for the entrypoint."""
+
+
+class EntrypointParameterNamesNotUniqueError(Exception):
+    """Mutliple entrypoint parameters share the same name."""
+
+
+def register_error_handlers(api: Api) -> None:
+    @api.errorhandler(EntrypointDoesNotExistError)
+    def handle_entrypoint_does_not_exist_error(error):
+        return {"message": "Not Found - The requested entrypoint does not exist"}, 404
+
+    @api.errorhandler(EntrypointPluginDoesNotExistError)
+    def handle_entrypoint_plugin_does_not_exist_error(error):
+        return {
+            "message": "Not Found - The requested plugin does not exist for this "
+            "entrypoint"
+        }, 404
+
+    @api.errorhandler(EntrypointAlreadyExistsError)
+    def handle_entrypoint_already_exists_error(error):
+        return (
+            {
+                "message": "Bad Request - The entrypoint name on the registration form "
+                "already exists. Please select another and resubmit."
+            },
+            400,
+        )
+
+    @api.errorhandler(EntrypointParameterNamesNotUniqueError)
+    def handle_entrypoint_parameter_names_not_unique_error(error):
+        return {
+            "message": "Bad Request - The entrypoint contains multiple parameters "
+            "with the same name."
+        }, 400

--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -15,8 +15,9 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """The schemas for serializing/deserializing Entrypoint resources."""
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 
+from dioptra.restapi.v1.queues.schema import QueueRefSchema
 from dioptra.restapi.v1.schemas import (
     BasePageSchema,
     GroupIdQueryParametersSchema,
@@ -27,20 +28,59 @@ from dioptra.restapi.v1.schemas import (
 )
 
 
+class EntrypointPluginFileSchema(Schema):
+    """The schema for the data stored in a Entrypoint PluginFile snapshot."""
+
+    id = fields.Integer(
+        attribute="id",
+        metadata=dict(description="ID for the PluginFile resource."),
+    )
+    filename = fields.String(
+        attribute="filename",
+        metadata=dict(description="Filename of the PluginFile resource."),
+    )
+    snapshotId = fields.Integer(
+        attribute="snapshot_id",
+        metadata=dict(description="Snapshot ID for the PluginFile resource."),
+    )
+    url = fields.Url(
+        attribute="url",
+        metadata=dict(description="URL for accessing the full PluginFile snapshot."),
+        relative=True,
+    )
+
+
+class EntrypointPluginSchema(Schema):
+    """The schema for the data stored in a Entrypoint Plugin snapshot."""
+
+    id = fields.Integer(
+        attribute="id",
+        metadata=dict(description="ID for the Plugin resource."),
+    )
+    name = fields.String(
+        attribute="name",
+        metadata=dict(description="Name of the Plugin resource."),
+    )
+    snapshotId = fields.Integer(
+        attribute="snapshot_id",
+        metadata=dict(description="Snapshot ID for the Plugin resource."),
+    )
+    url = fields.Url(
+        attribute="url",
+        metadata=dict(description="URL for accessing the full Plugin snapshot."),
+        relative=True,
+    )
+    files = fields.Nested(
+        EntrypointPluginFileSchema,
+        attribute="files",
+        many=True,
+        metadata=dict(description="List of parameters for the entrypoint."),
+    )
+
+
 class EntrypointParameterSchema(Schema):
     """The schema for the data stored in a Entrypoint parameter resource."""
 
-    entrypointId = fields.Integer(
-        attribute="entrypoint_id",
-        data_key="entrypoint",
-        metadata=dict(description="ID for the associated entrypoint."),
-        required=True,
-    )
-    parameterNumber = fields.Integer(
-        attribute="parameter_number",
-        metadata=dict(description="Index of the Entrypoint parameter."),
-        required=True,
-    )
     name = fields.String(
         attribute="name",
         metadata=dict(description="Name of the Entrypoint parameter resource."),
@@ -55,6 +95,7 @@ class EntrypointParameterSchema(Schema):
         attribute="parameter_type",
         metadata=dict(description="Data type of the Entrypoint parameter."),
         required=True,
+        validate=validate.OneOf(["string", "float", "path", "uri"]),
     )
 
 
@@ -90,16 +131,53 @@ class EntrypointMutableFieldsSchema(Schema):
     )
     parameters = fields.Nested(
         EntrypointParameterSchema,
+        attribute="parameters",
         many=True,
         metadata=dict(description="List of parameters for the entrypoint."),
+    )
+    queueIds = fields.List(
+        fields.Integer(),
+        attribute="queue_ids",
+        data_key="queues",
+        metadata=dict(description="The queue for the entrypoint."),
+        load_only=True,
+    )
+
+
+class EntrypointPluginMutableFieldsSchema(Schema):
+    pluginIds = fields.List(
+        fields.Integer(),
+        attribute="plugin_ids",
+        data_key="plugins",
+        metadata=dict(description="List of plugin files for the entrypoint."),
+        load_only=True,
     )
 
 
 EntrypointBaseSchema = generate_base_resource_schema("Entrypoint", snapshot=True)
 
 
-class EntrypointSchema(EntrypointMutableFieldsSchema, EntrypointBaseSchema):  # type: ignore
+class EntrypointSchema(
+    EntrypointPluginMutableFieldsSchema,
+    EntrypointMutableFieldsSchema,
+    EntrypointBaseSchema,  # type: ignore
+):
     """The schema for the data stored in a Entrypoint resource."""
+
+    plugins = fields.Nested(
+        EntrypointPluginSchema,
+        attribute="plugins",
+        many=True,
+        metadata=dict(description="List of plugin files for the entrypoint."),
+        dump_only=True,
+    )
+    queues = fields.Nested(
+        QueueRefSchema,
+        attribute="queues",
+        many=True,
+        metadata=dict(description="The queue for the entrypoint."),
+        dump_only=True,
+    )
 
 
 class EntrypointPageSchema(BasePageSchema):

--- a/src/dioptra/restapi/v1/entrypoints/service.py
+++ b/src/dioptra/restapi/v1/entrypoints/service.py
@@ -579,11 +579,20 @@ class EntrypointIdPluginsService(object):
             ),
         )["entry_point"]
 
+        new_entrypoint_parameters = [
+            models.EntryPointParameter(
+                name=param.name,
+                default_value=param.default_value,
+                parameter_type=param.parameter_type,
+                parameter_number=param.parameter_number
+            )
+            for param in entrypoint.parameters
+        ]
         new_entrypoint = models.EntryPoint(
             name=entrypoint.name,
             description=entrypoint.description,
             task_graph=entrypoint.task_graph,
-            parameters=entrypoint.parameters,
+            parameters=new_entrypoint_parameters,
             resource=entrypoint.resource,
             creator=current_user,
         )

--- a/src/dioptra/restapi/v1/entrypoints/service.py
+++ b/src/dioptra/restapi/v1/entrypoints/service.py
@@ -1,0 +1,830 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The server-side functions that perform entrypoint endpoint operations."""
+from __future__ import annotations
+
+from typing import Any, Final, cast
+
+import structlog
+from flask_login import current_user
+from injector import inject
+from sqlalchemy import Integer, func, select
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import db, models
+from dioptra.restapi.errors import BackendDatabaseError
+from dioptra.restapi.v1 import utils
+from dioptra.restapi.v1.groups.service import GroupIdService
+from dioptra.restapi.v1.plugins.service import PluginIdsService
+from dioptra.restapi.v1.queues.service import QueueIdsService
+from dioptra.restapi.v1.shared.search_parser import construct_sql_query_filters
+
+from .errors import (
+    EntrypointAlreadyExistsError,
+    EntrypointDoesNotExistError,
+    EntrypointParameterNamesNotUniqueError,
+    EntrypointPluginDoesNotExistError,
+)
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+RESOURCE_TYPE: Final[str] = "entry_point"
+SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
+    "name": lambda x: models.EntryPoint.name.like(x, escape="/"),
+    "description": lambda x: models.EntryPoint.description.like(x, escape="/"),
+    "task_graph": lambda x: models.EntryPoint.task_graph.like(x, escape="/"),
+}
+
+
+class EntrypointService(object):
+    """The service methods for creating and managing entrypoints."""
+
+    @inject
+    def __init__(
+        self,
+        entrypoint_name_service: EntrypointNameService,
+        plugin_ids_service: PluginIdsService,
+        queue_ids_service: QueueIdsService,
+        group_id_service: GroupIdService,
+    ) -> None:
+        """Initialize the entrypoint service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_name_service: A EntrypointNameService object.
+            plugin_ids_service: A PluginIdsService object.
+            queue_ids_service: A QueueIdsService object.
+            group_id_service: A GroupIdService object.
+        """
+        self._entrypoint_name_service = entrypoint_name_service
+        self._plugin_ids_service = plugin_ids_service
+        self._queue_ids_service = queue_ids_service
+        self._group_id_service = group_id_service
+
+    def create(
+        self,
+        name: str,
+        description: str,
+        task_graph: str,
+        parameters: list[dict[str, Any]],
+        plugin_ids: list[int],
+        queue_ids: list[int],
+        group_id: int,
+        commit: bool = True,
+        **kwargs,
+    ) -> utils.EntrypointDict:
+        """Create a new entrypoint.
+
+        Args:
+            name: The name of the entrypoint. The combination of name and group_id must
+                be unique.
+            description: The description of the entrypoint.
+            group_id: The group that will own the entrypoint.
+            commit: If True, commit the transaction. Defaults to True.
+
+        Returns:
+            The newly created entrypoint object.
+
+        Raises:
+            EntrypointAlreadyExistsError: If a entrypoint with the given name already
+                exists.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        if (
+            self._entrypoint_name_service.get(name, group_id=group_id, log=log)
+            is not None
+        ):
+            log.debug("Entrypoint name already exists", name=name, group_id=group_id)
+            raise EntrypointAlreadyExistsError
+
+        group = self._group_id_service.get(group_id, error_if_not_found=True)
+        queues = self._queue_ids_service.get(queue_ids, error_if_not_found=True)
+        plugins = self._plugin_ids_service.get(plugin_ids, error_if_not_found=True)
+
+        resource = models.Resource(resource_type=RESOURCE_TYPE, owner=group)
+
+        entrypoint_parameters = [
+            models.EntryPointParameter(
+                name=param["name"],
+                default_value=param["default_value"],
+                parameter_type=param["parameter_type"],
+                parameter_number=i,
+            )
+            for i, param in enumerate(parameters)
+        ]
+
+        new_entrypoint = models.EntryPoint(
+            name=name,
+            description=description,
+            task_graph=task_graph,
+            parameters=entrypoint_parameters,
+            resource=resource,
+            creator=current_user,
+        )
+
+        entry_point_plugin_files = [
+            models.EntryPointPluginFile(
+                entry_point=new_entrypoint,
+                plugin=plugin["plugin"],
+                plugin_file=plugin_file,
+            )
+            for plugin in plugins
+            for plugin_file in plugin["plugin_files"]
+        ]
+        new_entrypoint.entry_point_plugin_files = entry_point_plugin_files
+
+        plugin_resources = [plugin["plugin"].resource for plugin in plugins]
+        queue_resources = [queue.resource for queue in queues]
+        new_entrypoint.children.extend(plugin_resources + queue_resources)
+
+        db.session.add(new_entrypoint)
+
+        if commit:
+            db.session.commit()
+            log.debug(
+                "Entrypoint registration successful",
+                entrypoint_id=new_entrypoint.resource_id,
+                name=new_entrypoint.name,
+            )
+
+        return utils.EntrypointDict(
+            entry_point=new_entrypoint, queues=queues, plugins=plugins, has_draft=False
+        )
+
+    def get(
+        self,
+        group_id: int | None,
+        search_string: str,
+        page_index: int,
+        page_length: int,
+        **kwargs,
+    ) -> tuple[list[utils.EntrypointDict], int]:
+        """Fetch a list of entrypoints, optionally filtering by search string and paging
+        parameters.
+
+        Args:
+            group_id: A group ID used to filter results.
+            search_string: A search string used to filter results.
+            page_index: The index of the first group to be returned.
+            page_length: The maximum number of entrypoints to be returned.
+
+        Returns:
+            A tuple containing a list of entrypoints and the total number of entrypoints
+            matching the query.
+
+        Raises:
+            SearchNotImplementedError: If a search string is provided.
+            BackendDatabaseError: If the database query returns a None when counting
+                the number of entrypoints.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get full list of entrypoints")
+
+        filters = list()
+
+        if group_id is not None:
+            filters.append(models.Resource.group_id == group_id)
+
+        if search_string:
+            filters.append(
+                construct_sql_query_filters(search_string, SEARCHABLE_FIELDS)
+            )
+
+        stmt = (
+            select(func.count(models.EntryPoint.resource_id))
+            .join(models.Resource)
+            .where(
+                *filters,
+                models.Resource.is_deleted == False,  # noqa: E712
+                models.Resource.latest_snapshot_id
+                == models.EntryPoint.resource_snapshot_id,
+            )
+        )
+        total_num_entrypoints = db.session.scalars(stmt).first()
+
+        if total_num_entrypoints is None:
+            log.error(
+                "The database query returned a None when counting the number of "
+                "groups when it should return a number.",
+                sql=str(stmt),
+            )
+            raise BackendDatabaseError
+
+        if total_num_entrypoints == 0:
+            return [], total_num_entrypoints
+
+        entrypoints_stmt = (
+            select(models.EntryPoint)
+            .join(models.Resource)
+            .where(
+                *filters,
+                models.Resource.is_deleted == False,  # noqa: E712
+                models.Resource.latest_snapshot_id
+                == models.EntryPoint.resource_snapshot_id,
+            )
+            .offset(page_index)
+            .limit(page_length)
+        )
+        entrypoints = list(db.session.scalars(entrypoints_stmt).all())
+
+        queue_ids = set(
+            resource.resource_id
+            for entrypoint in entrypoints
+            for resource in entrypoint.children
+            if resource.resource_type == "queue"
+        )
+        queues = {
+            queue.resource_id: queue
+            for queue in self._queue_ids_service.get(
+                list(queue_ids), error_if_not_found=True
+            )
+        }
+
+        entrypoint_dicts = {
+            entrypoint.resource_id: utils.EntrypointDict(
+                entry_point=entrypoint, queues=[], plugins=[], has_draft=False
+            )
+            for entrypoint in entrypoints
+        }
+        for entrypoint in entrypoint_dicts.values():
+            entrypoint["plugins"] = _get_entrypoint_plugin_snapshots(
+                entrypoint["entry_point"]
+            )
+            for resource in entrypoint["entry_point"].children:
+                if resource.resource_type == "queue":
+                    entrypoint["queues"].append(queues[resource.resource_id])
+
+        drafts_stmt = select(
+            models.DraftResource.payload["resource_id"].as_string().cast(Integer)
+        ).where(
+            models.DraftResource.payload["resource_id"]
+            .as_string()
+            .cast(Integer)
+            .in_(tuple(entrypoint_dicts.keys())),
+            models.DraftResource.user_id == current_user.user_id,
+        )
+        for resource_id in db.session.scalars(drafts_stmt):
+            entrypoint_dicts[resource_id]["has_draft"] = True
+
+        return list(entrypoint_dicts.values()), total_num_entrypoints
+
+
+class EntrypointIdService(object):
+    """The service methods for creating and managing entrypoints by their unique id."""
+
+    @inject
+    def __init__(
+        self,
+        entrypoint_name_service: EntrypointNameService,
+        queue_ids_service: QueueIdsService,
+    ) -> None:
+        """Initialize the entrypoint service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_name_service: A EntrypointNameService object.
+            queue_ids_service: A QueueIdsService object.
+        """
+        self._entrypoint_name_service = entrypoint_name_service
+        self._queue_ids_service = queue_ids_service
+
+    def get(
+        self,
+        entrypoint_id: int,
+        error_if_not_found: bool = False,
+        **kwargs,
+    ) -> utils.EntrypointDict | None:
+        """Fetch a entrypoint by its unique id.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+            error_if_not_found: If True, raise an error if the entrypoint is not found.
+                Defaults to False.
+
+        Returns:
+            The entrypoint object if found, otherwise None.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found and
+            `error_if_not_found` is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get entrypoint by id", entrypoint_id=entrypoint_id)
+
+        stmt = (
+            select(models.EntryPoint)
+            .join(models.Resource)
+            .where(
+                models.EntryPoint.resource_id == entrypoint_id,
+                models.EntryPoint.resource_snapshot_id
+                == models.Resource.latest_snapshot_id,
+                models.Resource.is_deleted == False,  # noqa: E712
+            )
+        )
+        entrypoint = db.session.scalars(stmt).first()
+
+        if entrypoint is None:
+            if error_if_not_found:
+                log.debug("Entrypoint not found", entrypoint_id=entrypoint_id)
+                raise EntrypointDoesNotExistError
+
+            return None
+
+        queue_ids = set(
+            resource.resource_id
+            for resource in entrypoint.children
+            if resource.resource_type == "queue"
+        )
+        queues = self._queue_ids_service.get(list(queue_ids), error_if_not_found=True)
+        plugins = _get_entrypoint_plugin_snapshots(entrypoint)
+
+        drafts_stmt = (
+            select(models.DraftResource.draft_resource_id)
+            .where(
+                models.DraftResource.payload["resource_id"].as_string().cast(Integer)
+                == entrypoint.resource_id,
+                models.DraftResource.user_id == current_user.user_id,
+            )
+            .exists()
+            .select()
+        )
+        has_draft = db.session.scalar(drafts_stmt)
+
+        return utils.EntrypointDict(
+            entry_point=entrypoint, queues=queues, plugins=plugins, has_draft=has_draft
+        )
+
+    def modify(
+        self,
+        entrypoint_id: int,
+        name: str,
+        description: str,
+        task_graph: str,
+        parameters: list[dict[str, Any]],
+        queue_ids: list[int],
+        error_if_not_found: bool = False,
+        commit: bool = True,
+        **kwargs,
+    ) -> utils.EntrypointDict | None:
+        """Modify an entrypoint.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+            name: The new name of the entrypoint.
+            description: The new description of the entrypoint.
+            task_graph: The new task graph of the entrypoint.
+            parameters: the new parameters of the entrypoint.
+            error_if_not_found: If True, raise an error if the group is not found.
+                Defaults to False.
+            commit: If True, commit the transaction. Defaults to True.
+
+        Returns:
+            The updated entrypoint object.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found and
+                `error_if_not_found` is True.
+            EntrypointAlreadyExistsError: If the entrypoint name already exists.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        parameter_names = [parameter["name"] for parameter in parameters]
+        if len(parameter_names) > len(set(parameter_names)):
+            raise EntrypointParameterNamesNotUniqueError
+
+        entrypoint_dict = self.get(
+            entrypoint_id, error_if_not_found=error_if_not_found, log=log
+        )
+
+        if entrypoint_dict is None:
+            return None
+
+        entrypoint = entrypoint_dict["entry_point"]
+        group_id = entrypoint.resource.group_id
+        if (
+            name != entrypoint.name
+            and self._entrypoint_name_service.get(name, group_id=group_id, log=log)
+            is not None
+        ):
+            log.debug("Entrypoint name already exists", name=name, group_id=group_id)
+            raise EntrypointAlreadyExistsError
+
+        queues = self._queue_ids_service.get(queue_ids, error_if_not_found=True)
+
+        entrypoint_parameters = [
+            models.EntryPointParameter(
+                name=param["name"],
+                default_value=param["default_value"],
+                parameter_type=param["parameter_type"],
+                parameter_number=i,
+            )
+            for i, param in enumerate(parameters)
+        ]
+
+        new_entrypoint = models.EntryPoint(
+            name=name,
+            description=description,
+            task_graph=task_graph,
+            parameters=entrypoint_parameters,
+            resource=entrypoint.resource,
+            creator=current_user,
+        )
+        new_entrypoint.entry_point_plugin_files = entrypoint.entry_point_plugin_files
+
+        plugins = _get_entrypoint_plugin_snapshots(new_entrypoint)
+
+        plugin_resources = [plugin["plugin"].resource for plugin in plugins]
+        queue_resources = [queue.resource for queue in queues]
+        new_entrypoint.children = plugin_resources + queue_resources
+
+        db.session.add(new_entrypoint)
+
+        if commit:
+            db.session.commit()
+            log.debug(
+                "Entrypoint modification successful",
+                entrypoint_id=entrypoint_id,
+                name=name,
+                description=description,
+            )
+
+        return utils.EntrypointDict(
+            entry_point=new_entrypoint, queues=queues, plugins=plugins, has_draft=False
+        )
+
+    def delete(self, entrypoint_id: int, **kwargs) -> dict[str, Any]:
+        """Delete a entrypoint.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+
+        Returns:
+            A dictionary reporting the status of the request.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        stmt = select(models.Resource).filter_by(
+            resource_id=entrypoint_id, resource_type=RESOURCE_TYPE, is_deleted=False
+        )
+        entrypoint_resource = db.session.scalars(stmt).first()
+
+        if entrypoint_resource is None:
+            raise EntrypointDoesNotExistError
+
+        deleted_resource_lock = models.ResourceLock(
+            resource_lock_type="delete",
+            resource=entrypoint_resource,
+        )
+        db.session.add(deleted_resource_lock)
+        db.session.commit()
+        log.debug("Entrypoint deleted", entrypoint_id=entrypoint_id)
+
+        return {"status": "Success", "entrypoint_id": entrypoint_id}
+
+
+class EntrypointIdPluginsService(object):
+    """The service methods for creating and managing entrypoints by their unique id."""
+
+    @inject
+    def __init__(
+        self,
+        entrypoint_id_service: EntrypointIdService,
+        plugin_ids_service: PluginIdsService,
+        queue_ids_service: QueueIdsService,
+    ) -> None:
+        """Initialize the entrypoint service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_id_service: A EntrypointIdService object.
+            plugin_ids_service: A PluginIdsService object.
+            queue_ids_service: A QueueIdsService object.
+        """
+        self._entrypoint_id_service = entrypoint_id_service
+        self._plugin_ids_service = plugin_ids_service
+        self._queue_ids_service = queue_ids_service
+
+    def get(
+        self,
+        entrypoint_id: int,
+        **kwargs,
+    ) -> utils.EntrypointDict:
+        """Fetch the plugin snapshots for an entrypoint by its unique id.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+
+        Returns:
+            The plugin snapshots for the entrypoint.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get entrypoint by id", entrypoint_id=entrypoint_id)
+
+        return cast(
+            utils.EntrypointDict,
+            self._entrypoint_id_service.get(
+                entrypoint_id, error_if_not_found=True, log=log
+            ),
+        )
+
+    def append(
+        self,
+        entrypoint_id: int,
+        plugin_ids: list[int],
+        commit: bool = True,
+        **kwargs,
+    ) -> utils.EntrypointDict:
+        """Append plugins to an entrypoint.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+            plugin_ids: The plugins to be appended. If a plugin is already attached
+                to the entrypoint, it is synced to the latest snapshot.
+            commit: If True, commit the transaction. Defaults to True.
+
+        Returns:
+            The updated entrypoint object.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found.
+            EntrypointAlreadyExistsError: If the entrypoint name already exists.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        entrypoint = cast(
+            utils.EntrypointDict,
+            self._entrypoint_id_service.get(
+                entrypoint_id, error_if_not_found=True, log=log
+            ),
+        )["entry_point"]
+
+        new_entrypoint = models.EntryPoint(
+            name=entrypoint.name,
+            description=entrypoint.description,
+            task_graph=entrypoint.task_graph,
+            parameters=entrypoint.parameters,
+            resource=entrypoint.resource,
+            creator=current_user,
+        )
+
+        new_entry_point_plugin_files = [
+            models.EntryPointPluginFile(
+                entry_point=new_entrypoint,
+                plugin=plugin["plugin"],
+                plugin_file=plugin_file,
+            )
+            for plugin in self._plugin_ids_service.get(
+                plugin_ids, error_if_not_found=True
+            )
+            for plugin_file in plugin["plugin_files"]
+        ]
+        existing_entry_point_plugin_files = [
+            entry_point_plugin_file
+            for entry_point_plugin_file in entrypoint.entry_point_plugin_files
+            if entry_point_plugin_file.plugin.resource_id not in set(plugin_ids)
+        ]
+        new_entrypoint.entry_point_plugin_files = (
+            existing_entry_point_plugin_files + new_entry_point_plugin_files
+        )
+
+        plugins = _get_entrypoint_plugin_snapshots(new_entrypoint)
+
+        queue_ids = set(
+            resource.resource_id
+            for resource in entrypoint.children
+            if resource.resource_type == "queue"
+        )
+        queues = self._queue_ids_service.get(list(queue_ids), error_if_not_found=True)
+
+        plugin_resources = [plugin["plugin"].resource for plugin in plugins]
+        queue_resources = [queue.resource for queue in queues]
+        new_entrypoint.children = plugin_resources + queue_resources
+
+        db.session.add(new_entrypoint)
+
+        if commit:
+            db.session.commit()
+            log.debug(
+                "Entrypoint modification successful",
+                entrypoint_id=entrypoint_id,
+                name=entrypoint.name,
+                description=entrypoint.description,
+            )
+
+        return utils.EntrypointDict(
+            entry_point=new_entrypoint, queues=queues, plugins=plugins, has_draft=False
+        )
+
+
+class EntrypointIdPluginsIdService(object):
+    """The service methods for creating and managing entrypoints by their unique id."""
+
+    @inject
+    def __init__(
+        self,
+        entrypoint_id_service: EntrypointIdService,
+        queue_ids_service: QueueIdsService,
+    ) -> None:
+        """Initialize the entrypoint service.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            entrypoint_id_service: A EntrypointIdService object.
+            queue_ids_service: A QueueIdsService object.
+        """
+        self._entrypoint_id_service = entrypoint_id_service
+        self._queue_ids_service = queue_ids_service
+
+    def get(
+        self,
+        entrypoint_id: int,
+        plugin_id: int,
+        error_if_not_found: bool = True,
+        **kwargs,
+    ) -> utils.PluginWithFilesDict | None:
+        """Fetch the plugin snapshots for an entrypoint by its unique id.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+
+        Returns:
+            The plugin snapshots for the entrypoint.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get entrypoint by id", entrypoint_id=entrypoint_id)
+
+        plugins_dict = cast(
+            utils.EntrypointDict,
+            self._entrypoint_id_service.get(
+                entrypoint_id, error_if_not_found=True, log=log
+            ),
+        )["plugins"]
+        plugins = {plugin["plugin"].resource_id: plugin for plugin in plugins_dict}
+
+        if error_if_not_found and plugin_id not in plugins:
+            raise EntrypointPluginDoesNotExistError
+
+        return plugins.get(plugin_id, None)
+
+    def delete(
+        self,
+        entrypoint_id: int,
+        plugin_id: int,
+        commit: bool = True,
+        **kwargs,
+    ) -> utils.EntrypointDict:
+        """Remove a plugin from an entrypoint.
+
+        Args:
+            entrypoint_id: The unique id of the entrypoint.
+            plugin_id: The plugin to be removed.
+            commit: If True, commit the transaction. Defaults to True.
+
+        Returns:
+            The updated entrypoint object.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        entrypoint = cast(
+            utils.EntrypointDict,
+            self._entrypoint_id_service.get(
+                entrypoint_id, error_if_not_found=True, log=log
+            ),
+        )["entry_point"]
+
+        new_entrypoint = models.EntryPoint(
+            name=entrypoint.name,
+            description=entrypoint.description,
+            task_graph=entrypoint.task_graph,
+            parameters=entrypoint.parameters,
+            resource=entrypoint.resource,
+            creator=current_user,
+        )
+        new_entrypoint.entry_point_plugin_files = [
+            entry_point_plugin_file
+            for entry_point_plugin_file in entrypoint.entry_point_plugin_files
+            if entry_point_plugin_file.plugin.resource_id != plugin_id
+        ]
+
+        plugins = _get_entrypoint_plugin_snapshots(new_entrypoint)
+
+        queue_ids = set(
+            resource.resource_id
+            for resource in entrypoint.children
+            if resource.resource_type == "queue"
+        )
+        queues = self._queue_ids_service.get(list(queue_ids), error_if_not_found=True)
+
+        plugin_resources = [plugin["plugin"].resource for plugin in plugins]
+        queue_resources = [queue.resource for queue in queues]
+        new_entrypoint.children = plugin_resources + queue_resources
+
+        db.session.add(new_entrypoint)
+
+        if commit:
+            db.session.commit()
+            log.debug(
+                "Entrypoint modification successful",
+                entrypoint_id=entrypoint_id,
+                name=entrypoint.name,
+                description=entrypoint.description,
+            )
+
+        return utils.EntrypointDict(
+            entry_point=new_entrypoint, queues=queues, plugins=plugins, has_draft=False
+        )
+
+
+class EntrypointNameService(object):
+    """The service methods for managing entrypoints by their name."""
+
+    def get(
+        self,
+        name: str,
+        group_id: int,
+        error_if_not_found: bool = False,
+        **kwargs,
+    ) -> models.EntryPoint | None:
+        """Fetch a entrypoint by its name.
+
+        Args:
+            name: The name of the entrypoint.
+            group_id: The the group id of the entrypoint.
+            error_if_not_found: If True, raise an error if the entrypoint is not found.
+                Defaults to False.
+
+        Returns:
+            The entrypoint object if found, otherwise None.
+
+        Raises:
+            EntrypointDoesNotExistError: If the entrypoint is not found and
+                `error_if_not_found` is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get entrypoint by name", entrypoint_name=name, group_id=group_id)
+
+        stmt = (
+            select(models.EntryPoint)
+            .join(models.Resource)
+            .where(
+                models.EntryPoint.name == name,
+                models.Resource.group_id == group_id,
+                models.Resource.is_deleted == False,  # noqa: E712
+                models.Resource.latest_snapshot_id
+                == models.EntryPoint.resource_snapshot_id,
+            )
+        )
+        entrypoint = db.session.scalars(stmt).first()
+
+        if entrypoint is None:
+            if error_if_not_found:
+                log.debug("Entrypoint not found", name=name)
+                raise EntrypointDoesNotExistError
+
+            return None
+
+        return entrypoint
+
+
+def _get_entrypoint_plugin_snapshots(
+    entrypoint: models.EntryPoint,
+) -> list[utils.PluginWithFilesDict]:
+    plugins_dict = {
+        entry_point_plugin_file.plugin.resource_id: utils.PluginWithFilesDict(
+            plugin=entry_point_plugin_file.plugin, plugin_files=[], has_draft=False
+        )
+        for entry_point_plugin_file in entrypoint.entry_point_plugin_files
+    }
+    for entry_point_plugin_file in entrypoint.entry_point_plugin_files:
+        resource_id = entry_point_plugin_file.plugin.resource_id
+        plugin_file = entry_point_plugin_file.plugin_file
+        plugins_dict[resource_id]["plugin_files"].append(plugin_file)
+    return list(plugins_dict.values())

--- a/src/dioptra/restapi/v1/plugins/controller.py
+++ b/src/dioptra/restapi/v1/plugins/controller.py
@@ -384,14 +384,14 @@ PluginSnapshotsResource = generate_resource_snapshots_endpoint(
     route_prefix=V1_PLUGINS_ROUTE,
     searchable_fields=PLUGIN_SEARCHABLE_FIELDS,
     page_schema=PluginPageSchema,
-    build_fn=utils.build_plugin_snapshot,
+    build_fn=utils.build_plugin,
 )
 PluginSnapshotsIdResource = generate_resource_snapshots_id_endpoint(
     api=api,
     resource_model=models.Plugin,
     resource_name=PLUGIN_RESOURCE_TYPE,
     response_schema=PluginSchema,
-    build_fn=utils.build_plugin_snapshot,
+    build_fn=utils.build_plugin,
 )
 
 PluginTagsResource = generate_resource_tags_endpoint(

--- a/src/dioptra/restapi/v1/plugins/service.py
+++ b/src/dioptra/restapi/v1/plugins/service.py
@@ -521,6 +521,8 @@ class PluginIdsService(object):
                 models.Resource.latest_snapshot_id.in_(
                     select(plugin_file_snapshot_ids_cte)
                 ),
+                models.Resource.latest_snapshot_id
+                == models.PluginFile.resource_snapshot_id,
                 models.Resource.is_deleted == False,  # noqa: E712
             )
         )

--- a/src/dioptra/restapi/v1/plugins/service.py
+++ b/src/dioptra/restapi/v1/plugins/service.py
@@ -447,6 +447,112 @@ class PluginIdService(object):
         return {"status": "Success", "id": [plugin_id]}
 
 
+class PluginIdsService(object):
+    """The service methods for registering and managing plugins by their unique id."""
+
+    def get(
+        self,
+        plugin_ids: list[int],
+        error_if_not_found: bool = False,
+        **kwargs,
+    ) -> list[utils.PluginWithFilesDict]:
+        """Fetch a plugin by its unique id.
+
+        Args:
+            plugin_ids: The unique ids of the plugins.
+            error_if_not_found: If True, raise an error if the plugin is not found.
+                Defaults to False.
+
+        Returns:
+            A list of  plugin objects.
+
+        Raises:
+            PluginDoesNotExistError: If the plugin is not found and `error_if_not_found`
+                is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+
+        latest_plugins_stmt = (
+            select(models.Plugin)
+            .join(models.Resource)
+            .where(
+                models.Plugin.resource_id.in_(tuple(plugin_ids)),
+                models.Resource.is_deleted == False,  # noqa: E712
+                models.Resource.latest_snapshot_id
+                == models.Plugin.resource_snapshot_id,
+            )
+        )
+        plugins = db.session.scalars(latest_plugins_stmt).all()
+
+        if len(plugins) != len(plugin_ids) and error_if_not_found:
+            plugin_ids_missing = set(plugin_ids) - set(
+                plugin.resource_id for plugin in plugins
+            )
+            log.debug("Plugin not found", plugin_ids=list(plugin_ids_missing))
+            raise PluginDoesNotExistError
+
+        # extract list of plugin ids
+        plugin_ids = [plugin.resource_id for plugin in plugins]
+
+        # Build CTE that retrieves all snapshot ids for the list of plugin files
+        # associated with retrieved plugins
+        parent_plugin = aliased(models.Plugin)
+        plugin_file_snapshot_ids_cte = (
+            select(models.PluginFile.resource_snapshot_id)
+            .join(
+                models.resource_dependencies_table,
+                models.PluginFile.resource_id
+                == models.resource_dependencies_table.c.child_resource_id,
+            )
+            .join(
+                parent_plugin,
+                parent_plugin.resource_id
+                == models.resource_dependencies_table.c.parent_resource_id,
+            )
+            .where(parent_plugin.resource_id.in_(plugin_ids))
+            .cte()
+        )
+
+        # get the latest plugin file snapshots associated with the retrieved plugins
+        latest_plugin_files_stmt = (
+            select(models.PluginFile)
+            .join(models.Resource)
+            .where(
+                models.Resource.latest_snapshot_id.in_(
+                    select(plugin_file_snapshot_ids_cte)
+                ),
+                models.Resource.is_deleted == False,  # noqa: E712
+            )
+        )
+        plugin_files = db.session.scalars(latest_plugin_files_stmt).unique().all()
+
+        # build a dictionary structure to re-associate plugins and plugin files
+        plugins_dict: dict[int, utils.PluginWithFilesDict] = {
+            plugin.resource_id: utils.PluginWithFilesDict(
+                plugin=plugin, plugin_files=[], has_draft=False
+            )
+            for plugin in plugins
+        }
+        for plugin_file in plugin_files:
+            plugins_dict[plugin_file.plugin_id]["plugin_files"].append(plugin_file)
+
+        drafts_stmt = select(
+            models.DraftResource.payload["resource_id"].as_string().cast(Integer)
+        ).where(
+            models.DraftResource.payload["resource_id"]
+            .as_string()
+            .cast(Integer)
+            .in_(
+                tuple(plugin["plugin"].resource_id for plugin in plugins_dict.values())
+            ),
+            models.DraftResource.user_id == current_user.user_id,
+        )
+        for resource_id in db.session.scalars(drafts_stmt):
+            plugins_dict[resource_id]["has_draft"] = True
+
+        return list(plugins_dict.values())
+
+
 class PluginNameService(object):
     """The service methods for managing plugins by their name."""
 

--- a/src/dioptra/restapi/v1/queues/service.py
+++ b/src/dioptra/restapi/v1/queues/service.py
@@ -368,6 +368,53 @@ class QueueIdService(object):
         return {"status": "Success", "queue_id": queue_id}
 
 
+class QueueIdsService(object):
+    """The service methods for retrieving queues from a list of ids."""
+
+    def get(
+        self,
+        queue_ids: list[int],
+        error_if_not_found: bool = False,
+        **kwargs,
+    ) -> list[models.Queue]:
+        """Fetch a list of queues by their unique ids.
+
+        Args:
+            queue_ids: The unique ids of the queues.
+            error_if_not_found: If True, raise an error if the queue is not found.
+                Defaults to False.
+
+        Returns:
+            The queue object if found, otherwise None.
+
+        Raises:
+            QueueDoesNotExistError: If the queue is not found and `error_if_not_found`
+                is True.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get queue by id", queue_ids=queue_ids)
+
+        stmt = (
+            select(models.Queue)
+            .join(models.Resource)
+            .where(
+                models.Queue.resource_id.in_(tuple(queue_ids)),
+                models.Queue.resource_snapshot_id == models.Resource.latest_snapshot_id,
+                models.Resource.is_deleted == False,  # noqa: E712
+            )
+        )
+        queues = list(db.session.scalars(stmt).all())
+
+        if len(queues) != len(queue_ids) and error_if_not_found:
+            queue_ids_missing = set(queue_ids) - set(
+                queue.resource_id for queue in queues
+            )
+            log.debug("Queue not found", queue_ids=list(queue_ids_missing))
+            raise QueueDoesNotExistError
+
+        return queues
+
+
 class QueueNameService(object):
     """The service methods for managing queues by their name."""
 

--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -117,7 +117,7 @@ def generate_base_resource_ref_schema(
             metadata=dict(description=f"ID for the {name} resource."),
         ),
         "snapshotId": fields.Integer(
-            attribute="id",
+            attribute="snapshot_id",
             metadata=dict(description=f"Snapshot ID for the {name} resource."),
         ),
         "group": fields.Nested(

--- a/src/dioptra/restapi/v1/shared/snapshots/controller.py
+++ b/src/dioptra/restapi/v1/shared/snapshots/controller.py
@@ -96,7 +96,7 @@ def generate_resource_snapshots_endpoint(
             page_length = parsed_query_params["page_length"]
 
             snapshots, total_num_snapshots = cast(
-                tuple[list[models.ResourceSnapshot], int],
+                tuple[list[dict[str, Any]], int],
                 self._snapshots_service.get(
                     resource_id=id,
                     group_id=group_id,

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -72,6 +72,7 @@ class PluginFileDict(TypedDict):
 
 class ExperimentDict(TypedDict):
     experiment: models.Experiment
+    entrypoints: list[models.EntryPoint]
     queue: models.Queue | None
     has_draft: bool | None
 
@@ -248,7 +249,7 @@ def build_entrypoint_ref(entrypoint: models.EntryPoint) -> dict[str, Any]:
     """Build a EntrypointRef dictionary.
 
     Args:
-        queue: The Entrypoint object to convert into a EntrypointRef dictionary.
+        entrypoint: The Entrypoint object to convert into a EntrypointRef dictionary.
 
     Returns:
         The EntrypointRef dictionary.
@@ -257,7 +258,7 @@ def build_entrypoint_ref(entrypoint: models.EntryPoint) -> dict[str, Any]:
         "id": entrypoint.resource_id,
         "name": entrypoint.name,
         "group": build_group_ref(entrypoint.resource.owner),
-        "url": f"/{ENTRYPOINTS}/{entrypoint.entry_point_id}",
+        "url": f"/{ENTRYPOINTS}/{entrypoint.resource_id}",
     }
 
 
@@ -391,6 +392,7 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         The Experiment response dictionary.
     """
     experiment = experiment_dict["experiment"]
+    entrypoints = experiment_dict["entrypoints"]
     has_draft = experiment_dict.get("has_draft", None)
 
     data = {
@@ -398,7 +400,7 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         "snapshot_id": experiment.resource_snapshot_id,
         "name": experiment.name,
         "description": experiment.description,
-        "entrypoints": [],
+        "entrypoints": [build_entrypoint_ref(entrypoint) for entrypoint in entrypoints],
         "jobs": [],
         "user": build_user_ref(experiment.creator),
         "group": build_group_ref(experiment.resource.owner),

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -123,10 +123,8 @@ def register_experiment(
         payload["description"] = description
     else:
         payload["description"] = ""
-    # if entrypoint_ids is not None:
-    #     payload["entrypoint_ids"] = entrypoint_ids
-    # else:
-    #     payload["entrypoint_ids"] = list()
+    if entrypoint_ids is not None:
+        payload["entrypoints"] = entrypoint_ids
 
     return client.post(
         f"/{V1_ROOT}/{V1_EXPERIMENTS_ROUTE}/",

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -26,6 +26,7 @@ from werkzeug.test import TestResponse
 
 from dioptra.restapi.routes import (
     V1_AUTH_ROUTE,
+    V1_ENTRYPOINTS_ROUTE,
     V1_EXPERIMENTS_ROUTE,
     V1_GROUPS_ROUTE,
     V1_PLUGIN_PARAMETER_TYPES_ROUTE,
@@ -51,6 +52,48 @@ def login(client: FlaskClient, username: str, password: str) -> TestResponse:
     return client.post(
         f"/{V1_ROOT}/{V1_AUTH_ROUTE}/login",
         json={"username": username, "password": password},
+    )
+
+
+def register_entrypoint(
+    client: FlaskClient,
+    name: str,
+    description: str,
+    group_id: int,
+    task_graph: str,
+    parameters: list[dict[str, Any]],
+    plugin_ids: list[int],
+    queue_ids: list[int],
+) -> TestResponse:
+    """Register an entrypoint using the API.
+
+    Args:
+        client: The Flask test client.
+        name: The name to assign to the new entrypoint.
+        description: The description for the new entrypoint.
+        group_id: The group to create the new entrypoint in.
+        task_graph: A graph of the tasks to perform in a entry point.
+        parameters: A list of entrypoint parameters.
+
+    Returns:
+        The response from the API.
+    """
+    payload: dict[str, Any] = {
+        "name": name,
+        "group": group_id,
+        "taskGraph": task_graph,
+        "parameters": parameters,
+        "plugins": plugin_ids,
+        "queues": queue_ids,
+    }
+
+    if description:
+        payload["description"] = description
+
+    return client.post(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/",
+        json=payload,
+        follow_redirects=True,
     )
 
 

--- a/tests/unit/restapi/lib/asserts.py
+++ b/tests/unit/restapi/lib/asserts.py
@@ -161,8 +161,6 @@ def assert_draft_response_contents_matches_expectations(
         "resourceSnapshot",
         "metadata",
     }
-    print(expected_keys)
-    print(set(response.keys()))
     assert set(response.keys()) == expected_keys
 
     # Validate the non-Ref fields

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -935,7 +935,6 @@ def test_manage_entrypoint_snapshots(
       response
     """
     entrypoint_to_rename = registered_entrypoints["entrypoint1"]
-    plugin_ids = [plugin["id"] for plugin in entrypoint_to_rename["plugins"]]
     queue_ids = [queue["id"] for queue in entrypoint_to_rename["queues"]]
     modified_entrypoint = modify_entrypoint(
         client,
@@ -948,7 +947,6 @@ def test_manage_entrypoint_snapshots(
     ).get_json()
     entrypoint_to_rename["latestSnapshot"] = False
     entrypoint_to_rename["lastModifiedOn"] = modified_entrypoint["lastModifiedOn"]
-    entrypoint_to_rename.pop("plugins")
     entrypoint_to_rename.pop("queues")
     entrypoint_to_rename.pop("hasDraft")
     asserts.assert_retrieving_snapshot_by_id_works(
@@ -958,7 +956,6 @@ def test_manage_entrypoint_snapshots(
         snapshot_id=entrypoint_to_rename["snapshot"],
         expected=entrypoint_to_rename,
     )
-    modified_entrypoint.pop("plugins")
     modified_entrypoint.pop("queues")
     modified_entrypoint.pop("hasDraft")
     asserts.assert_retrieving_snapshot_by_id_works(

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -1,0 +1,1048 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""Test suite for entrypoint operations.
+
+This module contains a set of tests that validate the CRUD operations and additional
+functionalities for the entrypoint entity. The tests ensure that the entrypoints can be
+registered, renamed, deleted, and locked/unlocked as expected through the REST API.
+"""
+import textwrap
+from typing import Any
+
+from flask.testing import FlaskClient
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.test import TestResponse
+
+from dioptra.restapi.routes import V1_ENTRYPOINTS_ROUTE, V1_ROOT
+
+from ..lib import actions, asserts, helpers
+
+# -- Actions ---------------------------------------------------------------------------
+
+
+def modify_entrypoint(
+    client: FlaskClient,
+    entrypoint_id: int,
+    new_name: str,
+    new_description: str,
+    new_task_graph: str,
+    new_parameters: list[dict[str, Any]],
+    new_queue_ids: list[int],
+) -> TestResponse:
+    """Rename a entrypoint using the API.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to rename.
+        new_name: The new name to assign to the entrypoint.
+        new_description: The new description to assign to the entrypoint.
+
+    Returns:
+        The response from the API.
+    """
+    payload: dict[str, Any] = {
+        "name": new_name,
+        "description": new_description,
+        "taskGraph": new_task_graph,
+        "parameters": new_parameters,
+        "queues": new_queue_ids,
+    }
+
+    return client.put(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/{entrypoint_id}",
+        json=payload,
+        follow_redirects=True,
+    )
+
+
+def delete_entrypoint(
+    client: FlaskClient,
+    entrypoint_id: int,
+) -> TestResponse:
+    """Delete a entrypoint using the API.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to delete.
+
+    Returns:
+        The response from the API.
+    """
+
+    return client.delete(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/{entrypoint_id}",
+        follow_redirects=True,
+    )
+
+
+# -- Assertions ------------------------------------------------------------------------
+
+
+def assert_entrypoint_response_contents_matches_expectations(
+    response: dict[str, Any], expected_contents: dict[str, Any]
+) -> None:
+    """Assert that entrypoint response contents is valid.
+
+    Args:
+        response: The actual response from the API.
+        expected_contents: The expected response from the API.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response or if the response contents is not
+            valid.
+    """
+    expected_keys = {
+        "id",
+        "snapshot",
+        "group",
+        "user",
+        "createdOn",
+        "lastModifiedOn",
+        "latestSnapshot",
+        "hasDraft",
+        "name",
+        "description",
+        "taskGraph",
+        "parameters",
+        "plugins",
+        "queues",
+        "tags",
+    }
+    assert set(response.keys()) == expected_keys
+
+    # Validate the non-Ref fields
+    assert isinstance(response["id"], int)
+    assert isinstance(response["snapshot"], int)
+    assert isinstance(response["name"], str)
+    assert isinstance(response["description"], str)
+    assert isinstance(response["createdOn"], str)
+    assert isinstance(response["lastModifiedOn"], str)
+    assert isinstance(response["latestSnapshot"], bool)
+    assert isinstance(response["hasDraft"], bool)
+
+    assert response["name"] == expected_contents["name"]
+    assert response["description"] == expected_contents["description"]
+    assert response["taskGraph"] == expected_contents["task_graph"]
+
+    assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["lastModifiedOn"])
+
+    # Validate PluginRef structure
+    for plugin in response["plugins"]:
+        assert isinstance(plugin["id"], int)
+        assert isinstance(plugin["snapshotId"], int)
+        assert isinstance(plugin["name"], str)
+        assert isinstance(plugin["url"], str)
+        for plugin_file in plugin["files"]:
+            assert isinstance(plugin_file["id"], int)
+            assert isinstance(plugin_file["snapshotId"], int)
+            assert isinstance(plugin_file["filename"], str)
+            assert isinstance(plugin_file["url"], str)
+
+    # Validate the Queue IDs structure
+    for queue in response["queues"]:
+        assert isinstance(queue["id"], int)
+        assert isinstance(queue["group"], dict)
+        assert isinstance(queue["url"], str)
+
+    # Validate the UserRef structure
+    assert isinstance(response["user"]["id"], int)
+    assert isinstance(response["user"]["username"], str)
+    assert isinstance(response["user"]["url"], str)
+    assert response["user"]["id"] == expected_contents["user_id"]
+
+    # Validate the GroupRef structure
+    assert isinstance(response["group"]["id"], int)
+    assert isinstance(response["group"]["name"], str)
+    assert isinstance(response["group"]["url"], str)
+    assert response["group"]["id"] == expected_contents["group_id"]
+
+    # Validate the TagRef structure
+    for tag in response["tags"]:
+        assert isinstance(tag["id"], int)
+        assert isinstance(tag["name"], str)
+        assert isinstance(tag["url"], str)
+    assert response["tags"] == expected_contents["tags"]
+
+    # Validate the EntryPointParameter structure
+    for param in response["parameters"]:
+        assert isinstance(param["name"], str)
+        assert isinstance(param["defaultValue"], str)
+        assert isinstance(param["parameterType"], str)
+    assert response["parameters"] == expected_contents["parameters"]
+
+
+def assert_retrieving_entrypoint_by_id_works(
+    client: FlaskClient,
+    entrypoint_id: int,
+    expected: dict[str, Any],
+) -> None:
+    """Assert that retrieving a entrypoint by id works.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to retrieve.
+        expected: The expected response from the API.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+    response = client.get(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/{entrypoint_id}", follow_redirects=True
+    )
+    assert response.status_code == 200 and response.get_json() == expected
+
+
+def assert_retrieving_entrypoints_works(
+    client: FlaskClient,
+    expected: list[dict[str, Any]],
+    group_id: int | None = None,
+    search: str | None = None,
+    paging_info: dict[str, Any] | None = None,
+) -> None:
+    """Assert that retrieving all entrypoints works.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected response from the API.
+        group_id: The group ID used in query parameters.
+        search: The search string used in query parameters.
+        paging_info: The paging information used in query parameters.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    if group_id is not None:
+        query_string["groupId"] = group_id
+
+    if search is not None:
+        query_string["search"] = search
+
+    if paging_info is not None:
+        query_string["index"] = paging_info["index"]
+        query_string["pageLength"] = paging_info["page_length"]
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200 and response.get_json()["data"] == expected
+
+
+def assert_registering_existing_entrypoint_name_fails(
+    client: FlaskClient,
+    name: str,
+    description: str,
+    group_id: int,
+    task_graph: str,
+    parameters: list[dict[str, Any]],
+    plugin_ids: list[int],
+    queue_ids: list[int],
+) -> None:
+    """Assert that registering a entrypoint with an existing name fails.
+
+    Args:
+        client: The Flask test client.
+        name: The name to assign to the new entrypoint.
+
+    Raises:
+        AssertionError: If the response status code is not 400.
+    """
+    response = actions.register_entrypoint(
+        client,
+        name=name,
+        description=description,
+        group_id=group_id,
+        task_graph=task_graph,
+        parameters=parameters,
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    )
+    assert response.status_code == 400
+
+
+def assert_entrypoint_name_matches_expected_name(
+    client: FlaskClient, entrypoint_id: int, expected_name: str
+) -> None:
+    """Assert that the name of a entrypoint matches the expected name.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to retrieve.
+        expected_name: The expected name of the entrypoint.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the name of the
+            entrypoint does not match the expected name.
+    """
+    response = client.get(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/{entrypoint_id}",
+        follow_redirects=True,
+    )
+    assert response.status_code == 200 and response.get_json()["name"] == expected_name
+
+
+def assert_entrypoint_is_not_found(
+    client: FlaskClient,
+    entrypoint_id: int,
+) -> None:
+    """Assert that a entrypoint is not found.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to retrieve.
+
+    Raises:
+        AssertionError: If the response status code is not 404.
+    """
+    response = client.get(
+        f"/{V1_ROOT}/{V1_ENTRYPOINTS_ROUTE}/{entrypoint_id}",
+        follow_redirects=True,
+    )
+    assert response.status_code == 404
+
+
+def assert_cannot_rename_entrypoint_with_existing_name(
+    client: FlaskClient,
+    entrypoint_id: int,
+    existing_name: str,
+    existing_description: str,
+    existing_task_graph: str,
+    existing_parameters: list[dict[str, Any]],
+    existing_queue_ids: list[int],
+) -> None:
+    """Assert that renaming a entrypoint with an existing name fails.
+
+    Args:
+        client: The Flask test client.
+        entrypoint_id: The id of the entrypoint to rename.
+        existing_name: str,
+        existing_description: str,
+        existing_task_graph: str,
+        existing_parameters: list[dict[str, Any]],
+        existing_queue_ids: list[int],
+
+    Raises:
+        AssertionError: If the response status code is not 400.
+    """
+    response = modify_entrypoint(
+        client,
+        entrypoint_id=entrypoint_id,
+        new_name=existing_name,
+        new_description=existing_description,
+        new_task_graph=existing_task_graph,
+        new_parameters=existing_parameters,
+        new_queue_ids=existing_queue_ids,
+    )
+    assert response.status_code == 400
+
+
+def assert_entrypoint_must_have_unique_param_names(
+    client: FlaskClient,
+    name: str,
+    description: str,
+    group_id: int,
+    task_graph: str,
+    parameters: list[dict[str, Any]],
+    plugin_ids: list[int],
+    queue_ids: list[int],
+) -> None:
+    response = actions.register_entrypoint(
+        client,
+        name=name,
+        description=description,
+        group_id=group_id,
+        task_graph=task_graph,
+        parameters=parameters,
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    )
+    assert response.status_code == 400
+
+
+# -- Tests -----------------------------------------------------------------------------
+
+
+def test_create_entrypoint(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_plugin_with_files: dict[str, Any],
+    registered_queues: dict[str, Any],
+) -> None:
+    """Test that entrypoints can be correctly registered and retrieved using the API.
+
+    Given an authenticated user, registered plugins, and registed queues, this test
+    validates the following sequence of actions:
+
+    - The user registers a entrypoint named "tensorflow_cpu".
+    - The response is valid matches the expected values given the registration request.
+    - The user is able to retrieve information about the entrypoint using the entrypoint id.
+    """
+    name = "my_entrypoint"
+    description = "The first entrypoint."
+    user_id = auth_account["id"]
+    group_id = auth_account["groups"][0]["id"]
+    task_graph = textwrap.dedent(
+        """# my entrypoint graph
+        graph:
+          message:
+            my_entrypoint: $name
+        """
+    )
+    parameters = [
+        {
+            "name": "my_entrypoint_param_1",
+            "defaultValue": "my_value",
+            "parameterType": "string",
+        },
+        {
+            "name": "my_entrypoint_param_2",
+            "defaultValue": "my_value",
+            "parameterType": "string",
+        },
+    ]
+    plugin_ids = [registered_plugin_with_files["plugin"]["id"]]
+    queue_ids = [queue["id"] for queue in list(registered_queues.values())]
+    entrypoint_response = actions.register_entrypoint(
+        client,
+        name=name,
+        description=description,
+        group_id=group_id,
+        task_graph=task_graph,
+        parameters=parameters,
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    )
+    entrypoint_expected = entrypoint_response.get_json()
+    assert_entrypoint_response_contents_matches_expectations(
+        response=entrypoint_expected,
+        expected_contents={
+            "name": name,
+            "description": description,
+            "user_id": user_id,
+            "group_id": group_id,
+            "task_graph": task_graph,
+            "parameters": parameters,
+            "plugin_ids": plugin_ids,
+            "queue_ids": queue_ids,
+            "tags": [],
+        },
+    )
+    assert_retrieving_entrypoint_by_id_works(
+        client, entrypoint_id=entrypoint_expected["id"], expected=entrypoint_expected
+    )
+
+    # Testing that parameter names must be unique
+    bad_parameters = [
+        {
+            "name": "not_unique",
+            "defaultValue": "my_value",
+            "parameterType": "string",
+        },
+        {
+            "name": "not_unique",
+            "defaultValue": "my_value",
+            "parameterType": "string",
+        },
+    ]
+    assert_entrypoint_must_have_unique_param_names(
+        client,
+        name=name,
+        description=description,
+        group_id=group_id,
+        task_graph=task_graph,
+        parameters=bad_parameters,
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    )
+
+
+def test_entrypoint_get_all(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that all entrypoints can be retrieved.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - A user registers three entrypoints, "tensorflow_cpu", "tensorflow_gpu", "pytorch_cpu".
+    - The user is able to retrieve a list of all registered entrypoints.
+    - The returned list of entrypoints matches the full list of registered entrypoints.
+    """
+    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    assert_retrieving_entrypoints_works(client, expected=entrypoint_expected_list)
+
+
+def test_entrypoint_search_query(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that entrypoints can be queried with a search term.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user is able to retrieve a list of all registered entrypoints with various queries.
+    - The returned list of entrypoints matches the expected matches from the query.
+    """
+    entrypoint_expected_list = list(registered_entrypoints.values())[:2]
+    assert_retrieving_entrypoints_works(
+        client, expected=entrypoint_expected_list, search="description:*entrypoint*"
+    )
+    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    assert_retrieving_entrypoints_works(
+        client, expected=entrypoint_expected_list, search="*"
+    )
+
+
+def test_entrypoint_group_query(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that entrypoints can retrieved using a group filter.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user is able to retrieve a list of all registered entrypoints that are owned by the
+      default group.
+    - The returned list of entrypoints matches the expected list owned by the default group.
+    """
+    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    assert_retrieving_entrypoints_works(
+        client,
+        expected=entrypoint_expected_list,
+        group_id=auth_account["groups"][0]["id"],
+    )
+
+
+def test_cannot_register_existing_entrypoint_name(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+    registered_plugin_with_files: dict[str, Any],
+    registered_queues: dict[str, Any],
+) -> None:
+    """Test that registering a entrypoint with an existing name fails.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user attempts to register a second entrypoint with the same name.
+    - The request fails with an appropriate error message and response code.
+    """
+    existing_entrypoint = registered_entrypoints["entrypoint1"]
+    plugin_ids = [registered_plugin_with_files["plugin"]["id"]]
+    queue_ids = [queue["id"] for queue in list(registered_queues.values())]
+
+    assert_registering_existing_entrypoint_name_fails(
+        client,
+        name=existing_entrypoint["name"],
+        description="",
+        group_id=existing_entrypoint["group"]["id"],
+        task_graph="",
+        parameters=[],
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    )
+
+
+def test_rename_entrypoint(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that a entrypoint can be renamed.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user issues a request to change the name of a entrypoint.
+    - The user retrieves information about the same entrypoint and it reflects the name
+      change.
+    - The user issues a request to change the name of the entrypoint to the existing name.
+    - The user retrieves information about the same entrypoint and verifies the name remains
+      unchanged.
+    - The user issues a request to change the name of a entrypoint to an existing entrypoint's
+      name.
+    - The request fails with an appropriate error message and response code.
+    """
+    updated_entrypoint_name = "new_entrypoint_name"
+    entrypoint_to_rename = registered_entrypoints["entrypoint1"]
+    existing_entrypoint = registered_entrypoints["entrypoint2"]
+    queue_ids = [queue["id"] for queue in entrypoint_to_rename["queues"]]
+
+    modified_entrypoint = modify_entrypoint(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        new_name=updated_entrypoint_name,
+        new_description=entrypoint_to_rename["description"],
+        new_task_graph=entrypoint_to_rename["taskGraph"],
+        new_parameters=entrypoint_to_rename["parameters"],
+        new_queue_ids=queue_ids,
+    ).get_json()
+    assert_entrypoint_name_matches_expected_name(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        expected_name=updated_entrypoint_name,
+    )
+    entrypoint_expected_list = [
+        modified_entrypoint,
+        registered_entrypoints["entrypoint2"],
+        registered_entrypoints["entrypoint3"],
+    ]
+    assert_retrieving_entrypoints_works(client, expected=entrypoint_expected_list)
+
+    modified_entrypoint = modify_entrypoint(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        new_name=updated_entrypoint_name,
+        new_description=entrypoint_to_rename["description"],
+        new_task_graph=entrypoint_to_rename["taskGraph"],
+        new_parameters=entrypoint_to_rename["parameters"],
+        new_queue_ids=entrypoint_to_rename["queues"],
+    ).get_json()
+    assert_entrypoint_name_matches_expected_name(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        expected_name=updated_entrypoint_name,
+    )
+
+    assert_cannot_rename_entrypoint_with_existing_name(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        existing_name=existing_entrypoint["name"],
+        existing_description=entrypoint_to_rename["description"],
+        existing_task_graph=entrypoint_to_rename["taskGraph"],
+        existing_parameters=entrypoint_to_rename["parameters"],
+        existing_queue_ids=entrypoint_to_rename["queues"],
+    )
+
+
+def test_delete_entrypoint_by_id(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that a entrypoint can be deleted by referencing its id.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user deletes a entrypoint by referencing its id.
+    - The user attempts to retrieve information about the deleted entrypoint.
+    - The request fails with an appropriate error message and response code.
+    """
+    entrypoint_to_delete = registered_entrypoints["entrypoint1"]
+
+    delete_entrypoint(client, entrypoint_id=entrypoint_to_delete["id"])
+    assert_entrypoint_is_not_found(client, entrypoint_id=entrypoint_to_delete["id"])
+
+
+def test_manage_existing_entrypoint_draft(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that a draft of an existing entrypoint can be created and managed by the user
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user creates a draft of an existing entrypoint
+    - The user retrieves information about the draft and gets the expected response
+    - The user attempts to create another draft of the same existing entrypoint
+    - The request fails with an appropriate error message and response code.
+    - The user modifies the name of the entrypoint in the draft
+    - The user retrieves information about the draft and gets the expected response
+    - The user deletes the draft
+    - The user attempts to retrieve information about the deleted draft.
+    - The request fails with an appropriate error message and response code.
+    """
+    entrypoint = registered_entrypoints["entrypoint1"]
+    name = "draft"
+    new_name = "draft2"
+    description = "description"
+    task_graph = textwrap.dedent(
+        """# my entrypoint graph
+        graph:
+          message:
+            my_entrypoint: $name
+        """
+    )
+    parameters = [
+        {
+            "name": "my_entrypoint_param",
+            "defaultValue": "my_value",
+            "parameterType": "string",
+        }
+    ]
+    plugin_ids = [plugin["id"] for plugin in entrypoint["plugins"]]
+    queue_ids = [queue["id"] for queue in entrypoint["queues"]]
+
+    # test creation
+    payload = {
+        "name": name,
+        "description": description,
+        "taskGraph": task_graph,
+        "parameters": parameters,
+        "plugins": plugin_ids,
+        "queues": queue_ids,
+    }
+    expected = {
+        "user_id": auth_account["id"],
+        "group_id": entrypoint["group"]["id"],
+        "resource_id": entrypoint["id"],
+        "resource_snapshot_id": entrypoint["snapshot"],
+        "num_other_drafts": 0,
+        "payload": {
+            "name": name,
+            "description": description,
+            "task_graph": task_graph,
+            "parameters": [
+                {
+                    "name": "my_entrypoint_param",
+                    "default_value": "my_value",
+                    "parameter_type": "string",
+                }
+            ],
+            "plugin_ids": plugin_ids,
+            "queue_ids": queue_ids,
+        },
+    }
+    response = actions.create_existing_resource_draft(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        payload=payload,
+    ).get_json()
+    asserts.assert_draft_response_contents_matches_expectations(response, expected)
+    asserts.assert_retrieving_draft_by_resource_id_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        expected=response,
+    )
+    asserts.assert_creating_another_existing_draft_fails(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+
+    # test modification
+    payload = {"name": new_name, "description": description, "taskGraph": task_graph}
+    expected = {
+        "user_id": auth_account["id"],
+        "group_id": entrypoint["group"]["id"],
+        "resource_id": entrypoint["id"],
+        "resource_snapshot_id": entrypoint["snapshot"],
+        "num_other_drafts": 0,
+        "payload": {
+            "name": new_name,
+            "description": description,
+            "task_graph": task_graph,
+        },
+    }
+    response = actions.modify_existing_resource_draft(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        payload=payload,
+    ).get_json()
+    asserts.assert_draft_response_contents_matches_expectations(response, expected)
+
+    # test deletion
+    actions.delete_existing_resource_draft(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+    asserts.assert_existing_draft_is_not_found(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+
+
+def test_manage_new_entrypoint_drafts(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+) -> None:
+    """Test that drafts of entrypoint can be created and managed by the user
+
+    Given an authenticated user, this test validates the following sequence of actions:
+
+    - The user creates two entrypoint drafts
+    - The user retrieves information about the drafts and gets the expected response
+    - The user modifies the description of the entrypoint in the first draft
+    - The user retrieves information about the draft and gets the expected response
+    - The user deletes the first draft
+    - The user attempts to retrieve information about the deleted draft.
+    - The request fails with an appropriate error message and response code.
+    """
+    group_id = auth_account["groups"][0]["id"]
+    drafts = {
+        "draft1": {
+            "name": "entrypoint1",
+            "description": "new entrypoint",
+            "taskGraph": "graph",
+        },
+        "draft2": {
+            "name": "entrypoint2",
+            "taskGraph": "graph",
+            "queues": [1, 3],
+            "plugins": [2],
+        },
+    }
+
+    # test creation
+    draft1_expected = {
+        "user_id": auth_account["id"],
+        "group_id": group_id,
+        "payload": {
+            "name": drafts["draft1"]["name"],
+            "description": drafts["draft1"]["description"],
+            "task_graph": drafts["draft1"]["taskGraph"],
+        },
+    }
+    draft1_response = actions.create_new_resource_draft(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        group_id=group_id,
+        payload=drafts["draft1"],
+    ).get_json()
+    asserts.assert_draft_response_contents_matches_expectations(
+        draft1_response, draft1_expected
+    )
+    asserts.assert_retrieving_draft_by_id_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        draft_id=draft1_response["id"],
+        expected=draft1_response,
+    )
+    draft2_expected = {
+        "user_id": auth_account["id"],
+        "group_id": group_id,
+        "payload": {
+            "name": drafts["draft2"]["name"],
+            "description": None,
+            "task_graph": drafts["draft2"]["taskGraph"],
+            "queue_ids": drafts["draft2"]["queues"],
+            "plugin_ids": drafts["draft2"]["plugins"],
+        },
+    }
+    draft2_response = actions.create_new_resource_draft(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        group_id=group_id,
+        payload=drafts["draft2"],
+    ).get_json()
+    asserts.assert_draft_response_contents_matches_expectations(
+        draft2_response, draft2_expected
+    )
+    asserts.assert_retrieving_draft_by_id_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        draft_id=draft2_response["id"],
+        expected=draft2_response,
+    )
+    asserts.assert_retrieving_drafts_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        expected=[draft1_response, draft2_response],
+    )
+
+    # test modification
+    draft1_mod = {
+        "name": "draft1",
+        "description": "new description",
+        "taskGraph": "graph",
+    }
+    draft1_mod_expected = {
+        "user_id": auth_account["id"],
+        "group_id": group_id,
+        "payload": {
+            "name": draft1_mod["name"],
+            "description": draft1_mod["description"],
+            "task_graph": draft1_mod["taskGraph"],
+        },
+    }
+    response = actions.modify_new_resource_draft(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        draft_id=draft1_response["id"],
+        payload=draft1_mod,
+    ).get_json()
+    asserts.assert_draft_response_contents_matches_expectations(
+        response, draft1_mod_expected
+    )
+
+    # test deletion
+    actions.delete_new_resource_draft(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, draft_id=draft1_response["id"]
+    )
+    asserts.assert_new_draft_is_not_found(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, draft_id=draft1_response["id"]
+    )
+
+
+def test_manage_entrypoint_snapshots(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+) -> None:
+    """Test that different snapshots of a entrypoint can be retrieved by the user.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    - The user modifies a entrypoint
+    - The user retrieves information about the original snapshot of the entrypoint and gets
+      the expected response
+    - The user retrieves information about the new snapshot of the entrypoint and gets the
+      expected response
+    - The user retrieves a list of all snapshots of the entrypoint and gets the expected
+      response
+    """
+    entrypoint_to_rename = registered_entrypoints["entrypoint1"]
+    plugin_ids = [plugin["id"] for plugin in entrypoint_to_rename["plugins"]]
+    queue_ids = [queue["id"] for queue in entrypoint_to_rename["queues"]]
+    modified_entrypoint = modify_entrypoint(
+        client,
+        entrypoint_id=entrypoint_to_rename["id"],
+        new_name=entrypoint_to_rename["name"] + "modified",
+        new_description=entrypoint_to_rename["description"],
+        new_task_graph=entrypoint_to_rename["taskGraph"],
+        new_parameters=entrypoint_to_rename["parameters"],
+        new_queue_ids=queue_ids,
+    ).get_json()
+    entrypoint_to_rename["latestSnapshot"] = False
+    entrypoint_to_rename["lastModifiedOn"] = modified_entrypoint["lastModifiedOn"]
+    entrypoint_to_rename.pop("plugins")
+    entrypoint_to_rename.pop("queues")
+    entrypoint_to_rename.pop("hasDraft")
+    asserts.assert_retrieving_snapshot_by_id_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint_to_rename["id"],
+        snapshot_id=entrypoint_to_rename["snapshot"],
+        expected=entrypoint_to_rename,
+    )
+    modified_entrypoint.pop("plugins")
+    modified_entrypoint.pop("queues")
+    modified_entrypoint.pop("hasDraft")
+    asserts.assert_retrieving_snapshot_by_id_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=modified_entrypoint["id"],
+        snapshot_id=modified_entrypoint["snapshot"],
+        expected=modified_entrypoint,
+    )
+    expected_snapshots = [entrypoint_to_rename, modified_entrypoint]
+    asserts.assert_retrieving_snapshots_works(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint_to_rename["id"],
+        expected=expected_snapshots,
+    )
+
+
+def test_tag_entrypoint(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+    registered_tags: dict[str, Any],
+) -> None:
+    """Test that different versions of a entrypoint can be retrieved by the user.
+
+    Given an authenticated user and registered entrypoints, this test validates the following
+    sequence of actions:
+
+    """
+    entrypoint = registered_entrypoints["entrypoint1"]
+    tags = [tag["id"] for tag in registered_tags.values()]
+
+    # test append
+    response = actions.append_tags(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        tag_ids=[tags[0], tags[1]],
+    )
+    asserts.assert_tags_response_contents_matches_expectations(
+        response.get_json(), [tags[0], tags[1]]
+    )
+    response = actions.append_tags(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        tag_ids=[tags[1], tags[2]],
+    )
+    asserts.assert_tags_response_contents_matches_expectations(
+        response.get_json(), [tags[0], tags[1], tags[2]]
+    )
+
+    # test remove
+    actions.remove_tag(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        tag_id=tags[1],
+    )
+    response = actions.get_tags(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+    asserts.assert_tags_response_contents_matches_expectations(
+        response.get_json(), [tags[0], tags[2]]
+    )
+
+    # test modify
+    response = actions.modify_tags(
+        client,
+        resource_route=V1_ENTRYPOINTS_ROUTE,
+        resource_id=entrypoint["id"],
+        tag_ids=[tags[1], tags[2]],
+    )
+    asserts.assert_tags_response_contents_matches_expectations(
+        response.get_json(), [tags[1], tags[2]]
+    )
+
+    # test delete
+    response = actions.remove_tags(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+    response = actions.get_tags(
+        client, resource_route=V1_ENTRYPOINTS_ROUTE, resource_id=entrypoint["id"]
+    )
+    asserts.assert_tags_response_contents_matches_expectations(response.get_json(), [])

--- a/tests/unit/restapi/v1/test_group.py
+++ b/tests/unit/restapi/v1/test_group.py
@@ -74,7 +74,6 @@ def assert_group_response_contents_matches_expectations(
             does not match the expected response or if the response contents is not
             valid.
     """
-    print("RESPONSE FROM API", response)
     expected_keys = {
         "id",
         "name",

--- a/tests/unit/restapi/v1/test_plugin_parameter_type.py
+++ b/tests/unit/restapi/v1/test_plugin_parameter_type.py
@@ -60,7 +60,6 @@ def modify_plugin_parameter_type(
 
     if new_description is not None:
         json_payload["description"] = new_description
-    print("MODIFY", json_payload)
 
     return client.put(
         f"/{V1_ROOT}/{V1_PLUGIN_PARAMETER_TYPES_ROUTE}/{id}",


### PR DESCRIPTION
This feature adds an implementation of the service layer for v1 of the REST API for the Entrypoints
endpoint. It includes the Tags, ResourceDrafts, and ResourceSnapshots (versions) subendpoints. as
well as search functionality. This commit also includes unit tests that cover common user
interactions with Entrypoints.

The primary implementations are in `restapi/entrypoints/service.py`. The services are injected into
controller layer in `restapi/entrypoints/controller.py` which calls the appropriate service layer
functionality. The controller layer uses helper functions from `restapi/utils.py` to translate ORM
objects back to the response types expected by the schema. Error handling is added to v1 routes by
registering error handlers in `restapi/errors.py`.