### PR TITLE
feat: add search, drafts, snapshots, and tags to Experiments

### DIFF
--- a/src/dioptra/restapi/v1/experiments/schema.py
+++ b/src/dioptra/restapi/v1/experiments/schema.py
@@ -60,7 +60,7 @@ class ExperimentMutableFieldsSchema(Schema):
             description="A list of Entrypoint IDs.",
         ),
         load_only=True,
-        load_default=list,
+        load_default=list(),
     )
 
 
@@ -73,17 +73,6 @@ class ExperimentSchema(ExperimentMutableFieldsSchema, ExperimentBaseSchema):  # 
     from dioptra.restapi.v1.entrypoints.schema import EntrypointRefSchema
     from dioptra.restapi.v1.jobs.schema import JobRefSchema
 
-    tagIds = fields.List(
-        fields.Int(),
-        attribute="tag_ids",
-        data_key="tags",
-        allow_none=True,
-        metadata=dict(
-            description="A list of Tag IDs.",
-        ),
-        load_only=True,
-        load_default=list,
-    )
     entrypoints = fields.Nested(
         EntrypointRefSchema,
         attribute="entrypoints",
@@ -97,6 +86,19 @@ class ExperimentSchema(ExperimentMutableFieldsSchema, ExperimentBaseSchema):  # 
         many=True,
         metadata=dict(description="List of associated Jobs resources."),
         dump_only=True,
+    )
+
+
+class ExperimentDraftSchema(ExperimentMutableFieldsSchema, ExperimentBaseSchema):  # type: ignore
+    entrypointIds = fields.List(
+        fields.Int(),
+        attribute="entrypoint_ids",
+        data_key="entrypoints",
+        allow_none=True,
+        metadata=dict(
+            description="A list of Entrypoint IDs.",
+        ),
+        load_default=list(),
     )
 
 

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -23,15 +23,15 @@ from marshmallow import Schema
 from dioptra.restapi.db import models
 from dioptra.restapi.routes import V1_ROOT
 
-USERS: Final[str] = "users"
 ENTRYPOINTS: Final[str] = "entrypoints"
 EXPERIMENTS: Final[str] = "experiments"
 GROUPS: Final[str] = "groups"
-PLUGIN_PARAMETER_TYPES: Final[str] = "pluginParameterTypes"
 PLUGINS: Final[str] = "plugins"
 PLUGIN_FILES: Final[str] = "files"
+PLUGIN_PARAMETER_TYPES: Final[str] = "pluginParameterTypes"
 QUEUES: Final[str] = "queues"
 TAGS: Final[str] = "tags"
+USERS: Final[str] = "users"
 
 # -- Typed Dictionaries --------------------------------------------------------
 
@@ -116,6 +116,7 @@ def build_experiment_ref(experiment: models.Experiment) -> dict[str, Any]:
     return {
         "id": experiment.resource_id,
         "name": experiment.name,
+        "group": build_group_ref(experiment.resource.owner),
         "url": build_url(f"{EXPERIMENTS}/{experiment.resource_id}"),
     }
 
@@ -401,7 +402,7 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         The Experiment response dictionary.
     """
     experiment = experiment_dict["experiment"]
-    entrypoints = experiment_dict["entrypoints"]
+    entrypoints = experiment_dict.get("entrypoints", None)
     has_draft = experiment_dict.get("has_draft", None)
 
     data = {
@@ -409,7 +410,6 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         "snapshot_id": experiment.resource_snapshot_id,
         "name": experiment.name,
         "description": experiment.description,
-        "entrypoints": [build_entrypoint_ref(entrypoint) for entrypoint in entrypoints],
         "jobs": [],
         "user": build_user_ref(experiment.creator),
         "group": build_group_ref(experiment.resource.owner),
@@ -419,6 +419,11 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         == experiment.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in experiment.tags],
     }
+
+    if entrypoints is not None:
+        data["entrypoints"] = [
+            build_entrypoint_ref(entrypoint) for entrypoint in entrypoints
+        ]
 
     if has_draft is not None:
         data["has_draft"] = has_draft

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -121,8 +121,6 @@ def register_experiment(
 
     if description is not None:
         payload["description"] = description
-    else:
-        payload["description"] = ""
     if entrypoint_ids is not None:
         payload["entrypoints"] = entrypoint_ids
 


### PR DESCRIPTION
feat: add search, tags, drafts, and snapshots to Experiments

This feature adds the following funcionality to Experiments:
- search by name, description, or tag
- ability to manage (retriev, apply, and remove) tags
- ability to create drafts
- the ability to view the history of resource