### PR TITLE
Integrate Redis queue and add Dioptra V1 Worker functions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include CHANGELOG.md tox.ini
-recursive-include src/dioptra *.json
+recursive-include src/dioptra *.json *.tmpl
 recursive-include src/dioptra/restapi/db/alembic README *.mako *.ini
 
 graft docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ run-experiment = "dioptra.task_engine.run_experiment:main"
 validate-experiment = "dioptra.task_engine.validate:main"
 s3-download = "dioptra.worker.s3_download_cli:main"
 dioptra-worker = "dioptra.worker.dioptra_worker:main"
+dioptra-worker-v1 = "dioptra.worker.dioptra_worker_v1:main"
 
 [project.entry-points."dioptra.generics.estimator_predict"]
 tf_keras_model = "dioptra.generics_plugins.estimator_predict.tf_keras_model"

--- a/src/dioptra/restapi/bootstrap.py
+++ b/src/dioptra/restapi/bootstrap.py
@@ -32,6 +32,7 @@ from dioptra.restapi.v0.queue.service import QueueNameService
 from dioptra.restapi.v0.shared.password.service import PasswordService
 from dioptra.restapi.v0.shared.request_scope import request
 from dioptra.restapi.v0.shared.rq.service import RQService
+from dioptra.restapi.v1.shared.rq_service import RQServiceV1
 
 
 class MLFlowClientModule(Module):
@@ -61,6 +62,15 @@ class RQServiceModule(Module):
             run_mlflow=configuration.run_mlflow,
             run_task_engine=configuration.run_task_engine,
         )
+
+
+class RQServiceV1Module(Module):
+    @request
+    @provider
+    def provide_rq_service_module(
+        self, configuration: RQServiceConfiguration
+    ) -> RQServiceV1:
+        return RQServiceV1(redis=configuration.redis)
 
 
 class QueueNameServiceModule(Module):
@@ -139,5 +149,6 @@ def register_providers(modules: List[Callable[..., Any]]) -> None:
 
     modules.append(MLFlowClientModule)
     modules.append(RQServiceModule)
+    modules.append(RQServiceV1Module)
     modules.append(QueueNameServiceModule)
     modules.append(PasswordServiceModule)

--- a/src/dioptra/restapi/db/models/entry_points.py
+++ b/src/dioptra/restapi/db/models/entry_points.py
@@ -117,7 +117,9 @@ class EntryPointParameterValue(db.Model):  # type: ignore[name-defined]
 
     # Relationships
     job_resource: Mapped["Resource"] = relationship()
-    parameter: Mapped["EntryPointParameter"] = relationship(back_populates="values")
+    parameter: Mapped["EntryPointParameter"] = relationship(
+        back_populates="values", lazy="joined"
+    )
     entry_point_job: Mapped["EntryPointJob"] = relationship(
         init=False,
         back_populates="entry_point_parameter_values",

--- a/src/dioptra/restapi/utils.py
+++ b/src/dioptra/restapi/utils.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import datetime
 import functools
+from importlib.resources import as_file, files
 from typing import Any, Callable, List, Protocol, Type, cast
 
 from flask.views import View
@@ -180,6 +181,24 @@ def slugify(text: str) -> str:
     """
 
     return text.lower().strip().replace(" ", "-")
+
+
+def read_text_file(package: str, filename: str) -> str:
+    """Read a text file from a specified package into a string.
+
+    Args:
+        package: The name of the Python package containing the text file. This should
+            be a string representing the package's import path, for example
+            "my_package.subpackage".
+        filename: The base name of the text file, including its extension. For
+            example, "data.txt".
+
+    Returns:
+        A string with the contents of the text file.
+    """
+    traversable = files(package).joinpath(filename)
+    with as_file(traversable) as fp:
+        return fp.read_text()
 
 
 class _ClassBasedViewFunction(Protocol):

--- a/src/dioptra/restapi/v1/shared/rq_service.py
+++ b/src/dioptra/restapi/v1/shared/rq_service.py
@@ -1,0 +1,62 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from typing import Final
+
+import structlog
+from redis import Redis
+from rq.queue import Queue as RQQueue
+from structlog.stdlib import BoundLogger
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+TIMEOUT_24_HOURS: Final[int] = 24 * 3600
+RUN_V1_DIOPTRA_JOB_FUNC: Final[str] = "dioptra.rq.tasks.run_v1_dioptra_job"
+
+
+class RQServiceV1(object):
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+
+    def submit(
+        self,
+        job_id: int,
+        experiment_id: int,
+        queue: str,
+        timeout: str | None = None,
+    ):
+        log: BoundLogger = LOGGER.new()
+
+        cmd_kwargs = {
+            "job_id": job_id,
+            "experiment_id": experiment_id,
+        }
+
+        log.info(
+            "Enqueuing job",
+            function=RUN_V1_DIOPTRA_JOB_FUNC,
+            job_id=job_id,
+            cmd_kwargs=cmd_kwargs,
+            timeout=timeout,
+        )
+
+        q = RQQueue(queue, default_timeout=TIMEOUT_24_HOURS, connection=self._redis)
+        q.enqueue(
+            RUN_V1_DIOPTRA_JOB_FUNC,
+            kwargs=cmd_kwargs,
+            job_id=str(job_id),
+            timeout=timeout,
+        )

--- a/src/dioptra/restapi/v1/workflows/errors.py
+++ b/src/dioptra/restapi/v1/workflows/errors.py
@@ -24,7 +24,18 @@ class JobEntryPointDoesNotExistError(Exception):
     """The job's entry point does not exist."""
 
 
+class JobExperimentDoesNotExistError(Exception):
+    """The experiment associated with the job does not exist."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(JobEntryPointDoesNotExistError)
     def handle_experiment_job_does_not_exist_error(error):
         return {"message": "Not Found - The job's entry point does not exist"}, 404
+
+    @api.errorhandler(JobExperimentDoesNotExistError)
+    def handle_experiment_does_not_exist_error(error):
+        return {
+            "message": "Not Found - The experiment associated with the job does not "
+            "exist"
+        }, 404

--- a/src/dioptra/restapi/v1/workflows/lib/export_job_parameters.py
+++ b/src/dioptra/restapi/v1/workflows/lib/export_job_parameters.py
@@ -1,0 +1,73 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import json
+from pathlib import Path
+from typing import Final
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.db import models
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+FLOAT_PARAM_TYPE: Final[str] = "float"
+JSON_FILE_ENCODING: Final[str] = "utf-8"
+
+
+def export_job_parameters(
+    job_param_values: list[models.EntryPointParameterValue],
+    base_dir: Path,
+    logger: BoundLogger | None = None,
+) -> Path:
+    """Export a job's parameters to a parameters.json file in a specified directory.
+
+    Args:
+        base_dir: The directory to export the parameters JSON file to.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The path to the exported parameters.json file.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    job_params_json_path = Path(base_dir, "parameters").with_suffix(".json")
+
+    job_parameters: dict[str, str | int | float | None] = {}
+    for param_value in job_param_values:
+        if param_value.parameter.parameter_type == FLOAT_PARAM_TYPE:
+            job_parameters[param_value.parameter.name] = _convert_to_number(
+                param_value.value
+            )
+
+        else:
+            job_parameters[param_value.parameter.name] = param_value.value
+
+    with job_params_json_path.open("wt", encoding=JSON_FILE_ENCODING) as f:
+        json.dump(job_parameters, f, indent=2)
+
+    return job_params_json_path
+
+
+def _convert_to_number(number: str | None) -> int | float | None:
+    if number is None:
+        return None
+
+    if number.isnumeric():
+        return int(number)
+
+    return float(number)

--- a/src/dioptra/restapi/v1/workflows/lib/export_run_dioptra_job_script.py
+++ b/src/dioptra/restapi/v1/workflows/lib/export_run_dioptra_job_script.py
@@ -1,0 +1,80 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from pathlib import Path
+from string import Template
+from typing import Final
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.utils import read_text_file
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+SCRIPT_FILE_ENCODING: Final[str] = "utf-8"
+CURRENT_PACKAGE: Final[str] = "dioptra.restapi.v1.workflows.lib"
+TEMPLATE_FILENAME: Final[str] = "run_dioptra_job.py.tmpl"
+
+
+def export_run_dioptra_job_script(
+    job_id: int,
+    experiment_id: int,
+    task_engine_yaml_path: str,
+    job_params_json_path: str,
+    base_dir: Path,
+    logger: BoundLogger | None = None,
+) -> Path:
+    """Render and export the run_dioptra_job.py script to a specified directory.
+
+    Args:
+        base_dir: The directory to export the rendered script to.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The path to the exported script.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+    script_path = Path(base_dir, "run_dioptra_job").with_suffix(".py")
+    script = _render_run_dioptra_job_script(
+        job_id=job_id,
+        experiment_id=experiment_id,
+        task_engine_yaml_path=task_engine_yaml_path,
+        job_params_json_path=job_params_json_path,
+    )
+
+    with script_path.open("wt", encoding=SCRIPT_FILE_ENCODING) as f:
+        f.write(script)
+
+    return script_path
+
+
+def _render_run_dioptra_job_script(
+    job_id: int,
+    experiment_id: int,
+    task_engine_yaml_path: str,
+    job_params_json_path: str,
+):
+    template_text = read_text_file(package=CURRENT_PACKAGE, filename=TEMPLATE_FILENAME)
+    template = Template(template_text)
+
+    return template.substitute(
+        job_id=job_id,
+        experiment_id=experiment_id,
+        task_engine_yaml_path=task_engine_yaml_path,
+        job_params_json_path=job_params_json_path,
+    )

--- a/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
+++ b/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
@@ -1,0 +1,144 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import json
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, cast
+
+import mlflow
+import structlog
+import yaml
+from structlog.stdlib import BoundLogger
+
+from dioptra.sdk.utilities.contexts import sys_path_dirs
+from dioptra.task_engine.task_engine import run_experiment
+from dioptra.task_engine.validation import is_valid
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+DIOPTRA_JOB_ID = "dioptra.jobId"
+
+# Templated variables
+JOB_ID = ${job_id}
+EXPERIMENT_ID = ${experiment_id}
+JOB_YAML_PATH = "${task_engine_yaml_path}"
+JOB_PARAMS_JSON_PATH = "${job_params_json_path}"
+
+
+def main(
+    plugins_dir: str | Path = "plugins",
+    enable_mlflow_tracking: bool = False,
+    logger: BoundLogger | None = None,
+) -> None:
+    log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
+
+    if not Path(plugins_dir).exists():
+        log.error("Plugins directory does not exist", plugins_dir=str(plugins_dir))
+        raise ValueError(f"Plugins directory {plugins_dir} does not exist")
+
+    job_yaml = _load_job_yaml(JOB_YAML_PATH)
+    job_parameters = _load_job_params(JOB_PARAMS_JSON_PATH)
+
+    if not is_valid(job_yaml):
+        log.error("Job YAML was invalid!")
+        raise ValueError("Job YAML was invalid!")
+
+    if enable_mlflow_tracking:
+        return _run_mlflow_tracked_job(Path(plugins_dir), job_yaml, job_parameters, log)
+
+    return _run_job(Path(plugins_dir), job_yaml, job_parameters, log)
+
+
+def _run_job(
+    plugins_dir: Path,
+    job_yaml: Mapping[str, Any],
+    job_parameters: MutableMapping[str, Any],
+    logger: BoundLogger | None = None,
+) -> None:
+    """Run the job.
+
+    Args:
+        plugins_dir: Path to the plugins directory
+        job_yaml: A declarative experiment description, as a mapping
+        job_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+        logger: A structlog logger instance. If not provided, a new logger
+            will be created
+    """
+    log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
+
+    try:
+        with sys_path_dirs(dirs=(str(plugins_dir),)):
+            run_experiment(job_yaml, job_parameters)
+
+        log.info("=== Run succeeded ===")
+
+    except Exception as e:
+        log.exception("=== Run failed ===")
+        raise e
+
+
+def _run_mlflow_tracked_job(
+    plugins_dir: Path,
+    job_yaml: Mapping[str, Any],
+    job_parameters: MutableMapping[str, Any],
+    logger: BoundLogger | None = None,
+) -> None:
+    """Run the job and start tracking the run in MLflow tracking server.
+
+    Args:
+        plugins_dir: Path to the plugins directory
+        job_yaml: A declarative experiment description, as a mapping
+        job_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+        logger: A structlog logger instance. If not provided, a new logger
+            will be created
+    """
+    log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
+    _ = mlflow.start_run()
+
+    try:
+        mlflow.set_tag(DIOPTRA_JOB_ID, JOB_ID)
+        mlflow.log_dict(job_yaml, Path(JOB_YAML_PATH).name)
+        mlflow.log_params(job_parameters)
+
+        with sys_path_dirs(dirs=(str(plugins_dir),)):
+            run_experiment(job_yaml, job_parameters)
+
+        log.info("=== Run succeeded ===")
+        mlflow.end_run()
+
+    except Exception as e:
+        log.exception("=== Run failed ===")
+        mlflow.end_run("FAILED")
+        raise e
+
+
+def _load_job_yaml(filepath: str) -> Mapping[str, Any]:
+    job_filepath = Path(filepath)
+    with job_filepath.open("rt") as f:
+        return cast(Mapping[str, Any], yaml.safe_load(f))
+
+
+def _load_job_params(filepath: str) -> MutableMapping[str, Any]:
+    job_params_filepath = Path(filepath)
+    with job_params_filepath.open("rt") as f:
+        return cast(MutableMapping[str, Any], json.load(f))
+
+
+if __name__ == "__main__":
+    # Running the file as a script does not enable the Mlflow Tracking capability. This
+    # is useful for debugging whether the job YAML and plugins are set up appropriately.
+    main()

--- a/src/dioptra/restapi/v1/workflows/service.py
+++ b/src/dioptra/restapi/v1/workflows/service.py
@@ -45,13 +45,18 @@ class JobFilesDownloadService(object):
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.debug("Get job files download", job_id=job_id, file_type=file_type)
 
+        experiment = views.get_experiment(job_id=job_id, logger=log)
         entry_point = views.get_entry_point(job_id=job_id, logger=log)
         entry_point_plugin_files = views.get_entry_point_plugin_files(
             job_id=job_id, logger=log
         )
+        job_parameter_values = views.get_job_parameter_values(job_id=job_id, logger=log)
         return package_job_files(
+            job_id=job_id,
+            experiment=experiment,
             entry_point=entry_point,
             entry_point_plugin_files=entry_point_plugin_files,
+            job_parameter_values=job_parameter_values,
             file_type=file_type,
             logger=log,
         )

--- a/src/dioptra/rq/tasks/__init__.py
+++ b/src/dioptra/rq/tasks/__init__.py
@@ -16,5 +16,6 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode
 from .run_mlflow import run_mlflow_task
 from .run_task_engine import run_task_engine_task
+from .run_v1_dioptra_job import run_v1_dioptra_job
 
-__all__ = ["run_mlflow_task", "run_task_engine_task"]
+__all__ = ["run_mlflow_task", "run_task_engine_task", "run_v1_dioptra_job"]

--- a/src/dioptra/rq/tasks/run_v1_dioptra_job.py
+++ b/src/dioptra/rq/tasks/run_v1_dioptra_job.py
@@ -1,0 +1,193 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import importlib
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Final, cast
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import requests
+import structlog
+from structlog.stdlib import BoundLogger
+
+from dioptra.restapi.routes import (
+    V1_AUTH_ROUTE,
+    V1_EXPERIMENTS_ROUTE,
+    V1_ROOT,
+    V1_WORKFLOWS_ROUTE,
+)
+from dioptra.sdk.utilities.contexts import sys_path_dirs
+from dioptra.sdk.utilities.paths import set_cwd
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+ENV_DIOPTRA_API: Final[str] = "DIOPTRA_API"
+ENV_DIOPTRA_WORKER_USERNAME: Final[str] = "DIOPTRA_WORKER_USERNAME"
+ENV_DIOPTRA_WORKER_PASSWORD: Final[str] = "DIOPTRA_WORKER_PASSWORD"
+ENV_MLFLOW_S3_ENDPOINT_URL: Final[str] = "MLFLOW_S3_ENDPOINT_URL"
+
+DOWNLOAD_CHUNK_SIZE: Final[int] = 10 * 1024
+TAR_GZ_FILE_TYPE: Final[str] = "tar_gz"
+TAR_GZ_EXTENSION: Final[str] = ".tar.gz"
+
+JOB_FILES_DOWNLOAD_ENDPOINT: Final[str] = f"{V1_WORKFLOWS_ROUTE}/jobFilesDownload"
+
+
+class SimpleDioptraClient(object):
+    def __init__(self, username: str, password: str, api_url: str):
+        self._api_scheme, self._api_netloc = self._extract_scheme_and_netloc(api_url)
+        self._username = username
+        self._password = password
+        self._session: requests.Session | None = None
+
+    @property
+    def session(self) -> requests.Session:
+        if self._session is None:
+            self.login()
+
+        return cast(requests.Session, self._session)
+
+    def login(self) -> None:
+        if self._session is None:
+            self._session = requests.Session()
+
+        response = self._session.post(
+            self._build_url(f"{V1_AUTH_ROUTE}/login"),
+            json={"username": self._username, "password": self._password},
+        )
+        response.raise_for_status()
+
+    def download_job_files(self, job_id: int, output_dir: Path) -> Path:
+        url = self._build_url(
+            JOB_FILES_DOWNLOAD_ENDPOINT,
+            query_params={"jobId": str(job_id), "fileType": TAR_GZ_FILE_TYPE},
+        )
+        job_files_path = (output_dir / "job_files").with_suffix(TAR_GZ_EXTENSION)
+        with (
+            self.session.get(url, stream=True) as response,
+            job_files_path.open(mode="wb") as f,
+        ):
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                f.write(chunk)
+
+        return job_files_path
+
+    def set_job_status(self, job_id: int, experiment_id: int, status: str) -> None:
+        url = self._build_url(
+            f"{V1_EXPERIMENTS_ROUTE}/{experiment_id}/jobs/{job_id}/status"
+        )
+        response = self.session.put(url, json={"status": status})
+        response.raise_for_status()
+
+    def _build_url(
+        self, endpoint: str, query_params: dict[str, str] | None = None
+    ) -> str:
+        query_params = query_params or {}
+
+        return urlunparse(
+            (
+                self._api_scheme,
+                self._api_netloc,
+                f"/{V1_ROOT}/{endpoint}",
+                "",
+                urlencode(query_params),
+                "",
+            )
+        )
+
+    @staticmethod
+    def _extract_scheme_and_netloc(api_url: str) -> tuple[str, str]:
+        parsed_api_url = urlparse(url=api_url)
+        return parsed_api_url.scheme, parsed_api_url.netloc
+
+
+def run_v1_dioptra_job(job_id: int, experiment_id: int) -> None:
+    """Fetches the job files from the Dioptra API and runs the job.
+
+    Args:
+        job_id: The Dioptra job ID.
+        experiment_id: The Dioptra experiment ID.
+    """
+    log = LOGGER.new(job_id=job_id, experiment_id=experiment_id)  # noqa: F841
+
+    if (username := os.getenv(ENV_DIOPTRA_WORKER_USERNAME)) is None:
+        log.error(f"{ENV_DIOPTRA_WORKER_USERNAME} environment variable is not set")
+        raise ValueError(
+            f"{ENV_DIOPTRA_WORKER_USERNAME} environment variable is not set"
+        )
+
+    if (password := os.getenv(ENV_DIOPTRA_WORKER_PASSWORD)) is None:
+        log.error(f"{ENV_DIOPTRA_WORKER_PASSWORD} environment variable is not set")
+        raise ValueError(
+            f"{ENV_DIOPTRA_WORKER_PASSWORD} environment variable is not set"
+        )
+
+    if (api_url := os.getenv(ENV_DIOPTRA_API)) is None:
+        log.error(f"{ENV_DIOPTRA_API} environment variable is not set")
+        raise ValueError(f"{ENV_DIOPTRA_API} environment variable is not set")
+
+    # Instantiate a Dioptra client and login using worker's authentication details
+    client = SimpleDioptraClient(username=username, password=password, api_url=api_url)
+
+    # Set Dioptra Job status to "started"
+    client.set_job_status(job_id=job_id, experiment_id=experiment_id, status="started")
+
+    if os.getenv(ENV_MLFLOW_S3_ENDPOINT_URL) is None:
+        client.set_job_status(
+            job_id=job_id, experiment_id=experiment_id, status="failed"
+        )
+        log.error(f"{ENV_MLFLOW_S3_ENDPOINT_URL} environment variable is not set")
+        raise ValueError(
+            f"{ENV_MLFLOW_S3_ENDPOINT_URL} environment variable is not set"
+        )
+
+    # Set up a temporary directory and set it as the current working directory
+    with tempfile.TemporaryDirectory() as tempdir, set_cwd(tempdir):
+        working_dir = Path(tempdir)
+        plugins_dir = working_dir / "plugins"
+        run_dioptra_job_path = working_dir / "run_dioptra_job.py"
+
+        # Use client to download the job files for the provided job_id
+        job_files_package = client.download_job_files(
+            job_id=job_id, output_dir=working_dir
+        )
+
+        # Unpack the (trusted) tar.gz file in it.
+        with tarfile.open(job_files_package, mode="r:*") as tar:
+            tar.extractall(path=working_dir, filter="data")
+
+        # Import the run_dioptra_job.py file as a module
+        with sys_path_dirs(dirs=(str(working_dir),)):
+            run_dioptra_job = importlib.import_module(run_dioptra_job_path.stem)
+
+        # Execute the main function in the included script file.
+        try:
+            run_dioptra_job.main(
+                plugins_dir=plugins_dir, enable_mlflow_tracking=True, logger=log
+            )
+            client.set_job_status(
+                job_id=job_id, experiment_id=experiment_id, status="finished"
+            )
+
+        except Exception as e:
+            client.set_job_status(
+                job_id=job_id, experiment_id=experiment_id, status="failed"
+            )
+            log.exception("Error running job")
+            raise e

--- a/src/dioptra/sdk/utilities/contexts/_sys_path_dirs.py
+++ b/src/dioptra/sdk/utilities/contexts/_sys_path_dirs.py
@@ -14,8 +14,28 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
-from ._plugin_dirs import plugin_dirs
-from ._redirect_print import redirect_print
-from ._sys_path_dirs import sys_path_dirs
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Iterator, List
 
-__all__ = ["plugin_dirs", "redirect_print", "sys_path_dirs"]
+
+@contextmanager
+def sys_path_dirs(dirs: Iterable[str] = (".",)) -> Iterator[None]:
+    sys_path_copy: List[str] = sys.path.copy()
+    dirs = [
+        str(Path(x).resolve())
+        for x in dirs
+        if x and Path(x).resolve().is_dir() and str(Path(x).resolve()) not in sys.path
+    ]
+
+    try:
+        sys.path = _remove_duplicate_paths([*sys.path[:1], *dirs, *sys.path[1:]])
+        yield
+
+    finally:
+        sys.path = sys_path_copy
+
+
+def _remove_duplicate_paths(dirs: Iterable[str]) -> List[str]:
+    return list(dict.fromkeys(dirs))

--- a/src/dioptra/worker/dioptra_worker_v1.py
+++ b/src/dioptra/worker/dioptra_worker_v1.py
@@ -1,0 +1,72 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""
+A CLI tool used to start up a worker process for running jobs.
+"""
+
+import logging
+import os
+import sys
+
+import rq.cli
+
+from dioptra.sdk.utilities.logging import (
+    attach_stdout_stream_handler,
+    set_logging_level,
+)
+
+_REQUIRED_ENV = {
+    "MLFLOW_S3_ENDPOINT_URL",
+    "DIOPTRA_API",
+    "DIOPTRA_WORKER_USERNAME",
+    "DIOPTRA_WORKER_PASSWORD",
+}
+
+
+def _setup_logging() -> None:
+    attach_stdout_stream_handler(
+        True if os.getenv("DIOPTRA_RQ_WORKER_LOG_AS_JSON") else False,
+    )
+    set_logging_level(os.getenv("DIOPTRA_RQ_WORKER_LOG_LEVEL", default="INFO"))
+
+
+def main() -> int:
+    _setup_logging()
+    log = logging.getLogger("dioptra-worker")
+    exit_status = 0
+
+    # We know what functions will be executed through rq and what they
+    # require, so we may as well check that before starting up the worker.
+    # Better to error out as early as possible.
+    unset_vars = _REQUIRED_ENV - os.environ.keys()
+    if unset_vars:
+        exit_status = 1
+        log.fatal("Environment variables must be set: %s", ", ".join(unset_vars))
+    else:
+        # Disabling standalone mode means the worker function can return a
+        # value to this script, exceptions will propagate to us, etc. (as
+        # opposed to being intercepted and handled by click).  As a wrapper
+        # that seems appropriate, although I don't think the worker function
+        # is written to return anything, and we presently don't need to
+        # specially handle any of the exceptions.
+        rq.cli.worker(standalone_mode=False)
+
+    return exit_status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/restapi/conftest.py
+++ b/tests/unit/restapi/conftest.py
@@ -123,6 +123,7 @@ def dependency_modules() -> List[Any]:
         PasswordServiceModule,
         RQServiceConfiguration,
         RQServiceModule,
+        RQServiceV1Module,
         _bind_password_service_configuration,
     )
 
@@ -153,8 +154,9 @@ def dependency_modules() -> List[Any]:
 
     return [
         configure,
-        PasswordServiceModule(),
-        RQServiceModule(),
+        PasswordServiceModule,
+        RQServiceModule,
+        RQServiceV1Module,
     ]
 
 

--- a/tests/unit/restapi/lib/mock_rq.py
+++ b/tests/unit/restapi/lib/mock_rq.py
@@ -95,11 +95,12 @@ class MockRQQueue(object):
 
     def enqueue(self, *args, **kwargs) -> MockRQJob:
         LOGGER.info("Mocking rq.Queue.enqueue() function", args=args, kwargs=kwargs)
+        job_id = kwargs.get("job_id", str(uuid.uuid4()))
         cmd_kwargs = kwargs.get("kwargs")
         depends_on = kwargs.get("depends_on")
         timeout = kwargs.get("timeout")
         return MockRQJob(
-            id=str(uuid.uuid4()),
+            id=job_id,
             queue=self.name,
             timeout=timeout,
             cmd_kwargs=cmd_kwargs,

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -25,8 +25,9 @@ from flask import Flask
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from injector import Injector
+from pytest import MonkeyPatch
 
-from ..lib import actions
+from ..lib import actions, mock_rq
 
 
 @pytest.fixture
@@ -627,7 +628,12 @@ def registered_jobs(
     registered_queues: dict[str, Any],
     registered_experiments: dict[str, Any],
     registered_entrypoints: dict[str, Any],
+    monkeypatch: MonkeyPatch,
 ) -> dict[str, Any]:
+    # Inline import necessary to prevent circular import
+    import dioptra.restapi.v1.shared.rq_service as rq_service
+    monkeypatch.setattr(rq_service, "RQQueue", mock_rq.MockRQQueue)
+
     queue_id = registered_queues["queue1"]["snapshot"]
     experiment_id = registered_experiments["experiment1"]["snapshot"]
     entrypoint_id = registered_entrypoints["entrypoint1"]["snapshot"]


### PR DESCRIPTION
This commit adds the necessary functionality so that when Dioptra users create a Job, the defined job will be submitted to a Redis-based queue for execution. The queued job is then picked up by a worker process, which downloads the job files using the /workflows/jobFilesDownload endpoint and runs the job they define.

The contents of the downloaded tarfile/zipfile obtained via /workflows/jobFilesDownload has been updated to now include a run_dioptra_job.py script and a parameters.json file (these are the parameters set at job submission time). The script + parameters.json + task engine YAML + plugins directory, all of which are included in the tarfile, fully define the job that needs to be executed. The result is that the logic for the Dioptra v1 worker process is light-weight. It only needs to know how to download and unpack the tarfile and execute the included Python script.

A RQ service and worker script for Dioptra V1 has been defined and intergrated into the jobs service layer. The RQ service enqueues the job to Redis right after the Job information is committed to the database. This aspect is similar to how it worked in Dioptra v0, except the service no longer uploads anything to the S3 storage backend.

Additional updates include:

- A simplified sys_path_dirs contextmanager has been implemented to replace the plugin_dirs contextmanager. It is used by the worker process to set the plugins directory before executing the job.
- Bugs in the algorithm for assembling the task engine YAML files have been fixed.
- A utility for reading a text file stored in the dioptra python package has been added.
- The EntryPointParameter relationship on EntryPointParameterValue has been configured as a lazy join.