### PR TITLE
fix: resolve internal server error when modifying nonexistent draft

### DIFF
--- a/src/dioptra/restapi/v1/shared/drafts/controller.py
+++ b/src/dioptra/restapi/v1/shared/drafts/controller.py
@@ -191,7 +191,9 @@ def generate_resource_drafts_id_endpoint(
                 request_id=str(uuid.uuid4()), resource="Draft", request_type="POST"
             )
             parsed_obj = request.parsed_obj  # type: ignore
-            draft = self._draft_id_service.modify(draftId, payload=parsed_obj, log=log)
+            draft = self._draft_id_service.modify(
+                draftId, payload=parsed_obj, log=log, error_if_not_found=True
+            )
             return utils.build_resource_draft(
                 cast(models.DraftResource, draft), request_schema
             )


### PR DESCRIPTION
This fixes #547 by raising an error if the specified draft doesn't exist. The swagger docs now correctly report a 404 not found error when attempting to modify a draft that doesn't exist. This issue (and fix) applies to drafts for all applicable endpoints.