### PR TITLE
fix: an alternative fix for a mypy type error in error_message.py

### DIFF
--- a/src/dioptra/task_engine/error_message.py
+++ b/src/dioptra/task_engine/error_message.py
@@ -259,7 +259,7 @@ def _is_valid_for_sub_schema(
         resolver=jsonschema.validators.RefResolver.from_schema(full_schema),
     )
 
-    return cast(bool, validator.is_valid(sub_instance))
+    return validator.is_valid(sub_instance)
 
 
 def _one_of_too_many_alternatives_satisfied_message_lines(
@@ -280,11 +280,15 @@ def _one_of_too_many_alternatives_satisfied_message_lines(
         in another, with indented lines.
     """
 
-    alt_names = _get_one_of_alternative_names(error.validator_value, schema)
+    # In this specific case, validator_value contains the oneOf alternative
+    # schemas, but the typing is such that mypy can't tell that's the case.
+    alt_schemas = cast(Iterable[Any], error.validator_value)
+
+    alt_names = _get_one_of_alternative_names(alt_schemas, schema)
     error_desc = "Must be exactly one of: {}".format(", ".join(alt_names))
 
     satisfied_alt_names = []
-    for alt_name, alt_schema in zip(alt_names, error.validator_value):
+    for alt_name, alt_schema in zip(alt_names, alt_schemas):
         # Perform a little "mini" validation to determine which alternatives
         # were satisfied, and describe them in the error message.
         if _is_valid_for_sub_schema(schema, alt_schema, error.instance):
@@ -323,9 +327,13 @@ def _one_of_no_alternatives_satisfied_message_lines(
 
     message_lines = []
 
+    # In this specific case, validator_value contains the oneOf alternative
+    # schemas, but the typing is such that mypy can't tell that's the case.
+    alt_schemas = cast(Iterable[Any], error.validator_value)
+
     # First error message line describes the error in basic terms.
 
-    alt_names = _get_one_of_alternative_names(error.validator_value, schema)
+    alt_names = _get_one_of_alternative_names(alt_schemas, schema)
     basic_desc = (
         "Must be exactly one of: {}; all alternatives failed validation."
     ).format(", ".join(alt_names))

--- a/tox.ini
+++ b/tox.ini
@@ -240,6 +240,7 @@ deps =
     mypy_extensions
     types-cryptography
     types-freezegun
+    types-jsonschema
     types-mypy-extensions
     types-python-dateutil
     types-PyYAML


### PR DESCRIPTION
An alternative to the fix from ffeb0a2.

The pypi page for `types-jsonschema` says [1]:

> ... aims to provide accurate annotations for jsonschema==4.23.*

But additional typing information was also added to the `jsonschema` library in 4.23.  I don't really understand how all the typing information interacts, but the aforementioned pypi docs imply we still need the typestub library.  Having the library also resolves the typing error for the return value of `_is_valid_for_sub_schema`, which is something I had fixed (i.e. removal of the library actually seemed to "unfix" it).

The github action errors were:

```
src/dioptra/task_engine/error_message.py:283:47: error: Argument 1 to "_get_one_of_alternative_names" has incompatible type "Any | Unset"; expected "Iterable[Any]"  [arg-type]
src/dioptra/task_engine/error_message.py:287:48: error: Argument 2 to "zip" has incompatible type "Any | Unset"; expected "Iterable[Any]"  [arg-type]
src/dioptra/task_engine/error_message.py:328:47: error: Argument 1 to "_get_one_of_alternative_names" has incompatible type "Any | Unset"; expected "Iterable[Any]"  [arg-type]
Found 3 errors in 1 file (checked 293 source files)
```

so I thought I'd have a closer look at those.  They seem to be coherent problems which can be fixed, all pointing at the same underlying problem.  So I fixed them.

1. https://pypi.org/project/types-jsonschema/