### PR TITLE
feat: Truncate long text

### DIFF
--- a/src/frontend/src/components/CodeEditor.vue
+++ b/src/frontend/src/components/CodeEditor.vue
@@ -14,6 +14,7 @@
       :style="{ 'min-height': '250px', 'max-height': '70vh',
         'border': `${showError ? '2px solid red' : '2px solid black'}`
       }"
+      :disabled="readOnly"
     />
     <caption
       :class="{ invisible: showError?.length === 0 ? true : false }"
@@ -76,7 +77,7 @@
       oneDark,
       yamlLinter,
       lintGutter(),
-      EditorState.readOnly.of(props.readOnly)
+      EditorState.readOnly.of(props.readOnly) // not working, using disabled prop instead
     ]
   })
 </script>

--- a/src/frontend/src/components/PageTitle.vue
+++ b/src/frontend/src/components/PageTitle.vue
@@ -1,11 +1,11 @@
 <template>
-  <h1 class="text-capitalize q-mb-sm" 
+  <h1 class="q-mb-sm" 
     :class="{ invisible: title ? false : true }"
   >
     {{ title || 'Loading...' }}
   </h1>
   <nav aria-label="Breadcrumb">
-    <q-breadcrumbs class="text-grey text-capitalize">
+    <q-breadcrumbs class="text-grey">
       <template v-slot:separator>
         <q-icon
           size="1.2em"
@@ -17,6 +17,7 @@
         :label="path[0]" 
         :to="path[1] ? `/${path[0]}` : ''" 
         :aria-current="`${path.length === 1 ? 'true' : 'false'}`"
+        class="text-capitalize"
       />
       <q-breadcrumbs-el
         v-if="route.params.id && route.params.fileId"

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -43,13 +43,13 @@
             </div>
             <div v-else-if="col.name === 'name'">
               {{ props.row.name?.length <= 18 ? props.row.name : props.row.name?.replace(/(.{17})..+/, "$1…") }}
-              <q-tooltip v-if="props.row.name.length > 18" max-width="30vw">
+              <q-tooltip v-if="props.row.name.length > 18" max-width="30vw" style="overflow-wrap: break-word">
                 {{ props.row.name }}
               </q-tooltip>
             </div>
             <div v-else-if="col.name === 'description'">
               {{ props.row.description?.length <= 40 ? props.row.description : props.row.description?.replace(/(.{39})..+/, "$1…") }}
-              <q-tooltip v-if="props.row.description?.length > 40" max-width="30vw">
+              <q-tooltip v-if="props.row.description?.length > 40" max-width="30vw" style="overflow-wrap: break-word">
                 {{ props.row.description }}
               </q-tooltip>
             </div>
@@ -63,7 +63,7 @@
                 @click.stop
               >
                 {{ tag.name.length <= 18 ? tag.name : tag.name.replace(/(.{17})..+/, "$1…") }}
-                <q-tooltip v-if="tag.name.length > 18" max-width="30vw">
+                <q-tooltip v-if="tag.name.length > 18" max-width="30vw" style="overflow-wrap: break-word">
                   {{ tag.name }}
                 </q-tooltip>
               </q-chip>

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -42,13 +42,13 @@
               {{ col.value ? '✅' : 	'❌'}}
             </div>
             <div v-else-if="col.name === 'name'">
-              {{ props.row.name?.length < 18 ? props.row.name : props.row.name?.replace(/(.{18})..+/, "$1…") }}
+              {{ props.row.name?.length <= 18 ? props.row.name : props.row.name?.replace(/(.{17})..+/, "$1…") }}
               <q-tooltip v-if="props.row.name.length > 18" max-width="30vw">
                 {{ props.row.name }}
               </q-tooltip>
             </div>
             <div v-else-if="col.name === 'description'">
-              {{ props.row.description?.length < 40 ? props.row.description : props.row.description?.replace(/(.{40})..+/, "$1…") }}
+              {{ props.row.description?.length <= 40 ? props.row.description : props.row.description?.replace(/(.{39})..+/, "$1…") }}
               <q-tooltip v-if="props.row.description?.length > 40" max-width="30vw">
                 {{ props.row.description }}
               </q-tooltip>
@@ -62,8 +62,8 @@
                 clickable
                 @click.stop
               >
-                {{ tag.name.length < 18 ? tag.name : tag.name.replace(/(.{18})..+/, "$1…") }}
-                <q-tooltip v-if="tag.name.length > 18">
+                {{ tag.name.length <= 18 ? tag.name : tag.name.replace(/(.{17})..+/, "$1…") }}
+                <q-tooltip v-if="tag.name.length > 18" max-width="30vw">
                   {{ tag.name }}
                 </q-tooltip>
               </q-chip>

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -41,6 +41,39 @@
             <div v-if="typeof(col.value) === 'boolean'" class="text-body1">
               {{ col.value ? '✅' : 	'❌'}}
             </div>
+            <div v-else-if="col.name === 'name'">
+              {{ props.row.name?.length < 18 ? props.row.name : props.row.name?.replace(/(.{18})..+/, "$1…") }}
+              <q-tooltip v-if="props.row.name.length > 18" max-width="30vw">
+                {{ props.row.name }}
+              </q-tooltip>
+            </div>
+            <div v-else-if="col.name === 'description'">
+              {{ props.row.description?.length < 40 ? props.row.description : props.row.description?.replace(/(.{40})..+/, "$1…") }}
+              <q-tooltip v-if="props.row.description?.length > 40" max-width="30vw">
+                {{ props.row.description }}
+              </q-tooltip>
+            </div>
+            <div v-else-if="col.name === 'tags'">
+              <q-chip
+                v-for="(tag, i) in props.row.tags"
+                :key="i"
+                color="primary" 
+                text-color="white"
+                clickable
+                @click.stop
+              >
+                {{ tag.name.length < 18 ? tag.name : tag.name.replace(/(.{18})..+/, "$1…") }}
+                <q-tooltip v-if="tag.name.length > 18">
+                  {{ tag.name }}
+                </q-tooltip>
+              </q-chip>
+              <q-btn
+                round
+                size="sm"
+                icon="add"
+                @click.stop="$emit('editTags', props.row)"
+              />
+            </div>
             <div v-else>
               {{ col.value }}
             </div>
@@ -96,7 +129,7 @@
   const isMobile = inject('isMobile')
 
   const props = defineProps(['columns', 'rows', 'title', 'showExpand', 'hideEditBtn', 'hideDeleteBtn', 'showToggleDraft', 'hideSearch', 'disableSelect', 'rightCaption'])
-  const emit = defineEmits(['edit', 'delete', 'request', 'expand'])
+  const emit = defineEmits(['edit', 'delete', 'request', 'expand', 'editTags'])
 
   const finalColumns = computed(() => {
     let defaultColumns = [ ...props.columns ]

--- a/src/frontend/src/dialogs/AddTagsDialog.vue
+++ b/src/frontend/src/dialogs/AddTagsDialog.vue
@@ -17,7 +17,7 @@
         class="col q-mb-xs" 
         outlined 
         dense 
-        v-model="name" 
+        v-model.trim="name"  
         autofocus 
         :rules="[requiredRule]" 
         aria-labelledby="tagName"

--- a/src/frontend/src/dialogs/ArtifactsDialog.vue
+++ b/src/frontend/src/dialogs/ArtifactsDialog.vue
@@ -49,7 +49,7 @@
       </label>
       <q-input
         class="col"
-        v-model="description"
+        v-model.trim="description"
         outlined
         type="textarea"
         aria-labelledby="description"

--- a/src/frontend/src/dialogs/ModelsDialog.vue
+++ b/src/frontend/src/dialogs/ModelsDialog.vue
@@ -17,7 +17,7 @@
         class="col q-mb-xs" 
         outlined 
         dense 
-        v-model="name" 
+        v-model.trim="name"  
         autofocus 
         :rules="[requiredRule]" 
         aria-labelledby="modelName"
@@ -49,7 +49,7 @@
       </label>
       <q-input
         class="col"
-        v-model="description"
+        v-model.trim="description"
         outlined
         type="textarea"
         aria-labelledby="description"

--- a/src/frontend/src/dialogs/QueueDialog.vue
+++ b/src/frontend/src/dialogs/QueueDialog.vue
@@ -18,7 +18,7 @@
         class="col q-mb-xs" 
         outlined 
         dense 
-        v-model="name" 
+        v-model.trim="name"  
         autofocus 
         :rules="[requiredRule]" 
         aria-labelledby="queueName"
@@ -50,7 +50,7 @@
       </label>
       <q-input
         class="col"
-        v-model="description"
+        v-model.trim="description"
         outlined
         type="textarea"
         aria-labelledby="description"

--- a/src/frontend/src/dialogs/QueueDraftDialog.vue
+++ b/src/frontend/src/dialogs/QueueDraftDialog.vue
@@ -17,7 +17,7 @@
         class="col q-mb-xs" 
         outlined 
         dense 
-        v-model="name" 
+        v-model.trim="name"  
         autofocus 
         :rules="[requiredRule]" 
         aria-labelledby="queueName"
@@ -49,7 +49,7 @@
       </label>
       <q-input
         class="col"
-        v-model="description"
+        v-model.trim="description"
         outlined
         type="textarea"
         aria-labelledby="description"

--- a/src/frontend/src/views/AllJobsView.vue
+++ b/src/frontend/src/views/AllJobsView.vue
@@ -10,6 +10,7 @@
     @request="getJobs"
     ref="tableRef"
     :hideEditBtn="true"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-entrypoint="props">
       {{ props.row.entrypoint.name }}
@@ -19,22 +20,6 @@
     </template>
     <template #body-cell-group="props">
       {{ props.row.group.name }}
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
   </TableComponent>
 

--- a/src/frontend/src/views/ArtifactsView.vue
+++ b/src/frontend/src/views/ArtifactsView.vue
@@ -15,22 +15,6 @@
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
     </template>
-    <!-- <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="handleTags(props.row)"
-      />
-    </template> -->
     <template #expandedSlot="{ row }">
       <!-- <BasicTable
         :columns="fileColumns"

--- a/src/frontend/src/views/EditPluginsView.vue
+++ b/src/frontend/src/views/EditPluginsView.vue
@@ -8,8 +8,8 @@
           <q-input 
             outlined 
             dense 
-            v-model.trim="plugin.name"
-            :rules="[requiredRule]"
+            v-model="plugin.name"
+            :rules="[requiredRule, pythonModuleNameRule]"
             class="q-mb-sm q-mt-md"
             aria-required="true"
           >
@@ -109,6 +109,22 @@
     } catch(err) {
       notify.error(err.response.data.message)
     } 
+  }
+
+  function pythonModuleNameRule(val) {
+    if (/\s/.test(val)) {
+      return "A Python module name cannot contain spaces."
+    }
+    if (!/^[A-Za-z_]/.test(val)) {
+      return "A Python module name must start with a letter or underscore."
+    }
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(val)) {
+      return "A Python module name can only contain letters, numbers, and underscores."
+    }
+    if (val === "_") {
+      return "A Python module name cannot be '_' with no other characters."
+    }
+    return true
   }
 
 </script>

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -45,7 +45,7 @@
       </label>
     </template>
     <template #expandedSlot="{ row }">
-      <CodeEditor v-model="row.taskGraph" language="yaml" />
+      <CodeEditor v-model="row.taskGraph" language="yaml" :readOnly="true" />
     </template>
     <template #body-cell-plugins="props">
       <q-chip
@@ -87,7 +87,7 @@
         Task Graph YAML
       </label>
     </template>
-    <CodeEditor v-model="displayYaml" style="height: auto;" :readOnly="true" />
+    <CodeEditor v-model="displayYaml" language="yaml" style="height: auto;" :readOnly="true" />
   </InfoPopupDialog>
   <DeleteDialog 
     v-model="showDeleteDialog"

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -13,6 +13,7 @@
     @delete="showDeleteDialog = true"
     @request="getEntrypoints"
     ref="tableRef"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
@@ -45,22 +46,6 @@
     </template>
     <template #expandedSlot="{ row }">
       <CodeEditor v-model="row.taskGraph" language="yaml" />
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
     <template #body-cell-plugins="props">
       <q-chip
@@ -140,7 +125,7 @@
 
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
-    { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true, },
+    { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
     { name: 'taskGraph', label: 'Task Graph', align: 'left', field: 'taskGraph',sortable: true, },
     { name: 'parameterNames', label: 'Parameter Name(s)', align: 'left', sortable: true },
     { name: 'parameterTypes', label: 'Parameter Type(s)', align: 'left', field: 'parameterTypes', sortable: true },

--- a/src/frontend/src/views/ExperimentsView.vue
+++ b/src/frontend/src/views/ExperimentsView.vue
@@ -9,12 +9,16 @@
     @delete="showDeleteDialog = true"
     @request="getExperiments"
     ref="tableRef"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-name="props">
-        <RouterLink :to="`/experiments/${props.row.id}/jobs`">
-          {{props.row.name}}
-        </RouterLink>
-      </template>
+      <RouterLink :to="`/experiments/${props.row.id}/jobs`">
+        {{ props.row.name.length < 18 ? props.row.name : props.row.name.replace(/(.{18})..+/, "$1…") }}
+        <q-tooltip v-if="props.row.name.length > 18" max-width="30vw">
+          {{ props.row.name }}
+        </q-tooltip>
+      </RouterLink>
+    </template>
     <template #body-cell-draft="props">
       <q-chip v-if="props.row.draft" outline color="red" text-color="white" class="q-ml-none">
         DRAFT
@@ -23,22 +27,6 @@
     </template>
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
   </TableComponent>
 

--- a/src/frontend/src/views/ExperimentsView.vue
+++ b/src/frontend/src/views/ExperimentsView.vue
@@ -14,7 +14,7 @@
     <template #body-cell-name="props">
       <RouterLink :to="`/experiments/${props.row.id}/jobs`">
         {{ props.row.name.length < 18 ? props.row.name : props.row.name.replace(/(.{18})..+/, "$1…") }}
-        <q-tooltip v-if="props.row.name.length > 18" max-width="30vw">
+        <q-tooltip v-if="props.row.name.length > 18" max-width="30vw" style="overflow-wrap: break-word">
           {{ props.row.name }}
         </q-tooltip>
       </RouterLink>

--- a/src/frontend/src/views/JobsView.vue
+++ b/src/frontend/src/views/JobsView.vue
@@ -10,6 +10,7 @@
     ref="tableRef"
     :hideEditBtn="true"
     :showExpand="true"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-entrypoint="props">
       {{ props.row.entrypoint.name }}
@@ -31,22 +32,6 @@
         :hideEditTable="true"
         class="q-mx-md"
         :title="`Job Artifacts`"
-      />
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
       />
     </template>
   </TableComponent>

--- a/src/frontend/src/views/ModelsView.vue
+++ b/src/frontend/src/views/ModelsView.vue
@@ -11,25 +11,10 @@
     @request="getModels"
     ref="tableRef"
     @expand="getVersions"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
     <template #expandedSlot="{ row }">
       <TableComponent

--- a/src/frontend/src/views/PluginFiles.vue
+++ b/src/frontend/src/views/PluginFiles.vue
@@ -10,25 +10,10 @@
     :showExpand="true"
     @request="getFiles"
     ref="tableRef"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-tasks="props">
       {{ props.row.tasks.length }}
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
   </TableComponent>
   <q-btn 

--- a/src/frontend/src/views/PluginParamsView.vue
+++ b/src/frontend/src/views/PluginParamsView.vue
@@ -11,25 +11,10 @@
     @request="getPluginParameterTypes"
     ref="tableRef"
     :hideToggleDraft="true"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
   </TableComponent>
   <q-btn 

--- a/src/frontend/src/views/PluginsView.vue
+++ b/src/frontend/src/views/PluginsView.vue
@@ -10,25 +10,10 @@
     :showExpand="true"
     @request="getPlugins"
     ref="tableRef"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
-    </template>
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
     </template>
     <template #expandedSlot="{ row }">
       <q-btn 

--- a/src/frontend/src/views/QueuesView.vue
+++ b/src/frontend/src/views/QueuesView.vue
@@ -11,23 +11,8 @@
     @request="getQueues"
     ref="tableRef"
     :showToggleDraft="true"
+    @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
   >
-    <template #body-cell-tags="props">
-      <q-chip
-        v-for="(tag, i) in props.row.tags"
-        :key="i"
-        color="primary" 
-        text-color="white"
-      >
-        {{ tag.name }}
-      </q-chip>
-      <q-btn
-        round
-        size="sm"
-        icon="add"
-        @click.stop="editObjTags = props.row; showTagsDialog = true"
-      />
-    </template>
     <template #body-cell-hasDraft="props">
       <q-btn
         round


### PR DESCRIPTION
This MR truncates long text for names, tags, and descriptions to better fit everything on the table pages.  If truncated, you can mouse-over to view a tooltip of the full text.  The cutoff for names and tags is 18 characters.  The cutoff for descriptions is 40 characters.