### PR TITLE
Implement plugin task registration in plugin file sub-endpoints

### DIFF
--- a/src/dioptra/restapi/db/models/plugins.py
+++ b/src/dioptra/restapi/db/models/plugins.py
@@ -74,7 +74,9 @@ class PluginFile(ResourceSnapshot):
     )
 
     # Relationships
-    tasks: Mapped[list["PluginTask"]] = relationship(init=False, back_populates="file")
+    tasks: Mapped[list["PluginTask"]] = relationship(
+        init=False, back_populates="file", lazy="joined"
+    )
 
     # Additional settings
     __table_args__ = (  # type: ignore[assignment]
@@ -104,10 +106,10 @@ class PluginTask(db.Model):  # type: ignore[name-defined]
     # Relationships
     file: Mapped["PluginFile"] = relationship(back_populates="tasks")
     input_parameters: Mapped[list["PluginTaskInputParameter"]] = relationship(
-        back_populates="task"
+        back_populates="task", lazy="joined"
     )
     output_parameters: Mapped[list["PluginTaskOutputParameter"]] = relationship(
-        back_populates="task"
+        back_populates="task", lazy="joined"
     )
 
 
@@ -164,7 +166,7 @@ class PluginTaskInputParameter(db.Model):  # type: ignore[name-defined]
         init=False, back_populates="input_parameters"
     )
     parameter_type: Mapped["PluginTaskParameterType"] = relationship(
-        back_populates="input_parameters"
+        back_populates="input_parameters", lazy="joined"
     )
 
     # Additional settings
@@ -202,7 +204,7 @@ class PluginTaskOutputParameter(db.Model):  # type: ignore[name-defined]
         init=False, back_populates="output_parameters"
     )
     parameter_type: Mapped["PluginTaskParameterType"] = relationship(
-        back_populates="output_parameters"
+        back_populates="output_parameters", lazy="joined"
     )
 
     # Additional settings

--- a/src/dioptra/restapi/v1/plugins/controller.py
+++ b/src/dioptra/restapi/v1/plugins/controller.py
@@ -277,6 +277,7 @@ class PluginIdFilesEndpoint(Resource):
             filename=parsed_obj["filename"],
             contents=parsed_obj["contents"],
             description=parsed_obj["description"],
+            tasks=parsed_obj["tasks"],
             plugin_id=id,
             log=log,
         )
@@ -350,6 +351,7 @@ class PluginIdFileIdEndpoint(Resource):
                 plugin_file_id=fileId,
                 filename=parsed_obj["filename"],
                 contents=parsed_obj["contents"],
+                tasks=parsed_obj["tasks"],
                 description=parsed_obj["description"],
                 error_if_not_found=True,
                 log=log,

--- a/src/dioptra/restapi/v1/plugins/errors.py
+++ b/src/dioptra/restapi/v1/plugins/errors.py
@@ -36,6 +36,22 @@ class PluginFileDoesNotExistError(Exception):
     """The requested plugin file does not exist."""
 
 
+class PluginTaskParameterTypeNotFoundError(Exception):
+    """One ore more referenced plugin task parameter types were not found."""
+
+
+class PluginTaskNameAlreadyExistsError(Exception):
+    """More than one plugin task is being assigned the same name."""
+
+
+class PluginTaskInputParameterNameAlreadyExistsError(Exception):
+    """More than one plugin task input parameter is being assigned the same name."""
+
+
+class PluginTaskOutputParameterNameAlreadyExistsError(Exception):
+    """More than one plugin task output parameter is being assigned the same name."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(PluginDoesNotExistError)
     def handle_plugin_does_not_exist_error(error):
@@ -64,3 +80,31 @@ def register_error_handlers(api: Api) -> None:
             },
             400,
         )
+
+    @api.errorhandler(PluginTaskParameterTypeNotFoundError)
+    def handle_plugin_task_parameter_type_not_found_error(error):
+        return {
+            "message": "Bad Request - One or more referenced plugin task parameter "
+            "types were not found."
+        }, 400
+
+    @api.errorhandler(PluginTaskNameAlreadyExistsError)
+    def handle_plugin_task_name_already_exists_error(error):
+        return {
+            "message": "Bad Request - More than one plugin task is being assigned the "
+            "same name."
+        }, 400
+
+    @api.errorhandler(PluginTaskInputParameterNameAlreadyExistsError)
+    def handle_plugin_task_input_parameter_name_already_exists_error(error):
+        return {
+            "message": "Bad Request - More than one plugin task input parameter is "
+            "being assigned the same name."
+        }, 400
+
+    @api.errorhandler(PluginTaskOutputParameterNameAlreadyExistsError)
+    def handle_plugin_task_output_parameter_name_already_exists_error(error):
+        return {
+            "message": "Bad Request - More than one plugin task output parameter is "
+            "being assigned the same name."
+        }, 400

--- a/src/dioptra/restapi/v1/plugins/service.py
+++ b/src/dioptra/restapi/v1/plugins/service.py
@@ -17,6 +17,7 @@
 """The server-side functions that perform plugin endpoint operations."""
 from __future__ import annotations
 
+import itertools
 from typing import Any, Final, cast
 
 import structlog
@@ -37,6 +38,10 @@ from .errors import (
     PluginDoesNotExistError,
     PluginFileAlreadyExistsError,
     PluginFileDoesNotExistError,
+    PluginTaskInputParameterNameAlreadyExistsError,
+    PluginTaskNameAlreadyExistsError,
+    PluginTaskOutputParameterNameAlreadyExistsError,
+    PluginTaskParameterTypeNotFoundError,
 )
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
@@ -227,7 +232,7 @@ class PluginService(object):
                 models.Resource.is_deleted == False,  # noqa: E712
             )
         )
-        plugin_files = db.session.scalars(latest_plugin_files_stmt).all()
+        plugin_files = db.session.scalars(latest_plugin_files_stmt).unique().all()
 
         # build a dictionary structure to re-associate plugins and plugin files
         plugins_dict: dict[int, utils.PluginWithFilesDict] = {
@@ -325,7 +330,7 @@ class PluginIdService(object):
                 == models.PluginFile.resource_snapshot_id,
             )
         )
-        plugin_files = list(db.session.scalars(latest_plugin_files_stmt).all())
+        plugin_files = list(db.session.scalars(latest_plugin_files_stmt).unique().all())
 
         drafts_stmt = (
             select(models.DraftResource.draft_resource_id)
@@ -358,7 +363,7 @@ class PluginIdService(object):
             plugin_id: The unique id of the plugin.
             name: The new name of the plugin.
             description: The new description of the plugin.
-            error_if_not_found: If True, raise an error if the group is not found.
+            error_if_not_found: If True, raise an error if the plugin is not found.
                 Defaults to False.
             commit: If True, commit the transaction. Defaults to True.
 
@@ -426,7 +431,7 @@ class PluginIdService(object):
         stmt = select(models.Resource).filter_by(
             resource_id=plugin_id, resource_type=PLUGIN_RESOURCE_TYPE, is_deleted=False
         )
-        plugin_resource = db.session.scalars(stmt).first()
+        plugin_resource = db.session.scalar(stmt)
 
         if plugin_resource is None:
             raise PluginDoesNotExistError
@@ -481,7 +486,7 @@ class PluginNameService(object):
                 == models.Plugin.resource_snapshot_id,
             )
         )
-        plugin = db.session.scalars(stmt).first()
+        plugin = db.session.scalar(stmt)
 
         if plugin is None:
             if error_if_not_found:
@@ -530,7 +535,7 @@ class PluginFileNameService(object):
                 == models.PluginFile.resource_snapshot_id,
             )
         )
-        plugin_file = db.session.scalars(stmt).first()
+        plugin_file = db.session.scalar(stmt)
 
         if plugin_file is None:
             if error_if_not_found:
@@ -568,6 +573,7 @@ class PluginIdFileService(object):
         filename: str,
         contents: str,
         description: str,
+        tasks: list[dict[str, Any]],
         plugin_id: int,
         commit: bool = True,
         **kwargs,
@@ -578,17 +584,19 @@ class PluginIdFileService(object):
         with the PluginFile. The creator will be the current user.
 
         Args:
-            filename: the name of the PluginFile object.
-            contents (str): _description_
-            tasks (Dict[str, List[Dict]]): _description_
-            plugin_id (int): _description_
-            commit (bool, optional): _description_. Defaults to True.
-
-        Raises:
-            PluginFileAlreadyExistsError: _description_
+            filename: The name of the plugin file.
+            contents: The contents of the plugin file.
+            description: The description of the plugin file.
+            tasks: The tasks associated with the plugin file.
+            plugin_id: The unique id of the plugin containing the plugin file.
+            commit: If True, commit the transaction. Defaults to True.
 
         Returns:
-            _type_: _description_
+            The newly created plugin file object.
+
+        Raises:
+            PluginFileAlreadyExistsError: If a plugin file with the given filename
+                already exists.
         """
 
         log: BoundLogger = kwargs.get("log", LOGGER.new())
@@ -623,9 +631,11 @@ class PluginIdFileService(object):
             resource=resource,
             creator=current_user,
         )
-        new_plugin_file.parents.append(plugin.resource)
 
+        new_plugin_file.parents.append(plugin.resource)
         db.session.add(new_plugin_file)
+
+        _add_plugin_tasks(tasks, plugin_file=new_plugin_file, log=log)
 
         if commit:
             db.session.commit()
@@ -740,7 +750,7 @@ class PluginIdFileService(object):
             plugin_file.resource_id: utils.PluginFileDict(
                 plugin=plugin, plugin_file=plugin_file, has_draft=False
             )
-            for plugin_file in db.session.scalars(latest_plugin_files_stmt)
+            for plugin_file in db.session.scalars(latest_plugin_files_stmt).unique()
         }
 
         drafts_stmt = select(
@@ -777,7 +787,7 @@ class PluginIdFileService(object):
             resource_id=plugin_id, resource_type=PLUGIN_RESOURCE_TYPE, is_deleted=False
         )
 
-        plugin_resource = db.session.scalars(stmt).first()
+        plugin_resource = db.session.scalar(stmt)
 
         if plugin_resource is None:
             raise PluginDoesNotExistError
@@ -793,7 +803,7 @@ class PluginIdFileService(object):
             )
         )
 
-        plugin_files = db.session.scalars(latest_plugin_files_stmt).all()
+        plugin_files = db.session.scalars(latest_plugin_files_stmt).unique().all()
         num_plugin_files = len(plugin_files)
 
         plugin_file_ids = []
@@ -833,15 +843,15 @@ class PluginIdFileIdService(object):
         Args:
             plugin_id: The unique id of the plugin containing the plugin file.
             plugin_file_id: The unique id of the plugin file.
-            error_if_not_found: If True, raise an error if the plugin is not found.
-                Defaults to False.
+            error_if_not_found: If True, raise an error if the plugin or plugin file is
+                not found. Defaults to False.
 
         Returns:
             The plugin object if found, otherwise None.
 
         Raises:
-            PluginDoesNotExistError: If the plugin is not found and `error_if_not_found`
-                is True.
+            PluginDoesNotExistError: If the plugin or plugin file is not found and
+                `error_if_not_found` is True.
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.debug(
@@ -910,10 +920,31 @@ class PluginIdFileIdService(object):
         filename: str,
         contents: str,
         description: str,
+        tasks: list,
         error_if_not_found: bool = False,
         commit: bool = True,
         **kwargs,
-    ):
+    ) -> utils.PluginFileDict | None:
+        """Modify a plugin file.
+
+        Args:
+            plugin_id: The unique id of the plugin.
+            plugin_file_id: The unique id of the plugin file.
+            filename: The updated filename of the plugin file.
+            contents: The updated contents of the plugin file.
+            description: The updated description of the plugin file.
+            tasks: The updated tasks associated with the plugin file.
+            error_if_not_found: If True, raise an error if the plugin or plugin file is
+                not found. Defaults to False.
+            commit: If True, commit the transaction. Defaults to True.
+
+        Returns:
+            The updated plugin file object.
+
+        Raises:
+            PluginDoesNotExistError: If the plugin or plugin file is not found and
+                `error_if_not_found` is True.
+        """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
         plugin_file_dict = self.get(
@@ -937,38 +968,39 @@ class PluginIdFileIdService(object):
             is not None
         ):
             log.debug(
-                "Plugin file filename already exists",
-                filename=filename,
-                plugin_id=plugin_id,
+                "Plugin filename already exists", filename=filename, plugin_id=plugin_id
             )
             raise PluginFileAlreadyExistsError
 
-        new_plugin_file = models.PluginFile(
+        updated_plugin_file = models.PluginFile(
             filename=filename,
             contents=contents,
             description=description,
             resource=plugin_file.resource,
             creator=current_user,
         )
-        db.session.add(new_plugin_file)
+        db.session.add(updated_plugin_file)
+
+        _add_plugin_tasks(tasks, plugin_file=updated_plugin_file, log=log)
 
         if commit:
             db.session.commit()
             log.debug(
                 "Plugin file modification successful",
-                plugin_file_id=new_plugin_file.resource_id,
-                filename=new_plugin_file.filename,
+                plugin_file_id=updated_plugin_file.resource_id,
+                filename=updated_plugin_file.filename,
             )
 
         return utils.PluginFileDict(
-            plugin_file=new_plugin_file, plugin=plugin, has_draft=False
+            plugin_file=updated_plugin_file, plugin=plugin, has_draft=False
         )
 
     def delete(self, plugin_id: int, plugin_file_id: int, **kwargs) -> dict[str, Any]:
-        """Deletes all plugin files associated with a plugin.
+        """Deletes a plugin file.
 
         Args:
             plugin_id: The unique id of the plugin.
+            plugin_file_id: The unique id of the plugin file.
 
         Returns:
             A dictionary reporting the status of the request.
@@ -979,7 +1011,7 @@ class PluginIdFileIdService(object):
             resource_id=plugin_id, resource_type=PLUGIN_RESOURCE_TYPE, is_deleted=False
         )
 
-        plugin_resource = db.session.scalars(stmt).first()
+        plugin_resource = db.session.scalar(stmt)
         if plugin_resource is None:
             raise PluginDoesNotExistError
 
@@ -1013,3 +1045,135 @@ class PluginIdFileIdService(object):
         )
 
         return {"status": "Success", "id": [plugin_file_id_to_return]}
+
+
+def _construct_plugin_task(
+    plugin_file: models.PluginFile,
+    task: dict[str, Any],
+    parameter_types_id_to_orm: dict[int, models.PluginTaskParameterType],
+    log: BoundLogger,
+) -> models.PluginTask:
+    input_param_names = [x["name"] for x in task["input_params"]]
+    unique_input_param_names = set(input_param_names)
+
+    if len(unique_input_param_names) != len(input_param_names):
+        log.error(
+            "One or more input parameters have the same name",
+            plugin_task_name=task["name"],
+            input_param_names=input_param_names,
+        )
+        raise PluginTaskInputParameterNameAlreadyExistsError
+
+    output_param_names = [x["name"] for x in task["output_params"]]
+    unique_output_param_names = set(output_param_names)
+
+    if len(unique_output_param_names) != len(output_param_names):
+        log.error(
+            "One or more output parameters have the same name",
+            plugin_task_name=task["name"],
+            output_param_names=output_param_names,
+        )
+        raise PluginTaskOutputParameterNameAlreadyExistsError
+
+    input_parameters_list = []
+    for parameter_number, input_param in enumerate(task["input_params"]):
+        parameter_type = parameter_types_id_to_orm[input_param["parameter_type_id"]]
+        input_parameters_list.append(
+            models.PluginTaskInputParameter(
+                name=input_param["name"],
+                parameter_number=parameter_number,
+                parameter_type=parameter_type,
+            )
+        )
+
+    output_parameters_list = []
+    for parameter_number, output_param in enumerate(task["output_params"]):
+        parameter_type = parameter_types_id_to_orm[output_param["parameter_type_id"]]
+        output_parameters_list.append(
+            models.PluginTaskOutputParameter(
+                name=output_param["name"],
+                parameter_number=parameter_number,
+                parameter_type=parameter_type,
+            )
+        )
+
+    plugin_task_orm = models.PluginTask(
+        file=plugin_file,
+        plugin_task_name=task["name"],
+        input_parameters=input_parameters_list,
+        output_parameters=output_parameters_list,
+    )
+    return plugin_task_orm
+
+
+def _get_referenced_parameter_types(
+    tasks: list[dict[str, Any]], log: BoundLogger
+) -> dict[int, models.PluginTaskParameterType] | None:
+    parameter_type_ids = set(
+        [
+            param["parameter_type_id"]
+            for task in tasks
+            for param in itertools.chain(task["input_params"], task["output_params"])
+        ]
+    )
+
+    if not len(parameter_type_ids) > 0:
+        return None
+
+    parameter_types_stmt = (
+        select(models.PluginTaskParameterType)
+        .join(models.Resource)
+        .where(
+            models.PluginTaskParameterType.resource_id.in_(tuple(parameter_type_ids)),
+            models.Resource.is_deleted == False,  # noqa: E712
+            models.Resource.latest_snapshot_id
+            == models.PluginTaskParameterType.resource_snapshot_id,
+        )
+    )
+    parameter_types = db.session.scalars(parameter_types_stmt).all()
+
+    if parameter_types is None:
+        log.error(
+            "The database query returned a None when it should return plugin "
+            "parameter types.",
+            sql=str(parameter_types_stmt),
+            num_expected=len(parameter_type_ids),
+        )
+        raise BackendDatabaseError
+
+    if not len(parameter_types) == len(parameter_type_ids):
+        returned_parameter_type_ids = set([x.resource_id for x in parameter_types])
+        ids_not_found = parameter_type_ids - returned_parameter_type_ids
+        log.error(
+            "One or more referenced plugin task parameter types were not found",
+            num_expected=len(parameter_type_ids),
+            num_found=len(parameter_types),
+            ids_not_found=sorted(list(ids_not_found)),
+        )
+        raise PluginTaskParameterTypeNotFoundError
+
+    return {x.resource_id: x for x in parameter_types}
+
+
+def _add_plugin_tasks(
+    tasks: list[dict[str, Any]], plugin_file: models.PluginFile, log: BoundLogger
+) -> None:
+    if not tasks:
+        return None
+
+    task_names = [x["name"] for x in tasks]
+    unique_task_names = set(task_names)
+
+    if len(unique_task_names) != len(tasks):
+        log.error("One or more tasks have the same name", task_names=task_names)
+        raise PluginTaskNameAlreadyExistsError
+
+    parameter_types_id_to_orm = _get_referenced_parameter_types(tasks, log=log) or {}
+    for task in tasks:
+        plugin_task = _construct_plugin_task(
+            plugin_file,
+            task=task,
+            parameter_types_id_to_orm=parameter_types_id_to_orm,
+            log=log,
+        )
+        db.session.add(plugin_task)

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -33,6 +33,30 @@ TAGS: Final[str] = "tags"
 # -- Typed Dictionaries --------------------------------------------------------
 
 
+class GroupRefDict(TypedDict):
+    id: int
+    name: str
+    url: str
+
+
+class PluginParameterTypeRefDict(TypedDict):
+    id: int
+    group: GroupRefDict
+    url: str
+    name: str
+
+
+class PluginTaskParameterDict(TypedDict):
+    name: str
+    parameter_type: PluginParameterTypeRefDict
+
+
+class PluginTaskDict(TypedDict):
+    name: str
+    input_params: list[PluginTaskParameterDict]
+    output_params: list[PluginTaskParameterDict]
+
+
 class PluginWithFilesDict(TypedDict):
     plugin: models.Plugin
     plugin_files: list[models.PluginFile]
@@ -96,7 +120,7 @@ def build_user_ref(user: models.User) -> dict[str, Any]:
     }
 
 
-def build_group_ref(group: models.Group) -> dict[str, Any]:
+def build_group_ref(group: models.Group) -> GroupRefDict:
     """Build a GroupRef dictionary.
 
     Args:
@@ -196,7 +220,7 @@ def build_queue_ref(queue: models.Queue) -> dict[str, Any]:
 
 def build_plugin_parameter_type_ref(
     plugin_param_type: models.PluginTaskParameterType,
-) -> dict[str, Any]:
+) -> PluginParameterTypeRefDict:
     """Build a PluginParameterTypeRef dictionary.
 
     Args:
@@ -210,9 +234,7 @@ def build_plugin_parameter_type_ref(
         "id": plugin_param_type.resource_id,
         "name": plugin_param_type.name,
         "group": build_group_ref(plugin_param_type.resource.owner),
-        "url": build_url(
-            f"{PLUGIN_PARAMETER_TYPES}/{plugin_param_type.resource_id}"
-        ),
+        "url": build_url(f"{PLUGIN_PARAMETER_TYPES}/{plugin_param_type.resource_id}"),
     }
 
 
@@ -451,7 +473,7 @@ def build_plugin_file(plugin_file_with_plugin: PluginFileDict) -> dict[str, Any]
         "latest_snapshot": plugin_file.resource.latest_snapshot_id
         == plugin_file.resource_snapshot_id,
         "contents": plugin_file.contents,
-        "tasks": [],
+        "tasks": [build_plugin_task(task) for task in plugin_file.tasks],
         "plugin": build_plugin_ref(plugin),
     }
 
@@ -459,6 +481,36 @@ def build_plugin_file(plugin_file_with_plugin: PluginFileDict) -> dict[str, Any]
         data["has_draft"] = has_draft
 
     return data
+
+
+def build_plugin_task(plugin_task: models.PluginTask) -> PluginTaskDict:
+    input_params: list[PluginTaskParameterDict] = []
+    for input_parameter in plugin_task.input_parameters:
+        input_params.append(
+            PluginTaskParameterDict(
+                name=input_parameter.name,
+                parameter_type=build_plugin_parameter_type_ref(
+                    input_parameter.parameter_type
+                ),
+            )
+        )
+
+    output_params: list[PluginTaskParameterDict] = []
+    for output_parameter in plugin_task.output_parameters:
+        output_params.append(
+            PluginTaskParameterDict(
+                name=output_parameter.name,
+                parameter_type=build_plugin_parameter_type_ref(
+                    output_parameter.parameter_type
+                ),
+            )
+        )
+
+    return PluginTaskDict(
+        name=plugin_task.plugin_task_name,
+        input_params=input_params,
+        output_params=output_params,
+    )
 
 
 def build_plugin_parameter_type(

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -173,7 +173,7 @@ def register_plugin_file(
     description: str,
     filename: str,
     contents: str,
-    # tasks: dict[str, Any] | None = None,
+    tasks: list[dict[str, Any]] | None = None,
 ) -> TestResponse:
     """Register a plugin file using the API.
 
@@ -193,10 +193,8 @@ def register_plugin_file(
         "filename": filename,
         "contents": contents,
         "description": description,
+        "tasks": tasks or [],
     }
-
-    # if tasks:
-    #     payload["tasks"] = tasks
 
     return client.post(
         f"/{V1_ROOT}/{V1_PLUGINS_ROUTE}/{plugin_id}/files",
@@ -233,31 +231,6 @@ def register_plugin_parameter_type(
 
     return client.post(
         f"/{V1_ROOT}/{V1_PLUGIN_PARAMETER_TYPES_ROUTE}",
-        json=payload,
-        follow_redirects=True,
-    )
-
-
-def add_plugin_tasks_to_plugin_file(
-    client: FlaskClient,
-    plugin_id: int,
-    plugin_file_id: int,
-    tasks: List[dict[str, Any]],
-) -> TestResponse:
-    """Modify a plugin file to include tasks using the API.
-
-    Args:
-        client: The Flask test client.
-        plugin_id: The plugin ID with a file.
-        plugin_file_id: The plugin file ID to append the task.
-        tasks: A list of tasks to add to the file.
-    Returns:
-        The response from the API.
-    """
-    payload: dict[str, Any] = {"tasks": tasks}
-
-    return client.put(
-        f"/{V1_ROOT}/{V1_PLUGINS_ROUTE}/{plugin_id}/files/{plugin_file_id}",
         json=payload,
         follow_redirects=True,
     )

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -200,54 +200,66 @@ def registered_plugin_with_file_and_tasks(
         @pyplugs.register
         def hello_world(name: str) -> str:
             return f"Hello, {name}!"
+
+
+        @pyplugs.register
+        def add_one(x: int) -> int:
+            return x + 1
         """
     )
-    plugin_file_without_tasks_response = actions.register_plugin_file(
+    string_type_response = actions.register_plugin_parameter_type(
+        client,
+        name="string",
+        group_id=auth_account["default_group_id"],
+        structure=None,
+        description="The plugin parameter string type.",
+    ).get_json()
+    integer_type_response = actions.register_plugin_parameter_type(
+        client,
+        name="integer",
+        group_id=auth_account["default_group_id"],
+        structure=None,
+        description="The plugin parameter integer type.",
+    ).get_json()
+    hello_world_task = {
+        "name": "hello_world",
+        "inputParams": [
+            {"name": "name", "parameterType": string_type_response["id"]}
+        ],
+        "outputParams": [
+            {
+                "name": "hello_world_message",
+                "parameterType": string_type_response["id"],
+            }
+        ],
+    }
+    add_one_task = {
+        "name": "add_one",
+        "inputParams": [
+            {"name": "x", "parameterType": integer_type_response["id"]}
+        ],
+        "outputParams": [
+            {
+                "name": "value",
+                "parameterType": integer_type_response["id"],
+            }
+        ],
+    }
+    plugin_task_list = [hello_world_task, add_one_task]
+    plugin_file_response = actions.register_plugin_file(
         client,
         plugin_id=plugin_response["id"],
         description="The plugin file with tasks.",
         filename="plugin_file.py",
         contents=contents,
-    ).get_json()
-    plugin_parameter_type_response = actions.register_plugin_parameter_type(
-        client,
-        name="plugin_parameter_type",
-        group_id=auth_account["default_group_id"],
-        structure=None,
-        description="The plugin parameter type used for the tasks.",
-    ).get_json()
-
-    plugin_task1: dict[str, Any] = {
-        "name": "plugin_task_one",
-        "input_params": [plugin_parameter_type_response],
-        "output_params": [plugin_parameter_type_response],
-    }
-    plugin_task2: dict[str, Any] = {
-        "name": "plugin_task_two",
-        "input_params": [plugin_parameter_type_response],
-        "output_params": [plugin_parameter_type_response],
-    }
-    plugin_task3: dict[str, Any] = {
-        "name": "plugin_task_three",
-        "input_params": [plugin_parameter_type_response],
-        "output_params": [plugin_parameter_type_response],
-    }
-
-    plugin_task_list = [plugin_task1, plugin_task2, plugin_task3]
-    plugin_file_with_tasks_response = actions.add_plugin_tasks_to_plugin_file(
-        client,
-        plugin_id=plugin_response["id"],
-        plugin_file_id=plugin_file_without_tasks_response["id"],
         tasks=plugin_task_list,
     ).get_json()
     return {
         "plugin": plugin_response,
-        "plugin_file": plugin_file_with_tasks_response,
-        "plugin_parameter_type": plugin_parameter_type_response,
-        "plugin_task1": plugin_task1,
-        "plugin_task2": plugin_task2,
-        "plugin_task3": plugin_task3,
-        "plugin_task_list": plugin_task_list,
+        "plugin_file": plugin_file_response,
+        "string_parameter_type": string_type_response,
+        "integer_parameter_type": integer_type_response,
+        "tasks": plugin_task_list,
     }
 
 


### PR DESCRIPTION
This commit updates the PluginIdFileService and PluginIdFileIdService classes in the service layer with support for plugin tasks. Plugin tasks can be registered when a new PluginFile object is created or added by modifying an existing PluginFile to include them. Additional changes that were made to implement the plugin task functionality include:

- Configuring several plugin ORM relationships with the `lazy="joined"` setting to ensure the related data is eagerly pulled and cached at query time. Existing queries that retrieved multiple PluginFile objects had to have the `.unique()` method appended to them.
- Creating helper functions for constructing PluginTask ORM objects and adding them to the database.
- Adding support to existing helper functions for processing PluginFile data containing PluginTask objects into response dicts.
- Activating support for creating and modifying plugin tasks in the controller layer.
- Updating and extending existing tests to exercise the plugin task support and to reflect the current usage patterns for adding and modifying plugin tasks via the plugin file sub-endpoints.

Other updates include:

- Replacing uses of `.scalars(stmt).first()` with `.scalar(stmt)`
- Renaming variables to improve readability.
- Pruning unused testing code from the code base.
- Updating and streamlining service layer documentation and error messages.
- Removing commented-out code.