### PR TITLE
Auto-register and protect built-in plugin task parameter types

### DIFF
--- a/src/dioptra/restapi/db/alembic/versions/d2bae5f6d991_add_readonly_resource_locks_to_pre_.py
+++ b/src/dioptra/restapi/db/alembic/versions/d2bae5f6d991_add_readonly_resource_locks_to_pre_.py
@@ -1,0 +1,266 @@
+"""Add 'readonly' resource locks to pre-existing built-in parameter types
+
+Revision ID: d2bae5f6d991
+Revises: 10f9e72e72aa
+Create Date: 2024-06-28 12:30:13.685590
+
+"""
+
+import datetime
+from typing import Annotated, Any, Optional
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    column_property,
+    mapped_column,
+    relationship,
+    sessionmaker,
+)
+
+from dioptra.restapi.db.custom_types import TZDateTime
+
+# revision identifiers, used by Alembic.
+revision = "d2bae5f6d991"
+down_revision = "10f9e72e72aa"
+branch_labels = None
+depends_on = None
+
+
+# Declare list of allowed simple built-in parameter types
+BUILTIN_PARAMETER_TYPES = ["any", "number", "integer", "string", "boolean", "null"]
+
+
+# Migration data models
+bigint = Annotated[
+    int, mapped_column(sa.BigInteger().with_variant(sa.Integer, "sqlite"))
+]
+intpk = Annotated[
+    int,
+    mapped_column(sa.BigInteger().with_variant(sa.Integer, "sqlite"), primary_key=True),
+]
+text_ = Annotated[str, mapped_column(sa.Text())]
+bool_ = Annotated[bool, mapped_column(sa.Boolean())]
+datetimetz = Annotated[datetime.datetime, mapped_column(TZDateTime())]
+optionalbigint = Annotated[
+    Optional[int],
+    mapped_column(sa.BigInteger().with_variant(sa.Integer, "sqlite"), nullable=True),
+]
+optionaljson_ = Annotated[Optional[dict[str, Any]], mapped_column(sa.JSON)]
+optionalstr = Annotated[Optional[str], mapped_column(sa.Text(), nullable=True)]
+
+
+class UpgradeBase(DeclarativeBase, MappedAsDataclass):
+    pass
+
+
+class GroupUpgrade(UpgradeBase):
+    __tablename__ = "groups"
+
+    # Database fields
+    group_id: Mapped[intpk] = mapped_column(init=False)
+    name: Mapped[text_] = mapped_column(nullable=False)
+    user_id: Mapped[bigint] = mapped_column(nullable=False)
+
+
+class ResourceSnapshotUpgrade(UpgradeBase):
+    __tablename__ = "resource_snapshots"
+
+    # Database fields
+    resource_snapshot_id: Mapped[intpk] = mapped_column(init=False)
+    resource_id: Mapped[bigint] = mapped_column(nullable=False)
+    resource_type: Mapped[text_] = mapped_column(nullable=False)
+    user_id: Mapped[bigint] = mapped_column(nullable=False)
+    description: Mapped[optionalstr] = mapped_column()
+    created_on: Mapped[datetimetz] = mapped_column(init=False, nullable=False)
+
+    # Initialize default values using dataclass __post_init__ method
+    # https://docs.python.org/3/library/dataclasses.html#dataclasses.__post_init__
+    def __post_init__(self) -> None:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.created_on = timestamp
+
+
+class ResourceLockUpgrade(UpgradeBase):
+    __tablename__ = "resource_locks"
+
+    # Database fields
+    resource_id: Mapped[intpk] = mapped_column(sa.ForeignKey("resources.resource_id"))
+    resource_lock_type: Mapped[text_] = mapped_column(primary_key=True)
+    created_on: Mapped[datetimetz] = mapped_column(init=False, nullable=False)
+
+    # Relationships
+    resource: Mapped["ResourceUpgrade"] = relationship(
+        init=False, back_populates="locks"
+    )
+
+    # Initialize default values using dataclass __post_init__ method
+    # https://docs.python.org/3/library/dataclasses.html#dataclasses.__post_init__
+    def __post_init__(self) -> None:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.created_on = timestamp
+
+
+class ResourceUpgrade(UpgradeBase):
+    __tablename__ = "resources"
+
+    # Database fields
+    resource_id: Mapped[intpk] = mapped_column(init=False)
+    group_id: Mapped[bigint] = mapped_column(nullable=False)
+    resource_type: Mapped[text_] = mapped_column(nullable=False)
+    created_on: Mapped[datetimetz] = mapped_column(init=False, nullable=False)
+
+    # Derived fields (read-only)
+    is_deleted: Mapped[bool] = column_property(
+        sa.select(ResourceLockUpgrade.resource_id)
+        .where(
+            ResourceLockUpgrade.resource_id == resource_id,
+            ResourceLockUpgrade.resource_lock_type == "delete",
+        )
+        .correlate_except(ResourceLockUpgrade)
+        .exists()
+    )
+    is_readonly: Mapped[bool] = column_property(
+        sa.select(ResourceLockUpgrade.resource_id)
+        .where(
+            ResourceLockUpgrade.resource_id == resource_id,
+            ResourceLockUpgrade.resource_lock_type == "readonly",
+        )
+        .correlate_except(ResourceLockUpgrade)
+        .exists()
+    )
+    latest_snapshot_id: Mapped[optionalbigint] = column_property(
+        sa.Nullable(
+            sa.select(ResourceSnapshotUpgrade.resource_snapshot_id)
+            .where(ResourceSnapshotUpgrade.resource_id == resource_id)
+            .order_by(ResourceSnapshotUpgrade.created_on.desc())
+            .limit(1)
+            .correlate_except(ResourceSnapshotUpgrade)
+            .scalar_subquery()
+        )
+    )
+
+    # Relationships
+    locks: Mapped[list["ResourceLockUpgrade"]] = relationship(
+        init=False, back_populates="resource"
+    )
+
+    # Initialize default values using dataclass __post_init__ method
+    # https://docs.python.org/3/library/dataclasses.html#dataclasses.__post_init__
+    def __post_init__(self) -> None:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.created_on = timestamp
+
+
+class PluginTaskParameterTypeUpgrade(UpgradeBase):
+    __tablename__ = "plugin_task_parameter_types"
+
+    # Database fields
+    resource_snapshot_id: Mapped[intpk]
+    resource_id: Mapped[bigint] = mapped_column(nullable=False)
+    name: Mapped[text_] = mapped_column(nullable=False)
+    structure: Mapped[optionaljson_] = mapped_column(nullable=True)
+
+
+def upgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    bind = op.get_bind()
+    Session = sessionmaker(bind=bind)
+
+    with Session() as session:
+        # Search for built-in simple types that are in the database already and haven't
+        # been marked as deleted and don't have a "readonly" lock set. Set a "readonly"
+        # lock on any records found that match this criteria.
+        param_types_no_readonly_locks_stmt = (
+            sa.select(PluginTaskParameterTypeUpgrade.resource_id)
+            .join(
+                ResourceUpgrade,
+                PluginTaskParameterTypeUpgrade.resource_id
+                == ResourceUpgrade.resource_id,
+            )
+            .where(
+                PluginTaskParameterTypeUpgrade.name.in_(BUILTIN_PARAMETER_TYPES),
+                ResourceUpgrade.is_deleted == False,  # noqa: E712
+                ResourceUpgrade.is_readonly == False,  # noqa: E712
+                ResourceUpgrade.latest_snapshot_id
+                == PluginTaskParameterTypeUpgrade.resource_snapshot_id,
+            )
+        )
+
+        for resource_id in session.scalars(param_types_no_readonly_locks_stmt):
+            resource_lock = ResourceLockUpgrade(
+                resource_id=resource_id, resource_lock_type="readonly"
+            )
+            session.add(resource_lock)
+
+        # Get information about the default public group.
+        public_group = session.scalar(
+            sa.select(GroupUpgrade).where(GroupUpgrade.name == "public")
+        )
+
+        # If the public group already exists, then get a list of the built-in simple
+        # types that are already registered in the public group. Figure out which
+        # built-in types are still missing, register them, and mark them as readonly.
+        if public_group:
+            existing_builtin_param_types_stmt = (
+                sa.select(PluginTaskParameterTypeUpgrade.name)
+                .join(
+                    ResourceUpgrade,
+                    PluginTaskParameterTypeUpgrade.resource_id
+                    == ResourceUpgrade.resource_id,
+                )
+                .where(
+                    PluginTaskParameterTypeUpgrade.name.in_(BUILTIN_PARAMETER_TYPES),
+                    ResourceUpgrade.group_id == public_group.group_id,
+                    ResourceUpgrade.is_deleted == False,  # noqa: E712
+                    ResourceUpgrade.latest_snapshot_id
+                    == PluginTaskParameterTypeUpgrade.resource_snapshot_id,
+                )
+            )
+            existing_builtin_param_types = list(
+                session.scalars(existing_builtin_param_types_stmt).all()
+            )
+            missing_builtin_param_types = [
+                x
+                for x in BUILTIN_PARAMETER_TYPES
+                if x not in set(existing_builtin_param_types)
+            ]
+
+            for builtin_type in missing_builtin_param_types:
+                resource = ResourceUpgrade(
+                    group_id=public_group.group_id,
+                    resource_type="plugin_task_parameter_type",
+                )
+                session.add(resource)
+                session.flush()
+                resource_snapshot = ResourceSnapshotUpgrade(
+                    resource_id=resource.resource_id,
+                    resource_type="plugin_task_parameter_type",
+                    user_id=public_group.user_id,
+                    description=None,
+                )
+                session.add(resource_snapshot)
+                session.flush()
+                param_type = PluginTaskParameterTypeUpgrade(
+                    resource_snapshot_id=resource_snapshot.resource_snapshot_id,
+                    resource_id=resource.resource_id,
+                    name=builtin_type,
+                    structure=None,
+                )
+                resource_lock = ResourceLockUpgrade(
+                    resource_id=resource.resource_id, resource_lock_type="readonly"
+                )
+                session.add(param_type)
+                session.add(resource_lock)
+                session.flush()
+
+        session.commit()
+
+
+def downgrade():
+    # No downgrade necessary, the readonly locks are simply ignored and hidden when
+    # using previous commits.
+    pass

--- a/src/dioptra/restapi/v1/plugin_parameter_types/errors.py
+++ b/src/dioptra/restapi/v1/plugin_parameter_types/errors.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 from flask_restx import Api
 
 
+class PluginParameterTypeMatchesBuiltinTypeError(Exception):
+    """The plugin parameter type name cannot match a built-in type."""
+
+
 class PluginParameterTypeAlreadyExistsError(Exception):
     """The plugin parameter type name already exists."""
 
@@ -28,8 +32,8 @@ class PluginParameterTypeDoesNotExistError(Exception):
     """The requested plugin parameter type does not exist."""
 
 
-class PluginParameterTypeLockedError(Exception):
-    """The requested plugin parameter type is locked."""
+class PluginParameterTypeReadOnlyLockError(Exception):
+    """The plugin parameter type has a read-only lock and cannot be modified."""
 
 
 class PluginParameterTypeMissingParameterError(Exception):
@@ -37,6 +41,13 @@ class PluginParameterTypeMissingParameterError(Exception):
 
 
 def register_error_handlers(api: Api) -> None:
+    @api.errorhandler(PluginParameterTypeMatchesBuiltinTypeError)
+    def handle_plugin_parameter_type_matches_builtin_type_error(error):
+        return {
+            "message": "Bad Request - The requested plugin parameter type name "
+            "matches a built-in type. Please select another and resubmit."
+        }, 400
+
     @api.errorhandler(PluginParameterTypeDoesNotExistError)
     def handle_plugin_parameter_type_does_not_exist_error(error):
         return {
@@ -44,10 +55,11 @@ def register_error_handlers(api: Api) -> None:
             "not exist"
         }, 404
 
-    @api.errorhandler(PluginParameterTypeLockedError)
-    def handle_plugin_parameter_type_locked_error(error):
+    @api.errorhandler(PluginParameterTypeReadOnlyLockError)
+    def handle_plugin_parameter_type_read_only_lock_error(error):
         return {
-            "message": "Forbidden - The requested plugin parameter type is locked."
+            "message": "Forbidden - The plugin parameter type has a read-only "
+            "lock and cannot be modified."
         }, 403
 
     @api.errorhandler(PluginParameterTypeMissingParameterError)

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -337,6 +337,14 @@ def get_public_group(client: FlaskClient) -> TestResponse:
     return client.get(f"/{V1_ROOT}/{V1_GROUPS_ROUTE}/1", follow_redirects=True)
 
 
+def get_plugin_parameter_types(client: FlaskClient) -> TestResponse:
+    response = client.get(
+        f"/{V1_ROOT}/{V1_PLUGIN_PARAMETER_TYPES_ROUTE}",
+        follow_redirects=True,
+    )
+    return response
+
+
 def get_draft(
     client: FlaskClient,
     resource_route: str,

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -224,9 +224,7 @@ def registered_plugin_with_file_and_tasks(
     ).get_json()
     hello_world_task = {
         "name": "hello_world",
-        "inputParams": [
-            {"name": "name", "parameterType": string_type_response["id"]}
-        ],
+        "inputParams": [{"name": "name", "parameterType": string_type_response["id"]}],
         "outputParams": [
             {
                 "name": "hello_world_message",
@@ -236,9 +234,7 @@ def registered_plugin_with_file_and_tasks(
     }
     add_one_task = {
         "name": "add_one",
-        "inputParams": [
-            {"name": "x", "parameterType": integer_type_response["id"]}
-        ],
+        "inputParams": [{"name": "x", "parameterType": integer_type_response["id"]}],
         "outputParams": [
             {
                 "name": "value",
@@ -322,29 +318,36 @@ def registered_groups(
 def registered_plugin_parameter_types(
     client: FlaskClient, db: SQLAlchemy, auth_account: dict[str, Any]
 ) -> dict[str, Any]:
+    built_in_types = {"any", "number", "integer", "string", "boolean", "null"}
+    response = actions.get_plugin_parameter_types(client).get_json()
+    built_in_types_dict = {
+        param_type["name"]: param_type
+        for param_type in response["data"]
+        if param_type["name"] in built_in_types
+    }
     plugin_param_type1_response = actions.register_plugin_parameter_type(
         client,
-        name="int",
+        name="image_shape",
         group_id=auth_account["groups"][0]["id"],
-        structure=dict(),
-        description="The first parameter type.",
+        structure={"list": ["integer"]},
+        description="The dimensions of an image",
     ).get_json()
     plugin_param_type2_response = actions.register_plugin_parameter_type(
         client,
-        name="integer",
+        name="model_output",
         group_id=auth_account["groups"][0]["id"],
-        structure=dict(),
-        description="The second parameter type.",
+        structure=dict({"list": ["float"]}),
+        description="The softmax scores from a model",
     ).get_json()
-    # This is intentionally named using a different pattern for search query testing
     plugin_param_type3_response = actions.register_plugin_parameter_type(
         client,
-        name="string",
+        name="model",
         group_id=auth_account["groups"][0]["id"],
         structure=dict(),
-        description="Not retrieved.",
+        description="Opaque type for an ml model",
     ).get_json()
     return {
+        **built_in_types_dict,
         "plugin_param_type1": plugin_param_type1_response,
         "plugin_param_type2": plugin_param_type2_response,
         "plugin_param_type3": plugin_param_type3_response,

--- a/tests/unit/restapi/v1/test_plugin_parameter_type.py
+++ b/tests/unit/restapi/v1/test_plugin_parameter_type.py
@@ -441,18 +441,18 @@ def test_plugin_parameter_type_search_query(
     - The returned lists of plugin parameter types match the searches provided
       during both submissions.
     """
-    plugin_param_type_expected_list = list(registered_plugin_parameter_types.values())[
-        :2
-    ]
     assert_retrieving_plugin_parameter_types_works(
         client,
-        expected=plugin_param_type_expected_list,
-        search='description:"*parameter type*"',
+        expected=[registered_plugin_parameter_types["string"]],
+        search="name:string",
     )
     assert_retrieving_plugin_parameter_types_works(
         client,
-        expected=plugin_param_type_expected_list,
-        search="*parameter type*, name:*int*",
+        expected=[
+            registered_plugin_parameter_types["plugin_param_type2"],
+            registered_plugin_parameter_types["plugin_param_type3"],
+        ],
+        search="*model*",
     )
     plugin_param_type_expected_list = list(registered_plugin_parameter_types.values())
     assert_retrieving_plugin_parameter_types_works(


### PR DESCRIPTION
This update makes it so that the 6 built-in plugin task parameter types, "any", "number", "integer", "string", "boolean", and "null", are automatically registered and protected with a readonly lock immediately after the default public group is created (currently, this happens when the first user account is created). The plugin parameter types endpoint has been updated to prevent users from creating new plugin parameter types with case-insensitive names that match the built-in types. The endpoint has also been updated to check for the presence of the readonly lock to prevent modification in PUT requests.

In addition, an alembic migration script has been added that:

1. Scans the database for existing parameter types that match the built-ins and sets a read-only lock on them.
2. Checks if the public group exists and, if so, registers any missing built-in parameter types.