### PR TITLE
V1 schema fixes

### DIFF
--- a/src/dioptra/restapi/v1/entrypoints/controller.py
+++ b/src/dioptra/restapi/v1/entrypoints/controller.py
@@ -397,12 +397,12 @@ EntrypointDraftResource = generate_resource_drafts_endpoint(
 EntrypointDraftIdResource = generate_resource_drafts_id_endpoint(
     api,
     resource_name=RESOURCE_TYPE,
-    request_schema=EntrypointDraftSchema,
+    request_schema=EntrypointDraftSchema(exclude=["groupId"]),
 )
 EntrypointIdDraftResource = generate_resource_id_draft_endpoint(
     api,
     resource_name=RESOURCE_TYPE,
-    request_schema=EntrypointDraftSchema,
+    request_schema=EntrypointDraftSchema(exclude=["groupId"]),
 )
 
 EntrypointSnapshotsResource = generate_resource_snapshots_endpoint(

--- a/src/dioptra/restapi/v1/experiments/controller.py
+++ b/src/dioptra/restapi/v1/experiments/controller.py
@@ -407,12 +407,12 @@ ExperimentDraftResource = generate_resource_drafts_endpoint(
 ExperimentDraftIdResource = generate_resource_drafts_id_endpoint(
     api,
     resource_name=RESOURCE_TYPE,
-    request_schema=ExperimentDraftSchema,
+    request_schema=ExperimentDraftSchema(exclude=["groupId"]),
 )
 ExperimentIdDraftResource = generate_resource_id_draft_endpoint(
     api,
     resource_name=RESOURCE_TYPE,
-    request_schema=ExperimentDraftSchema,
+    request_schema=ExperimentDraftSchema(exclude=["groupId"]),
 )
 
 ExperimentSnapshotsResource = generate_resource_snapshots_endpoint(

--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -46,6 +46,7 @@ def generate_base_resource_schema(name: str, snapshot: bool) -> type[Schema]:
                 description=f"ID of the Group that will own the {name} resource."
             ),
             load_only=True,
+            required=True,
         ),
         "group": fields.Nested(
             GroupRefSchema,

--- a/src/dioptra/restapi/v1/shared/drafts/controller.py
+++ b/src/dioptra/restapi/v1/shared/drafts/controller.py
@@ -60,6 +60,13 @@ def generate_resource_drafts_endpoint(
         The generated Resource class
     """
 
+    if isinstance(request_schema, Schema):
+        model_name = "Drafts" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "Drafts" + "".join(request_schema.__name__.rsplit("Schema", 1))
+
     @api.route("/drafts/")
     class ResourceDraftsEndpoint(Resource):
         @inject
@@ -110,7 +117,7 @@ def generate_resource_drafts_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def post(self):
             """Creates a Draft for the resource."""
@@ -138,6 +145,13 @@ def generate_resource_drafts_id_endpoint(
     Returns:
         The generated Resource class
     """
+
+    if isinstance(request_schema, Schema):
+        model_name = "DraftsId" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "DraftsId" + "".join(request_schema.__name__.rsplit("Schema", 1))
 
     @api.route("/drafts/<int:draftId>")
     @api.param("draftId", f"ID for the Draft of the {resource_name} resource.")
@@ -167,7 +181,7 @@ def generate_resource_drafts_id_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def put(self, draftId: int):
             """Modifies a Draft for the resource."""
@@ -207,6 +221,13 @@ def generate_resource_id_draft_endpoint(
         The generated Resource class
     """
 
+    if isinstance(request_schema, Schema):
+        model_name = "Draft" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "Draft" + "".join(request_schema.__name__.rsplit("Schema", 1))
+
     @api.route("/<int:id>/draft")
     @api.param("id", "ID for the resource.")
     class ResourcesIdDraftEndpoint(Resource):
@@ -235,7 +256,7 @@ def generate_resource_id_draft_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def post(self, id: int):
             """Creates a Draft for this resource."""
@@ -251,7 +272,7 @@ def generate_resource_id_draft_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def put(self, id: int):
             """Modifies the Draft for this resource."""
@@ -298,6 +319,15 @@ def generate_nested_resource_drafts_endpoint(
     Returns:
         The generated Resource class
     """
+
+    if isinstance(request_schema, Schema):
+        model_name = "NestedDrafts" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "NestedDrafts" + "".join(
+            request_schema.__name__.rsplit("Schema", 1)
+        )
 
     @api.route(f"/<int:id>/{resource_route}/drafts/")
     class ResourceDraftsEndpoint(Resource):
@@ -349,7 +379,7 @@ def generate_nested_resource_drafts_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def post(self, id: int):
             """Creates a Draft for the resource."""
@@ -382,6 +412,15 @@ def generate_nested_resource_drafts_id_endpoint(
         The generated Resource class
     """
 
+    if isinstance(request_schema, Schema):
+        model_name = "NestedDraftsId" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "NestedDraftsId" + "".join(
+            request_schema.__name__.rsplit("Schema", 1)
+        )
+
     @api.route(f"/<int:id>/{resource_route}/drafts/<int:draftId>")
     @api.param("draftId", f"ID for the Draft of the {resource_name} resource.")
     class ResourcesDraftsIdEndpoint(Resource):
@@ -410,7 +449,7 @@ def generate_nested_resource_drafts_id_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def put(self, id: int, draftId: int):
             """Modifies a Draft for the resource."""
@@ -457,6 +496,15 @@ def generate_nested_resource_id_draft_endpoint(
     route_singular = resource_route[:-1]
     resource_id = f"{route_singular}Id"
 
+    if isinstance(request_schema, Schema):
+        model_name = "NestedDraft" + "".join(
+            request_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "NestedDraft" + "".join(
+            request_schema.__name__.rsplit("Schema", 1)
+        )
+
     @api.route(f"/<int:id>/{resource_route}/<int:{resource_id}>/draft")
     @api.param("id", "ID for the resource.")
     class ResourcesIdDraftEndpoint(Resource):
@@ -495,7 +543,7 @@ def generate_nested_resource_id_draft_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def post(self, id: int, **kwargs):
             """Creates a Draft for this resource."""
@@ -521,7 +569,7 @@ def generate_nested_resource_id_draft_endpoint(
             )
 
         @login_required
-        @accepts(schema=request_schema, api=api)
+        @accepts(schema=request_schema, model_name=model_name, api=api)
         @responds(schema=DraftSchema, api=api)
         def put(self, id: int, **kwargs):
             """Modifies the Draft for this resource."""

--- a/src/dioptra/restapi/v1/shared/drafts/controller.py
+++ b/src/dioptra/restapi/v1/shared/drafts/controller.py
@@ -60,6 +60,7 @@ def generate_resource_drafts_endpoint(
         The generated Resource class
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "Drafts" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)
@@ -146,6 +147,7 @@ def generate_resource_drafts_id_endpoint(
         The generated Resource class
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "DraftsId" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)
@@ -221,6 +223,7 @@ def generate_resource_id_draft_endpoint(
         The generated Resource class
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "Draft" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)
@@ -320,6 +323,7 @@ def generate_nested_resource_drafts_endpoint(
         The generated Resource class
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "NestedDrafts" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)
@@ -412,6 +416,7 @@ def generate_nested_resource_drafts_id_endpoint(
         The generated Resource class
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "NestedDraftsId" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)
@@ -496,6 +501,7 @@ def generate_nested_resource_id_draft_endpoint(
     route_singular = resource_route[:-1]
     resource_id = f"{route_singular}Id"
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(request_schema, Schema):
         model_name = "NestedDraft" + "".join(
             request_schema.__class__.__name__.rsplit("Schema", 1)

--- a/src/dioptra/restapi/v1/shared/drafts/service.py
+++ b/src/dioptra/restapi/v1/shared/drafts/service.py
@@ -401,9 +401,6 @@ class ResourceIdDraftService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        log.info(
-            "CREATE DRAFT", resource_id=resource_id, resource_type=self._resource_type
-        )
         stmt = select(models.Resource).filter_by(
             resource_id=resource_id, resource_type=self._resource_type, is_deleted=False
         )

--- a/src/dioptra/restapi/v1/shared/snapshots/controller.py
+++ b/src/dioptra/restapi/v1/shared/snapshots/controller.py
@@ -63,6 +63,13 @@ def generate_resource_snapshots_endpoint(
         The parameterized ResourceSnapshotsEndpoint class.
     """
 
+    if isinstance(page_schema, Schema):
+        model_name = "Snapshots" + "".join(
+            page_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "Snapshots" + "".join(page_schema.__name__.rsplit("Schema", 1))
+
     @api.route("/<int:id>/snapshots")
     @api.param("id", f"ID for the {resource_name} resource.")
     class ResourceSnapshotsEndpoint(Resource):
@@ -82,7 +89,7 @@ def generate_resource_snapshots_endpoint(
 
         @login_required
         @accepts(query_params_schema=ResourceGetQueryParameters, api=api)
-        @responds(schema=page_schema, api=api)
+        @responds(schema=page_schema, model_name=model_name, api=api)
         def get(self, id: int):
             """Gets the Snapshots for the resource."""
             log = LOGGER.new(
@@ -142,6 +149,15 @@ def generate_resource_snapshots_id_endpoint(
         The parameterized ResourceSnapshotsIdEndpoint class.
     """
 
+    if isinstance(response_schema, Schema):
+        model_name = "SnapshotsId" + "".join(
+            response_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "SnapshotsId" + "".join(
+            response_schema.__name__.rsplit("Schema", 1)
+        )
+
     @api.route("/<int:id>/snapshots/<int:snapshotId>")
     @api.param("id", f"ID for the {resource_name} resource.")
     @api.param("snapshotId", f"Snapshot ID for the {resource_name} resource.")
@@ -160,7 +176,7 @@ def generate_resource_snapshots_id_endpoint(
             super().__init__(*args, **kwargs)
 
         @login_required
-        @responds(schema=response_schema, api=api)
+        @responds(schema=response_schema, model_name=model_name, api=api)
         def get(self, id: int, snapshotId: int):
             """Gets a Snapshot for the resource by snapshot id."""
             log = LOGGER.new(
@@ -204,6 +220,15 @@ def generate_nested_resource_snapshots_endpoint(
         The parameterized ResourceSnapshotsEndpoint class.
     """
 
+    if isinstance(page_schema, Schema):
+        model_name = "NestedSnapshots" + "".join(
+            page_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "NestedSnapshots" + "".join(
+            page_schema.__name__.rsplit("Schema", 1)
+        )
+
     route_singular = resource_route[:-1]
     resource_id = f"{route_singular}Id"
 
@@ -227,7 +252,7 @@ def generate_nested_resource_snapshots_endpoint(
 
         @login_required
         @accepts(query_params_schema=ResourceGetQueryParameters, api=api)
-        @responds(schema=page_schema, api=api)
+        @responds(schema=page_schema, model_name=model_name, api=api)
         def get(self, id: int, **kwargs):
             """Gets the Snapshots for the resource."""
             log = LOGGER.new(
@@ -301,6 +326,15 @@ def generate_nested_resource_snapshots_id_endpoint(
     route_singular = resource_route[:-1]
     resource_id = f"{route_singular}Id"
 
+    if isinstance(response_schema, Schema):
+        model_name = "NestedSnapshotsId" + "".join(
+            response_schema.__class__.__name__.rsplit("Schema", 1)
+        )
+    else:
+        model_name = "NestedSnapshotsId" + "".join(
+            response_schema.__name__.rsplit("Schema", 1)
+        )
+
     @api.route(
         f"/<int:id>/{resource_route}/<int:{resource_id}>/snapshots/<int:snapshotId>"
     )
@@ -322,7 +356,7 @@ def generate_nested_resource_snapshots_id_endpoint(
             super().__init__(*args, **kwargs)
 
         @login_required
-        @responds(schema=response_schema, api=api)
+        @responds(schema=response_schema, model_name=model_name, api=api)
         def get(self, id: int, snapshotId: int, **kwargs):
             """Gets a Snapshot for the resource by snapshot id."""
             log = LOGGER.new(

--- a/src/dioptra/restapi/v1/shared/snapshots/controller.py
+++ b/src/dioptra/restapi/v1/shared/snapshots/controller.py
@@ -63,6 +63,7 @@ def generate_resource_snapshots_endpoint(
         The parameterized ResourceSnapshotsEndpoint class.
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(page_schema, Schema):
         model_name = "Snapshots" + "".join(
             page_schema.__class__.__name__.rsplit("Schema", 1)
@@ -149,6 +150,7 @@ def generate_resource_snapshots_id_endpoint(
         The parameterized ResourceSnapshotsIdEndpoint class.
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(response_schema, Schema):
         model_name = "SnapshotsId" + "".join(
             response_schema.__class__.__name__.rsplit("Schema", 1)
@@ -220,6 +222,7 @@ def generate_nested_resource_snapshots_endpoint(
         The parameterized ResourceSnapshotsEndpoint class.
     """
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(page_schema, Schema):
         model_name = "NestedSnapshots" + "".join(
             page_schema.__class__.__name__.rsplit("Schema", 1)
@@ -326,6 +329,7 @@ def generate_nested_resource_snapshots_id_endpoint(
     route_singular = resource_route[:-1]
     resource_id = f"{route_singular}Id"
 
+    # Based on: https://github.com/apryor6/flask_accepts/blob/05567461c421a534d6fc6e122d5e086b0b0e53aa/flask_accepts/utils.py#L154-L160  # noqa: B950
     if isinstance(response_schema, Schema):
         model_name = "NestedSnapshotsId" + "".join(
             response_schema.__class__.__name__.rsplit("Schema", 1)


### PR DESCRIPTION
This PR includes the following fixes:

    fix: set custom schema names to avoid name clashes in swagger

    This commit sets custom schema model names in generated subendpoint
    Resource classes. flask accepts autogenerates these names by default,
    but name clashes can occur when variations of a schema are used across
    different endpoints (e.g. when using exclude to remove a field), which
    was causing incorrect documentation in swagger.

    fix: exclude groupId from draft schema where it should be inferred

    fix: make group required in base resource load schema
