### PR TITLE
fix: update default docker compose command in cookiecutter template

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
@@ -4,7 +4,7 @@
     "container_registry": "",
     "__container_namespace": "dioptra",
     "container_tag": "dev",
-    "docker_compose_path": "/usr/local/bin/docker-compose",
+    "docker_compose_path": "docker compose",
     "systemd_required_mounts": "",
     "nginx_server_name": "dioptra.example.org",
     "nginx_expose_ports_on_localhost_only": ["True", "False"],


### PR DESCRIPTION
This commit changes the default Compose command in the cookiecutter config from the deprecated `docker-compose` to the modern Compose plugin command, `docker compose`.

closes #552