### PR TITLE
Fix build-breaking typo in cookiecutter.json

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
@@ -66,7 +66,7 @@
         "argbash": {
             "image": "argbash",
             "namespace": "matejak",
-            "tag": "sha-0d046a",
+            "tag": "sha-0d046ad",
             "registry": ""
         },
         "db": {


### PR DESCRIPTION
The tag for the `argbash` docker container set within cookiecutter.json is currently set to `sha-0d046a`, which doesn't exist and causes a build failure. This PR updates to `sha-0d046ad`, which is a valid tag.

Before fix: 
![Screenshot 2024-07-31 161520](https://github.com/user-attachments/assets/74ba88a1-c049-42bc-90c3-41390ac9c8fa)

After fix: 
![Screenshot 2024-07-31 161541](https://github.com/user-attachments/assets/e77d3ef6-25d0-4e67-b6f7-cc11aa3b09f7)

Maintainers: double check `matejak/argbash:sha-0d046ad` is the intended version from the [argbash Docker Hub repo](https://hub.docker.com/r/matejak/argbash/tags). 