### PR TITLE
Add the workflows/jobFilesDownload API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,4 @@ package-lock.json
 !docker/**/etc
 !tests/**/lib
 !src/**/tags
+!src/**/lib

--- a/src/dioptra/restapi/routes.py
+++ b/src/dioptra/restapi/routes.py
@@ -45,6 +45,7 @@ V1_PLUGINS_ROUTE = "plugins"
 V1_QUEUES_ROUTE = "queues"
 V1_TAGS_ROUTE = "tags"
 V1_USERS_ROUTE = "users"
+V1_WORKFLOWS_ROUTE = "workflows"
 
 
 def register_routes(api: Api, restapi_version: str) -> None:
@@ -98,6 +99,7 @@ def register_v1_routes(api: Api) -> None:
     from .v1.queues.controller import api as queues_api
     from .v1.tags.controller import api as tags_api
     from .v1.users.controller import api as users_api
+    from .v1.workflows.controller import api as workflows_api
 
     api.add_namespace(auth_api, path=f"/{V1_ROOT}/{V1_AUTH_ROUTE}")
     api.add_namespace(artifacts_api, path=f"/{V1_ROOT}/{V1_ARTIFACTS_ROUTE}")
@@ -113,3 +115,4 @@ def register_v1_routes(api: Api) -> None:
     api.add_namespace(queues_api, path=f"/{V1_ROOT}/{V1_QUEUES_ROUTE}")
     api.add_namespace(tags_api, path=f"/{V1_ROOT}/{V1_TAGS_ROUTE}")
     api.add_namespace(users_api, path=f"/{V1_ROOT}/{V1_USERS_ROUTE}")
+    api.add_namespace(workflows_api, path=f"/{V1_ROOT}/{V1_WORKFLOWS_ROUTE}")

--- a/src/dioptra/restapi/v1/workflows/__init__.py
+++ b/src/dioptra/restapi/v1/workflows/__init__.py
@@ -1,0 +1,19 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from .controller import api
+
+__all__ = ["api"]

--- a/src/dioptra/restapi/v1/workflows/controller.py
+++ b/src/dioptra/restapi/v1/workflows/controller.py
@@ -1,0 +1,80 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The module defining the endpoints for Workflow resources."""
+import uuid
+
+import structlog
+from flask import request, send_file
+from flask_accepts import accepts
+from flask_login import login_required
+from flask_restx import Namespace, Resource
+from injector import inject
+from structlog.stdlib import BoundLogger
+
+from .schema import FileTypes, JobFilesDownloadQueryParametersSchema
+from .service import JobFilesDownloadService
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+api: Namespace = Namespace("Workflows", description="Workflows endpoint")
+
+
+@api.route("/jobFilesDownload")
+class JobFilesDownloadEndpoint(Resource):
+    @inject
+    def __init__(
+        self, job_files_download_service: JobFilesDownloadService, *args, **kwargs
+    ) -> None:
+        """Initialize the workflow resource.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            job_files_download_service: A JobFilesDownloadService object.
+        """
+        self._job_files_download_service = job_files_download_service
+        super().__init__(*args, **kwargs)
+
+    @login_required
+    @accepts(query_params_schema=JobFilesDownloadQueryParametersSchema, api=api)
+    def get(self):
+        """Download a compressed file archive containing the files needed to execute a submitted job."""  # noqa: B950
+        log = LOGGER.new(  # noqa: F841
+            request_id=str(uuid.uuid4()),
+            resource="JobFilesDownload",
+            request_type="GET",
+        )
+        mimetype = {
+            FileTypes.TAR_GZ: "application/gzip",
+            FileTypes.ZIP: "application/zip",
+        }
+        download_name = {
+            FileTypes.TAR_GZ: "job_files.tar.gz",
+            FileTypes.ZIP: "job_files.zip",
+        }
+        parsed_query_params = request.parsed_query_params  # noqa: F841
+        job_files_download_package = self._job_files_download_service.get(
+            job_id=parsed_query_params["job_id"],
+            file_type=parsed_query_params["file_type"],
+            log=log,
+        )
+        return send_file(
+            path_or_file=job_files_download_package.name,
+            as_attachment=True,
+            mimetype=mimetype[parsed_query_params["file_type"]],
+            download_name=download_name[parsed_query_params["file_type"]],
+        )

--- a/src/dioptra/restapi/v1/workflows/errors.py
+++ b/src/dioptra/restapi/v1/workflows/errors.py
@@ -1,0 +1,30 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""Error handlers for the workflows endpoints."""
+from __future__ import annotations
+
+from flask_restx import Api
+
+
+class JobEntryPointDoesNotExistError(Exception):
+    """The job's entry point does not exist."""
+
+
+def register_error_handlers(api: Api) -> None:
+    @api.errorhandler(JobEntryPointDoesNotExistError)
+    def handle_experiment_job_does_not_exist_error(error):
+        return {"message": "Not Found - The job's entry point does not exist"}, 404

--- a/src/dioptra/restapi/v1/workflows/lib/__init__.py
+++ b/src/dioptra/restapi/v1/workflows/lib/__init__.py
@@ -1,0 +1,27 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from . import views
+from .export_plugin_files import export_plugin_files
+from .export_task_engine_yaml import export_task_engine_yaml
+from .package_job_files import package_job_files
+
+__all__ = [
+    "views",
+    "export_plugin_files",
+    "export_task_engine_yaml",
+    "package_job_files",
+]

--- a/src/dioptra/restapi/v1/workflows/lib/export_plugin_files.py
+++ b/src/dioptra/restapi/v1/workflows/lib/export_plugin_files.py
@@ -1,0 +1,56 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from pathlib import Path
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import models
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+
+def export_plugin_files(
+    entry_point_plugin_files: list[models.EntryPointPluginFile],
+    plugins_base_dir: Path,
+    logger: BoundLogger | None = None,
+) -> list[Path]:
+    """Export an entrypoint's plugin files and folders in a specified directory.
+
+    Args:
+        entry_point_plugin_files: A list of entrypoint plugin files to be exported.
+        plugins_base_dir: The base directory to save the plugin files and folders in.
+        logger: A structlog logger object.
+
+    Returns:
+        A list of paths pointing to the exported plugin directories.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    plugin_dirs: set[Path] = set()
+
+    for entry_point_plugin_file in entry_point_plugin_files:
+        plugin = entry_point_plugin_file.plugin
+        plugin_file = entry_point_plugin_file.plugin_file
+
+        plugin_path = plugins_base_dir / plugin.name
+        plugin_dirs.add(plugin_path)
+
+        plugin_path.mkdir(parents=True, exist_ok=True)
+        (plugin_path / plugin_file.filename).parent.mkdir(parents=True, exist_ok=True)
+        (plugin_path / plugin_file.filename).write_text(plugin_file.contents or "")
+
+    return list(plugin_dirs)

--- a/src/dioptra/restapi/v1/workflows/lib/export_task_engine_yaml.py
+++ b/src/dioptra/restapi/v1/workflows/lib/export_task_engine_yaml.py
@@ -1,0 +1,184 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from pathlib import Path
+from typing import Any, Final, cast
+
+import structlog
+import yaml
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import models
+from dioptra.task_engine.type_registry import BUILTIN_TYPES
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+YAML_FILE_ENCODING: Final[str] = "utf-8"
+YAML_EXPORT_SETTINGS: Final[dict[str, Any]] = {
+    "indent": 2,
+    "sort_keys": False,
+    "encoding": YAML_FILE_ENCODING,
+}
+
+
+def export_task_engine_yaml(
+    entrypoint: models.EntryPoint,
+    entry_point_plugin_files: list[models.EntryPointPluginFile],
+    base_dir: Path,
+    logger: BoundLogger | None = None,
+) -> Path:
+    """Export an entrypoint's task engine YAML file to a specified directory.
+
+    Args:
+        entrypoint: The entrypoint to export.
+        entry_point_plugin_files: The entrypoint's plugin files.
+        base_dir: The directory to export the task engine YAML file to.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The path to the exported task engine YAML file.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    task_yaml_path = Path(base_dir, entrypoint.name).with_suffix(".yml")
+    task_engine_dict = build_task_engine_dict(
+        entrypoint=entrypoint, entry_point_plugin_files=entry_point_plugin_files
+    )
+
+    with task_yaml_path.open("wt", encoding=YAML_FILE_ENCODING) as f:
+        yaml.safe_dump(task_engine_dict, f, **YAML_EXPORT_SETTINGS)
+
+    return task_yaml_path
+
+
+def build_task_engine_dict(
+    entrypoint: models.EntryPoint,
+    entry_point_plugin_files: list[models.EntryPointPluginFile],
+    logger: BoundLogger | None = None,
+) -> dict[str, Any]:
+    """Build a dictionary representation of a task engine YAML file.
+
+    Args:
+        entrypoint: The entrypoint to export.
+        entry_point_plugin_files: The entrypoint's plugin files.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        A dictionary representation of a task engine YAML file.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    tasks, parameter_types = extract_tasks(entry_point_plugin_files)
+    parameters = extract_parameters(entrypoint)
+    graph = extract_graph(entrypoint)
+    return {
+        "types": parameter_types,
+        "parameters": parameters,
+        "tasks": tasks,
+        "graph": graph,
+    }
+
+
+def extract_parameters(
+    entrypoint: models.EntryPoint,
+    logger: BoundLogger | None = None,
+) -> dict[str, Any]:
+    """Extract the parameters from an entrypoint.
+
+    Args:
+        entrypoint: The entrypoint to extract parameters from.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        A dictionary of the entrypoint's parameters.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    return {param.name: param.default_value for param in entrypoint.parameters}
+
+
+def extract_tasks(
+    entry_point_plugin_files: list[models.EntryPointPluginFile],
+    logger: BoundLogger | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Extract the plugin tasks and parameter types from the entrypoint plugin files.
+
+    Args:
+        entry_point_plugin_files: The entrypoint's plugin files.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        A tuple containing the plugin tasks dictionary and the parameter types
+        dictionary.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+
+    tasks = {}
+    parameter_types = {}
+    for entry_point_plugin_file in entry_point_plugin_files:
+        plugin = entry_point_plugin_file.plugin
+        plugin_file = entry_point_plugin_file.plugin_file
+
+        for task in plugin_file.tasks:
+            input_parameters = task.input_parameters
+            output_parameters = task.output_parameters
+
+            tasks[task.plugin_task_name] = {
+                "plugin": ".".join(
+                    [
+                        plugin.name,
+                        Path(plugin_file.filename).stem,
+                        task.plugin_task_name,
+                    ]
+                ),
+                "inputs": [
+                    {
+                        "name": input_param.name,
+                        "type": input_param.parameter_type.name,
+                    }
+                    for input_param in input_parameters
+                ],
+                "outputs": [
+                    {output_param.name: output_param.parameter_type.name}
+                    for output_param in output_parameters
+                ],
+            }
+
+            for param in input_parameters + output_parameters:
+                name = param.parameter_type.name
+                if name not in BUILTIN_TYPES:
+                    parameter_types[name] = param.parameter_type.structure
+
+    return tasks, parameter_types
+
+
+def extract_graph(
+    entrypoint: models.EntryPoint,
+    logger: BoundLogger | None = None,
+) -> dict[str, Any]:
+    """Extract the task graph from an entrypoint.
+
+    Args:
+        entrypoint: The entrypoint containing the task graph.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        A dictionary representation of the entrypoint's task graph.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    return cast(dict[str, Any], yaml.safe_load(entrypoint.task_graph))

--- a/src/dioptra/restapi/v1/workflows/lib/package_job_files.py
+++ b/src/dioptra/restapi/v1/workflows/lib/package_job_files.py
@@ -1,0 +1,117 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import tarfile
+import zipfile
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import IO
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import models
+
+from ..schema import FileTypes
+from .export_plugin_files import export_plugin_files
+from .export_task_engine_yaml import export_task_engine_yaml
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+
+def package_job_files(
+    entry_point: models.EntryPoint,
+    entry_point_plugin_files: list[models.EntryPointPluginFile],
+    file_type: FileTypes,
+    logger: BoundLogger | None = None,
+) -> IO[bytes]:
+    """Package the job files into a named temporary file.
+
+    Args:
+        entry_point: The job's entrypoint.
+        entry_point_plugin_files: The job's entrypoint plugin files.
+        file_type: The type of file to package the job files into.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The packaged job files as a named temporary file.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+
+    with TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        plugin_base_dir = base_dir / "plugins"
+
+        _ = export_plugin_files(
+            entry_point_plugin_files=entry_point_plugin_files,
+            plugins_base_dir=plugin_base_dir,
+            logger=log,
+        )
+        task_engine_yaml_path = export_task_engine_yaml(
+            entrypoint=entry_point,
+            entry_point_plugin_files=entry_point_plugin_files,
+            base_dir=base_dir,
+            logger=log,
+        )
+
+        if file_type == FileTypes.TAR_GZ:
+            return _package_as_tarfile(
+                plugin_base_dir=plugin_base_dir,
+                task_engine_yaml_path=task_engine_yaml_path,
+                logger=log,
+            )
+
+        if file_type == FileTypes.ZIP:
+            return _package_as_zipfile(
+                plugin_base_dir=plugin_base_dir,
+                task_engine_yaml_path=task_engine_yaml_path,
+                logger=log,
+            )
+
+
+def _package_as_tarfile(
+    plugin_base_dir: Path,
+    task_engine_yaml_path: Path,
+    logger: BoundLogger | None = None,
+) -> IO[bytes]:
+    log = logger or LOGGER.new()  # noqa: F841
+
+    package_file = NamedTemporaryFile(suffix=".tar.gz")
+    with tarfile.open(fileobj=package_file, mode="w:gz") as tar:
+        tar.add(str(plugin_base_dir), plugin_base_dir.name, recursive=True)
+        tar.add(str(task_engine_yaml_path), task_engine_yaml_path.name, recursive=False)
+
+    package_file.seek(0)
+    return package_file
+
+
+def _package_as_zipfile(
+    plugin_base_dir: Path,
+    task_engine_yaml_path: Path,
+    logger: BoundLogger | None = None,
+) -> IO[bytes]:
+    log = logger or LOGGER.new()  # noqa: F841
+
+    package_file = NamedTemporaryFile(suffix=".zip")
+    with zipfile.ZipFile(package_file, "w") as zipf:
+        for file in plugin_base_dir.rglob("*"):
+            zipf.write(file, file.relative_to(plugin_base_dir))
+
+        zipf.write(task_engine_yaml_path, task_engine_yaml_path.name)
+
+    package_file.seek(0)
+    return package_file

--- a/src/dioptra/restapi/v1/workflows/lib/views.py
+++ b/src/dioptra/restapi/v1/workflows/lib/views.py
@@ -1,0 +1,86 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import structlog
+from sqlalchemy import select
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import db, models
+
+from ..errors import JobEntryPointDoesNotExistError
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+
+def get_entry_point(
+    job_id: int, logger: BoundLogger | None = None
+) -> models.EntryPoint:
+    """Run a query to get the entrypoint for a job.
+
+    Args:
+        job_id: The ID of the job to get the entrypoint for.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The entrypoint for the job.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+
+    entry_point_stmt = (
+        select(models.EntryPoint)
+        .join(models.EntryPointJob)
+        .where(models.EntryPointJob.job_resource_id == job_id)
+    )
+    entry_point = db.session.scalar(entry_point_stmt)
+
+    if entry_point is None:
+        log.debug(
+            "The job's entrypoint does not exist",
+            job_id=job_id,
+        )
+        raise JobEntryPointDoesNotExistError
+
+    return entry_point
+
+
+def get_entry_point_plugin_files(
+    job_id: int, logger: BoundLogger | None = None
+) -> list[models.EntryPointPluginFile]:
+    """Run a query to get the plugin files for an entrypoint.
+
+    Args:
+        job_id: The ID of the job to get the plugin files for.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The plugin files for the entrypoint.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+
+    entry_point_resource_snapshot_id_stmt = (
+        select(models.EntryPoint.resource_snapshot_id)
+        .join(models.EntryPointJob)
+        .where(
+            models.EntryPointJob.job_resource_id == job_id,
+        )
+    )
+    entry_point_plugin_files_stmt = select(models.EntryPointPluginFile).where(
+        models.EntryPointPluginFile.entry_point_resource_snapshot_id
+        == entry_point_resource_snapshot_id_stmt.scalar_subquery(),
+    )
+    return list(db.session.scalars(entry_point_plugin_files_stmt).unique().all())

--- a/src/dioptra/restapi/v1/workflows/schema.py
+++ b/src/dioptra/restapi/v1/workflows/schema.py
@@ -1,0 +1,43 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The schemas for serializing/deserializing Workflow resources."""
+from enum import Enum
+
+from marshmallow import Schema, fields
+
+
+class FileTypes(Enum):
+    TAR_GZ = "tar_gz"
+    ZIP = "zip"
+
+
+class JobFilesDownloadQueryParametersSchema(Schema):
+    """The query parameters for making a jobFilesDownload workflow request."""
+
+    jobId = fields.String(
+        attribute="job_id",
+        metadata=dict(description="A job's unique identifier."),
+    )
+    fileType = fields.Enum(
+        FileTypes,
+        attribute="file_type",
+        metadata=dict(
+            description="The type of file to download: tar_gz or zip.",
+        ),
+        by_value=True,
+        default=FileTypes.TAR_GZ.value,
+    )

--- a/src/dioptra/restapi/v1/workflows/service.py
+++ b/src/dioptra/restapi/v1/workflows/service.py
@@ -1,0 +1,57 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""The server-side functions that perform workflows endpoint operations."""
+from typing import IO, Final
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from .lib import package_job_files, views
+from .schema import FileTypes
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+RESOURCE_TYPE: Final[str] = "workflow"
+
+
+class JobFilesDownloadService(object):
+    """The service methods for packaging job files for download."""
+
+    def get(self, job_id: int, file_type: FileTypes, **kwargs) -> IO[bytes]:
+        """Get the files needed to run a job and package them for download.
+
+        Args:
+            job_id: The identifier of the job.
+            file_type: The type of file to package the job files into. Must be one of
+                the values in the FileTypes enum.
+
+        Returns:
+            The packaged job files returned as a named temporary file.
+        """
+        log: BoundLogger = kwargs.get("log", LOGGER.new())
+        log.debug("Get job files download", job_id=job_id, file_type=file_type)
+
+        entry_point = views.get_entry_point(job_id=job_id, logger=log)
+        entry_point_plugin_files = views.get_entry_point_plugin_files(
+            job_id=job_id, logger=log
+        )
+        return package_job_files(
+            entry_point=entry_point,
+            entry_point_plugin_files=entry_point_plugin_files,
+            file_type=file_type,
+            logger=log,
+        )


### PR DESCRIPTION
This update implements the workflows/jobFilesDownload endpoint, which allows users to download a pre-packaged version of the job files needed to run a Dioptra job using the task engine. Retrieving the files requires users to issue a GET request to /workflows/jobFilesDownload, and provide the previously created job id and the desired file type as query parameters.