### PR TITLE
feat: add MlflowRun endpoint to Jobs

### DIFF
--- a/src/dioptra/restapi/v1/jobs/controller.py
+++ b/src/dioptra/restapi/v1/jobs/controller.py
@@ -42,10 +42,17 @@ from dioptra.restapi.v1.shared.tags.controller import (
     generate_resource_tags_id_endpoint,
 )
 
-from .schema import JobGetQueryParameters, JobPageSchema, JobSchema, JobStatusSchema
+from .schema import (
+    JobGetQueryParameters,
+    JobMlflowRunSchema,
+    JobPageSchema,
+    JobSchema,
+    JobStatusSchema,
+)
 from .service import (
     RESOURCE_TYPE,
     SEARCHABLE_FIELDS,
+    JobIdMlflowrunService,
     JobIdService,
     JobIdStatusService,
     JobService,
@@ -170,6 +177,60 @@ class JobIdStatusEndpoint(Resource):
         )
         return self._job_id_status_service.get(
             job_id=id, error_if_not_found=True, log=log
+        )
+
+
+@api.route("/<int:id>/mlflowRun")
+@api.param("id", "ID for the Job resource.")
+class JobIdMlflowrunEndpoint(Resource):
+    @inject
+    def __init__(
+        self,
+        job_id_mlflowrun_service: JobIdMlflowrunService,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Initialize the jobs resource.
+
+        All arguments are provided via dependency injection.
+
+        Args:
+            job_id_service: A JobIdStatusService object.
+        """
+        self._job_id_mlflowrun_service = job_id_mlflowrun_service
+        super().__init__(*args, **kwargs)
+
+    @login_required
+    @responds(schema=JobMlflowRunSchema, api=api)
+    def get(self, id: int):
+        """Gets a Job resource's mlflow run id."""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="JobIdMlflowrunEndpoint",
+            request_type="GET",
+            job_id=id,
+        )
+        return self._job_id_mlflowrun_service.get(
+            job_id=id, error_if_not_found=True, log=log
+        )
+
+    @login_required
+    @accepts(schema=JobMlflowRunSchema, api=api)
+    @responds(schema=JobMlflowRunSchema, api=api)
+    def post(self, id: int):
+        """Sets the mlflow run id for a Job"""
+        log = LOGGER.new(
+            request_id=str(uuid.uuid4()),
+            resource="JobIdMlflowrunEndpoint",
+            request_type="POST",
+            job_id=id,
+        )
+        parsed_obj = request.parsed_obj  # type: ignore
+        return self._job_id_mlflowrun_service.create(
+            job_id=id,
+            mlflow_run_id=parsed_obj["mlflow_run_id"],
+            error_if_not_found=True,
+            log=log,
         )
 
 

--- a/src/dioptra/restapi/v1/jobs/errors.py
+++ b/src/dioptra/restapi/v1/jobs/errors.py
@@ -32,6 +32,10 @@ class JobInvalidParameterNameError(Exception):
     """The requested job parameter name is invalid."""
 
 
+class JobMlflowRunAlreadySetError(Exception):
+    """The requested job already has an mlflow run id set."""
+
+
 class ExperimentJobDoesNotExistError(Exception):
     """The requested experiment job does not exist."""
 
@@ -60,6 +64,13 @@ def register_error_handlers(api: Api) -> None:
         return {
             "message": "Bad Request - A provided job parameter name does not match any "
             "entrypoint parameters"
+        }, 400
+
+    @api.errorhandler(JobMlflowRunAlreadySetError)
+    def handle_job_mlflow_run_already_set_error(error):
+        return {
+            "message": "Bad Request - The requested job already has an mlflow run id "
+            "set. It may not be changed."
         }, 400
 
     @api.errorhandler(ExperimentJobDoesNotExistError)

--- a/src/dioptra/restapi/v1/jobs/schema.py
+++ b/src/dioptra/restapi/v1/jobs/schema.py
@@ -31,6 +31,15 @@ JobRefSchema = generate_base_resource_ref_schema("Job")
 JobSnapshotRefSchema = generate_base_resource_ref_schema("Job", keep_snapshot_id=True)
 
 
+class JobMlflowRunSchema(Schema):
+    """The schema for the data in a mlflowRun resource."""
+
+    mlflowRunId = fields.UUID(
+        attribute="mlflow_run_id",
+        metadata=dict(description="UUID for the associated Mlflow Run."),
+    )
+
+
 class JobStatusSchema(Schema):
     """The fields schema for the data in a Job status resource."""
 


### PR DESCRIPTION
This commit adds the MlflowRun endpoint to Jobs. It contains functionality to get and set the MlflowRun ID for a job. The endpoint is nested under `/experiments/{id}/jobs/{jobId}/mlflowRrun`. The id can be set via a POST and retrieved via a GET. Once set, the id cannot be changed and the API will return a 400 BAD REQUEST error. Setting the mlflow run id does not create a new snapshot or change the last modified on timestamp.