### PR TITLE
fix TS errors in addItem and addDraft, also remove import.meta.env.BA…

### DIFF
--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(),
   routes: [
     {
       path: '/',

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -155,7 +155,7 @@ export async function updateItem<T extends ItemType>(type: T, id: number, params
   return await axios.put(`/api/${type}/${id}`, params)
 }
 
-export async function addItem<T extends ItemType>(type: T, params: CreateParams[T]) {
+export async function addItem<T extends keyof CreateParams>(type: T, params: CreateParams[T]) {
   return await axios.post(`/api/${type}/`, params)
 }
 
@@ -175,7 +175,7 @@ export async function deleteJob(id: number, jobId: number) {
   return await axios.delete(`/api/experiments/${id}/jobs/${jobId}`)
 }
 
-export async function addDraft<T extends ItemType>(type: T, params: CreateParams[T], id: number) {
+export async function addDraft<T extends keyof CreateParams>(type: T, params: CreateParams[T], id: number) {
   if(id) {
     return await axios.post(`/api/${type}/${id}/draft`, params)
   } else {


### PR DESCRIPTION
This is to fix the errors below.  
For addItem and addDraft, I changed T to `T extends keyof `CreateParams``
For the 3rd error, I removed `import.meta.env.BASE_URL` from `createWebHistory(import.meta.env.BASE_URL)`

 src/services/dataApi.ts:158:68 - error TS2536: Type ‘T’ cannot be used to index type ‘CreateParams’.
158 export async function addItem<T extends ItemType>(type: T, params: CreateParams[T]) {
                                                                       ~~~~~~~~~~~~~~~
src/services/dataApi.ts:178:69 - error TS2536: Type ‘T’ cannot be used to index type ‘CreateParams’.
178 export async function addDraft<T extends ItemType>(type: T, params: CreateParams[T], id: number) {
                                                                        ~~~~~~~~~~~~~~~
src/router/index.ts:5:41 - error TS2339: Property ‘env’ does not exist on type ‘ImportMeta’.
5   history: createWebHistory(import.meta.env.BASE_URL),