### PR TITLE
Update worker and job execution scripts to set mlflow run id

### DIFF
--- a/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
+++ b/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
@@ -15,8 +15,9 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 import json
+import uuid
 from pathlib import Path
-from typing import Any, Mapping, MutableMapping, cast
+from typing import Any, Mapping, MutableMapping, Protocol, cast
 
 import mlflow
 import structlog
@@ -37,9 +38,17 @@ JOB_YAML_PATH = "${task_engine_yaml_path}"
 JOB_PARAMS_JSON_PATH = "${job_params_json_path}"
 
 
+class SimpleDioptraClient(Protocol):
+    def set_job_mlflow_run_id(
+        self, job_id: int, mlflow_run_id: str | uuid.UUID
+    ) -> None:
+        ...  # fmt: skip
+
+
 def main(
     plugins_dir: str | Path = "plugins",
     enable_mlflow_tracking: bool = False,
+    dioptra_client: SimpleDioptraClient | None = None,
     logger: BoundLogger | None = None,
 ) -> None:
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
@@ -56,7 +65,19 @@ def main(
         raise ValueError("Job YAML was invalid!")
 
     if enable_mlflow_tracking:
-        return _run_mlflow_tracked_job(Path(plugins_dir), job_yaml, job_parameters, log)
+        if dioptra_client is None:
+            log.error(
+                "The client for the Dioptra API is missing, it must be provided to "
+                "enable MLflow tracking functionality."
+            )
+            raise ValueError(
+                "The client for the Dioptra API is missing, it must be provided to "
+                "enable MLflow tracking functionality."
+            )
+
+        return _run_mlflow_tracked_job(
+            dioptra_client, Path(plugins_dir), job_yaml, job_parameters, log
+        )
 
     return _run_job(Path(plugins_dir), job_yaml, job_parameters, log)
 
@@ -91,6 +112,7 @@ def _run_job(
 
 
 def _run_mlflow_tracked_job(
+    dioptra_client: SimpleDioptraClient,
     plugins_dir: Path,
     job_yaml: Mapping[str, Any],
     job_parameters: MutableMapping[str, Any],
@@ -99,6 +121,7 @@ def _run_mlflow_tracked_job(
     """Run the job and start tracking the run in MLflow tracking server.
 
     Args:
+        dioptra_client: A client for interacting with the Dioptra service.
         plugins_dir: Path to the plugins directory
         job_yaml: A declarative experiment description, as a mapping
         job_parameters: Global parameters for this run, as a mapping from
@@ -107,9 +130,12 @@ def _run_mlflow_tracked_job(
             will be created
     """
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
-    _ = mlflow.start_run()
+    active_run = mlflow.start_run()
 
     try:
+        dioptra_client.set_job_mlflow_run_id(
+            job_id=JOB_ID, mlflow_run_id=active_run.info.run_id
+        )
         mlflow.set_tag(DIOPTRA_JOB_ID, JOB_ID)
         mlflow.log_dict(job_yaml, Path(JOB_YAML_PATH).name)
         mlflow.log_params(job_parameters)


### PR DESCRIPTION
This commit updates the worker and job execution scripts to set the mlflow run id when the mlflow tracking capability is enabled.