### PR TITLE
feat: sort table columns

### DIFF
--- a/src/dioptra/restapi/v1/artifacts/controller.py
+++ b/src/dioptra/restapi/v1/artifacts/controller.py
@@ -83,12 +83,16 @@ class ArtifactEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         artifacts, total_num_artifacts = self._artifact_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -101,6 +105,8 @@ class ArtifactEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_artifacts,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/artifacts/errors.py
+++ b/src/dioptra/restapi/v1/artifacts/errors.py
@@ -28,6 +28,10 @@ class ArtifactDoesNotExistError(Exception):
     """The requested artifact does not exist."""
 
 
+class ArtifactSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(ArtifactDoesNotExistError)
     def handle_artifact_does_not_exist_error(error):
@@ -40,5 +44,12 @@ def register_error_handlers(api: Api) -> None:
                 "message": "Bad Request - The artifact uri on the registration form "
                 "already exists. Please select another and resubmit."
             },
+            400,
+        )
+
+    @api.errorhandler(ArtifactSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
             400,
         )

--- a/src/dioptra/restapi/v1/artifacts/schema.py
+++ b/src/dioptra/restapi/v1/artifacts/schema.py
@@ -22,6 +22,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -84,5 +85,6 @@ class ArtifactGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /artifacts endpoint."""

--- a/src/dioptra/restapi/v1/entrypoints/controller.py
+++ b/src/dioptra/restapi/v1/entrypoints/controller.py
@@ -100,12 +100,16 @@ class EntrypointEndpoint(Resource):
         search_string = parsed_query_params["search"]
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         entrypoints, total_num_entrypoints = self._entrypoint_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -118,6 +122,8 @@ class EntrypointEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_entrypoints,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/entrypoints/errors.py
+++ b/src/dioptra/restapi/v1/entrypoints/errors.py
@@ -36,6 +36,10 @@ class EntrypointParameterNamesNotUniqueError(Exception):
     """Multiple entrypoint parameters share the same name."""
 
 
+class EntrypointSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(EntrypointDoesNotExistError)
     def handle_entrypoint_does_not_exist_error(error):
@@ -64,3 +68,10 @@ def register_error_handlers(api: Api) -> None:
             "message": "Bad Request - The entrypoint contains multiple parameters "
             "with the same name."
         }, 400
+
+    @api.errorhandler(EntrypointSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
+            400,
+        )

--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -23,6 +23,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -227,5 +228,6 @@ class EntrypointGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /entrypoints endpoint."""

--- a/src/dioptra/restapi/v1/experiments/controller.py
+++ b/src/dioptra/restapi/v1/experiments/controller.py
@@ -112,12 +112,16 @@ class ExperimentEndpoint(Resource):
         search_string = parsed_query_params["search"]
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         experiments, total_num_experiments = self._experiment_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -130,6 +134,8 @@ class ExperimentEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_experiments,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required
@@ -260,12 +266,16 @@ class ExperimentIdJobEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = unquote(parsed_query_params["sort_by"])
+        descending = parsed_query_params["descending"]
 
         jobs, total_num_jobs = self._experiment_job_service.get(
             experiment_id=id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -278,6 +288,8 @@ class ExperimentIdJobEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_jobs,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/experiments/errors.py
+++ b/src/dioptra/restapi/v1/experiments/errors.py
@@ -26,6 +26,10 @@ class ExperimentDoesNotExistError(Exception):
     """The requested experiment does not exist."""
 
 
+class ExperimentSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(ExperimentAlreadyExistsError)
     def handle_experiment_already_exists_error(error):
@@ -40,3 +44,10 @@ def register_error_handlers(api: Api) -> None:
     @api.errorhandler(ExperimentDoesNotExistError)
     def handle_experiment_does_not_exist_error(error):
         return {"message": "Not Found - The requested experiment does not exist"}, 404
+
+    @api.errorhandler(ExperimentSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
+            400,
+        )

--- a/src/dioptra/restapi/v1/experiments/schema.py
+++ b/src/dioptra/restapi/v1/experiments/schema.py
@@ -22,6 +22,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -120,5 +121,6 @@ class ExperimentGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /experiments endpoint."""

--- a/src/dioptra/restapi/v1/jobs/controller.py
+++ b/src/dioptra/restapi/v1/jobs/controller.py
@@ -92,12 +92,16 @@ class JobEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         jobs, total_num_jobs = self._job_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -110,6 +114,8 @@ class JobEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_jobs,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
 

--- a/src/dioptra/restapi/v1/jobs/errors.py
+++ b/src/dioptra/restapi/v1/jobs/errors.py
@@ -48,6 +48,10 @@ class QueueNotRegisteredToEntryPointError(Exception):
     """The requested queue is not registered to the provided entry point."""
 
 
+class JobSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(JobDoesNotExistError)
     def handle_job_does_not_exist_error(error):
@@ -92,3 +96,10 @@ def register_error_handlers(api: Api) -> None:
             "message": "Bad Request - The requested queue is not registered to the "
             "provided entry point"
         }, 400
+
+    @api.errorhandler(JobSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
+            400,
+        )

--- a/src/dioptra/restapi/v1/jobs/schema.py
+++ b/src/dioptra/restapi/v1/jobs/schema.py
@@ -23,6 +23,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -157,6 +158,7 @@ class JobGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /jobs endpoint."""
 
@@ -164,6 +166,7 @@ class JobGetQueryParameters(
 class ExperimentJobGetQueryParameters(
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /experiments/{id}/jobs
     endpoint."""

--- a/src/dioptra/restapi/v1/models/controller.py
+++ b/src/dioptra/restapi/v1/models/controller.py
@@ -99,12 +99,16 @@ class ModelEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         models, total_num_models = self._model_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -117,6 +121,8 @@ class ModelEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_models,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/models/errors.py
+++ b/src/dioptra/restapi/v1/models/errors.py
@@ -32,6 +32,10 @@ class ModelVersionDoesNotExistError(Exception):
     """The requested version of the model does not exist."""
 
 
+class ModelSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(ModelDoesNotExistError)
     def handle_model_does_not_exist_error(error):
@@ -50,5 +54,12 @@ def register_error_handlers(api: Api) -> None:
                 "message": "Bad Request - The model name on the registration form "
                 "already exists. Please select another and resubmit."
             },
+            400,
+        )
+
+    @api.errorhandler(ModelSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
             400,
         )

--- a/src/dioptra/restapi/v1/models/schema.py
+++ b/src/dioptra/restapi/v1/models/schema.py
@@ -23,6 +23,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -157,6 +158,7 @@ class ModelGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /models endpoint."""
 

--- a/src/dioptra/restapi/v1/plugin_parameter_types/controller.py
+++ b/src/dioptra/restapi/v1/plugin_parameter_types/controller.py
@@ -96,6 +96,8 @@ class PluginParameterTypeEndpoint(Resource):
         search_string = parsed_query_params["search"]
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         (
             plugin_parameter_types,
@@ -105,6 +107,8 @@ class PluginParameterTypeEndpoint(Resource):
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -117,6 +121,8 @@ class PluginParameterTypeEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_plugin_param_types,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/plugin_parameter_types/errors.py
+++ b/src/dioptra/restapi/v1/plugin_parameter_types/errors.py
@@ -40,6 +40,10 @@ class PluginParameterTypeMissingParameterError(Exception):
     """The requested plugin parameter type is missing a required parameter."""
 
 
+class PluginParameterSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(PluginParameterTypeMatchesBuiltinTypeError)
     def handle_plugin_parameter_type_matches_builtin_type_error(error):
@@ -80,5 +84,12 @@ def register_error_handlers(api: Api) -> None:
                 "the registration form already exists. Please select "
                 "another and resubmit."
             },
+            400,
+        )
+
+    @api.errorhandler(PluginParameterSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
             400,
         )

--- a/src/dioptra/restapi/v1/plugin_parameter_types/schema.py
+++ b/src/dioptra/restapi/v1/plugin_parameter_types/schema.py
@@ -22,6 +22,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -87,6 +88,7 @@ class PluginParameterTypeGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /pluginParameterTypes
     endpoint."""

--- a/src/dioptra/restapi/v1/plugins/controller.py
+++ b/src/dioptra/restapi/v1/plugins/controller.py
@@ -127,12 +127,16 @@ class PluginEndpoint(Resource):
         search_string = parsed_query_params["search"]
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         plugins, total_num_plugins = self._plugin_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -145,6 +149,8 @@ class PluginEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_plugins,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required
@@ -261,12 +267,16 @@ class PluginIdFilesEndpoint(Resource):
         search_string = parsed_query_params["search"]
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         plugin_files, total_num_plugin_files = self._plugin_id_file_service.get(
             plugin_id=id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
 
@@ -280,6 +290,8 @@ class PluginIdFilesEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_plugin_files,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/plugins/errors.py
+++ b/src/dioptra/restapi/v1/plugins/errors.py
@@ -52,6 +52,10 @@ class PluginTaskOutputParameterNameAlreadyExistsError(Exception):
     """More than one plugin task output parameter is being assigned the same name."""
 
 
+class PluginSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(PluginDoesNotExistError)
     def handle_plugin_does_not_exist_error(error):
@@ -108,3 +112,10 @@ def register_error_handlers(api: Api) -> None:
             "message": "Bad Request - More than one plugin task output parameter is "
             "being assigned the same name."
         }, 400
+
+    @api.errorhandler(PluginSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
+            400,
+        )

--- a/src/dioptra/restapi/v1/plugins/schema.py
+++ b/src/dioptra/restapi/v1/plugins/schema.py
@@ -27,6 +27,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -220,6 +221,7 @@ class PluginGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /plugins endpoint."""
 
@@ -286,5 +288,6 @@ class PluginFilePageSchema(BasePageSchema):
 class PluginFileGetQueryParameters(
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /plugins/{id}/files/ endpoint."""

--- a/src/dioptra/restapi/v1/queues/controller.py
+++ b/src/dioptra/restapi/v1/queues/controller.py
@@ -86,12 +86,16 @@ class QueueEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         queues, total_num_queues = self._queue_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -104,6 +108,8 @@ class QueueEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_queues,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/queues/errors.py
+++ b/src/dioptra/restapi/v1/queues/errors.py
@@ -32,6 +32,10 @@ class QueueLockedError(Exception):
     """The requested queue is locked."""
 
 
+class QueueSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(QueueDoesNotExistError)
     def handle_queue_does_not_exist_error(error):
@@ -48,5 +52,12 @@ def register_error_handlers(api: Api) -> None:
                 "message": "Bad Request - The queue name on the registration form "
                 "already exists. Please select another and resubmit."
             },
+            400,
+        )
+
+    @api.errorhandler(QueueSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
             400,
         )

--- a/src/dioptra/restapi/v1/queues/schema.py
+++ b/src/dioptra/restapi/v1/queues/schema.py
@@ -22,6 +22,7 @@ from dioptra.restapi.v1.schemas import (
     GroupIdQueryParametersSchema,
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
     generate_base_resource_ref_schema,
     generate_base_resource_schema,
 )
@@ -86,5 +87,6 @@ class QueueGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /queues endpoint."""

--- a/src/dioptra/restapi/v1/queues/service.py
+++ b/src/dioptra/restapi/v1/queues/service.py
@@ -32,7 +32,7 @@ from dioptra.restapi.v1 import utils
 from dioptra.restapi.v1.groups.service import GroupIdService
 from dioptra.restapi.v1.shared.search_parser import construct_sql_query_filters
 
-from .errors import QueueAlreadyExistsError, QueueDoesNotExistError
+from .errors import QueueAlreadyExistsError, QueueDoesNotExistError, QueueSortError
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
@@ -41,6 +41,12 @@ SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "name": lambda x: models.Queue.name.like(x, escape="/"),
     "description": lambda x: models.Queue.description.like(x, escape="/"),
     "tag": lambda x: models.Queue.tags.any(models.Tag.name.like(x, escape="/")),
+}
+SORTABLE_FIELDS: Final[dict[str, Any]] = {
+    "name": models.Queue.name,
+    "createdOn": models.Queue.created_on,
+    "lastModifiedOn": models.Resource.last_modified_on,
+    "description": models.Queue.description,
 }
 
 
@@ -118,6 +124,8 @@ class QueueService(object):
         search_string: str,
         page_index: int,
         page_length: int,
+        sort_by_string: str,
+        descending: bool,
         **kwargs,
     ) -> tuple[list[utils.QueueDict], int]:
         """Fetch a list of queues, optionally filtering by search string and paging
@@ -128,6 +136,8 @@ class QueueService(object):
             search_string: A search string used to filter results.
             page_index: The index of the first group to be returned.
             page_length: The maximum number of queues to be returned.
+            sort_by_string: The name of the column to sort.
+            descending: Boolean indicating whether to sort by descending or not.
 
         Returns:
             A tuple containing a list of queues and the total number of queues matching
@@ -183,6 +193,18 @@ class QueueService(object):
             .offset(page_index)
             .limit(page_length)
         )
+
+        if sort_by_string and sort_by_string in SORTABLE_FIELDS:
+            sort_column = SORTABLE_FIELDS[sort_by_string]
+            if descending:
+                sort_column = sort_column.desc()
+            else:
+                sort_column = sort_column.asc()
+            queues_stmt = queues_stmt.order_by(sort_column)
+        elif sort_by_string and sort_by_string not in SORTABLE_FIELDS:
+            log.debug(f"sort_by_string: '{sort_by_string}' is not in SORTABLE_FIELDS")
+            raise QueueSortError
+
         queues = list(db.session.scalars(queues_stmt).all())
 
         drafts_stmt = select(

--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -238,6 +238,24 @@ class SearchQueryParametersSchema(Schema):
     )
 
 
+class SortByGetQueryParametersSchema(Schema):
+    """A schema for adding sort query parameters to a resource endpoint."""
+
+    sortBy = fields.String(
+        attribute="sort_by",
+        metadata=dict(description="The name of the column to sort."),
+        load_default="",
+    )
+
+    descending = fields.Bool(
+        attribute="descending",
+        metadata=dict(
+            description="Boolean indicating whether to sort by descending or not."
+        ),
+        load_default=False,
+    )
+
+
 class ResourceGetQueryParameters(
     PagingQueryParametersSchema,
     SearchQueryParametersSchema,

--- a/src/dioptra/restapi/v1/tags/controller.py
+++ b/src/dioptra/restapi/v1/tags/controller.py
@@ -75,12 +75,16 @@ class TagEndpoint(Resource):
         search_string = unquote(parsed_query_params["search"])
         page_index = parsed_query_params["index"]
         page_length = parsed_query_params["page_length"]
+        sort_by_string = parsed_query_params["sort_by"]
+        descending = parsed_query_params["descending"]
 
         tags, total_num_tags = self._tag_service.get(
             group_id=group_id,
             search_string=search_string,
             page_index=page_index,
             page_length=page_length,
+            sort_by_string=sort_by_string,
+            descending=descending,
             log=log,
         )
         return utils.build_paging_envelope(
@@ -93,6 +97,8 @@ class TagEndpoint(Resource):
             index=page_index,
             length=page_length,
             total_num_elements=total_num_tags,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
     @login_required

--- a/src/dioptra/restapi/v1/tags/errors.py
+++ b/src/dioptra/restapi/v1/tags/errors.py
@@ -28,6 +28,10 @@ class TagDoesNotExistError(Exception):
     """The requested tag does not exist."""
 
 
+class TagSortError(Exception):
+    """The requested sortBy column is not a sortable field."""
+
+
 def register_error_handlers(api: Api) -> None:
     @api.errorhandler(TagDoesNotExistError)
     def handle_tag_does_not_exist_error(error):
@@ -36,3 +40,10 @@ def register_error_handlers(api: Api) -> None:
     @api.errorhandler(TagAlreadyExistsError)
     def handle_tag_already_exists_error(error):
         return {"message": "Bad Request - The tag name already exists."}, 400
+
+    @api.errorhandler(TagSortError)
+    def handle_queue_sort_error(error):
+        return (
+            {"message": "Bad Request - This column can not be sorted."},
+            400,
+        )

--- a/src/dioptra/restapi/v1/tags/schema.py
+++ b/src/dioptra/restapi/v1/tags/schema.py
@@ -26,6 +26,7 @@ from dioptra.restapi.v1.schemas import (
     PagingQueryParametersSchema,
     ResourceTypeQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 )
 from dioptra.restapi.v1.users.schema import UserRefSchema
 
@@ -117,6 +118,7 @@ class TagGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,
     SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
 ):
     """The query parameters for the GET method of the /tags endpoint."""
 

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -15,7 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 """Utility functions to help in building responses from ORM models"""
-from typing import Any, Callable, Final, TypedDict, cast
+from typing import Any, Callable, Final, Optional, TypedDict, cast
 from urllib.parse import urlencode, urlunparse
 
 from marshmallow import Schema
@@ -994,6 +994,8 @@ def build_paging_envelope(
     index: int,
     length: int,
     total_num_elements: int,
+    sort_by: Optional[str] = None,
+    descending: Optional[bool] = None,
 ) -> dict[str, Any]:
     """Build the paging envelope for a response.
 
@@ -1008,6 +1010,8 @@ def build_paging_envelope(
         index: The index of the current page.
         length: The number of results to return per page.
         total_num_elements: The total number of elements in the collection.
+        sort_by: The name of the column to sort.
+        descending: Boolean indicating whether to sort by descending or not.
 
     Returns:
         The paging envelope for the response.
@@ -1020,6 +1024,8 @@ def build_paging_envelope(
         "index": index,
         "is_complete": is_complete,
         "total_num_results": total_num_elements,
+        "sort_by": sort_by,
+        "descending": descending,
         "first": build_paging_url(
             route_prefix,
             group_id=group_id,

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -76,7 +76,11 @@
                 text-color="black"
               />
             </div>
-            <div v-else>
+            <div v-else-if="col.name === 'createdOn' || col.name === 'lastModifiedOn'">
+              {{ formatDate(col.value) }}
+            </div>
+            <div v-else-if="!Array.isArray(col.value)">
+              <!-- if value is an array, then render it with a custom slot -->
               {{ col.value }}
             </div>
           </slot>
@@ -141,6 +145,12 @@
     }
     if(props.showExpand) {
       defaultColumns.push({ name: 'expand', align: 'center', sortable: false, label: 'Expand' })
+    }
+    if(showDrafts.value) {
+      defaultColumns = defaultColumns.map(column => ({
+        ...column,
+        sortable: false
+      }))
     }
     return defaultColumns
   })
@@ -215,6 +225,11 @@
     if(expanded) {
       emit('expand', row)
     }
+  }
+
+  function formatDate(dateString) {
+    const options = { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
+    return new Date(dateString).toLocaleString('en-US', options)
   }
 
 </script>

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -130,7 +130,9 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
       index: pagination.index,
       pageLength: pagination.rowsPerPage,
       search: urlEncode(pagination.search),
-      draftType: showDrafts ? 'new' : ''
+      draftType: showDrafts ? 'new' : '',
+      sortBy: pagination.sortBy,
+      descending: pagination.descending,
     },
   })
   if(showDrafts && res.data.data) {
@@ -148,6 +150,8 @@ export async function getJobs(id: number, pagination: Pagination) {
       index: pagination.index,
       pageLength: pagination.rowsPerPage,
       search: urlEncode(pagination.search),
+      sortBy: pagination.sortBy,
+      descending: pagination.descending,
     }
   })
 }
@@ -230,7 +234,9 @@ export async function getFiles(id: number, pagination: Pagination) {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage,
-      search: urlEncode(pagination.search)
+      search: urlEncode(pagination.search),
+      sortBy: pagination.sortBy,
+      descending: pagination.descending,
     }
   })
 }

--- a/src/frontend/src/views/AllJobsView.vue
+++ b/src/frontend/src/views/AllJobsView.vue
@@ -59,9 +59,9 @@
 
   const columns = [
     { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
-    { name: 'id', label: 'Job ID', align: 'left', field: 'id', sortable: true, },
-    { name: 'entrypoint', label: 'Entrypoint', align: 'left', field: 'entrypoint', sortable: true, },
-    { name: 'queue', label: 'Queue', align: 'left', field: 'queue', sortable: true, },
+    { name: 'id', label: 'Job ID', align: 'left', field: 'id', sortable: false, },
+    { name: 'entrypoint', label: 'Entrypoint', align: 'left', field: 'entrypoint', sortable: false, },
+    { name: 'queue', label: 'Queue', align: 'left', field: 'queue', sortable: false, },
     { name: 'status', label: 'Status', align: 'left', field: 'status', sortable: true },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
   ]

--- a/src/frontend/src/views/ArtifactsView.vue
+++ b/src/frontend/src/views/ArtifactsView.vue
@@ -94,9 +94,10 @@ async function getArtifacts(pagination) {
 }
 
 const columns = [
-  { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: false },
-  { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true },
+  { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: true },
   { name: 'uri', label: 'uri', align: 'left', field: 'uri', sortable: true },
+  { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', sortable: true },
+  { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', sortable: true },
   // { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
 ]
 

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -478,7 +478,7 @@
 
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
-    { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: false },
+    { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: true },
     { name: 'view', label: 'Structure', align: 'left', sortable: false },
   ]
 
@@ -505,7 +505,7 @@
   const outputParamForm = ref(null)
 
   const taskColumns = [
-    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
+    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: false, },
     { name: 'inputParams', label: 'Input Params', field: 'inputParams', align: 'left', sortable: false },
     { name: 'outputParams', label: 'Output Params', field: 'outputParams', align: 'left', sortable: false },
     { name: 'actions', label: 'Actions', align: 'center', },

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -8,7 +8,6 @@
     :showExpand="true"
     title="Entrypoints"
     v-model:selected="selected"
-    :pagination="{sortBy: 'draft', descending: true}"
     @edit="router.push(`/entrypoints/${selected[0].id}`)"
     @delete="showDeleteDialog = true"
     @request="getEntrypoints"
@@ -126,12 +125,12 @@
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
     { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
-    { name: 'taskGraph', label: 'Task Graph', align: 'left', field: 'taskGraph',sortable: true, },
-    { name: 'parameterNames', label: 'Parameter Name(s)', align: 'left', sortable: true },
-    { name: 'parameterTypes', label: 'Parameter Type(s)', align: 'left', field: 'parameterTypes', sortable: true },
-    { name: 'defaultValues', label: 'Default Values', align: 'left', field: 'defaultValues', sortable: true },
-    { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: true },
-    { name: 'plugins', label: 'Plugins', align: 'left', field: 'plugins', sortable: true },
+    { name: 'taskGraph', label: 'Task Graph', align: 'left', field: 'taskGraph',sortable: false, },
+    { name: 'parameterNames', label: 'Parameter Name(s)', align: 'left', sortable: false },
+    { name: 'parameterTypes', label: 'Parameter Type(s)', align: 'left', field: 'parameterTypes', sortable: false },
+    { name: 'defaultValues', label: 'Default Values', align: 'left', field: 'defaultValues', sortable: false },
+    { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
+    { name: 'plugins', label: 'Plugins', align: 'left', field: 'plugins', sortable: false },
   ]
 
   const selected = ref([])

--- a/src/frontend/src/views/ExperimentsView.vue
+++ b/src/frontend/src/views/ExperimentsView.vue
@@ -19,15 +19,6 @@
         </q-tooltip>
       </RouterLink>
     </template>
-    <template #body-cell-draft="props">
-      <q-chip v-if="props.row.draft" outline color="red" text-color="white" class="q-ml-none">
-        DRAFT
-      </q-chip>
-      <span v-else></span>
-    </template>
-    <template #body-cell-group="props">
-      <div>{{ props.row.group.name }}</div>
-    </template>
     <template #body-cell-entrypoints="props">
       <q-chip
         v-for="(entrypoint, i) in props.row.entrypoints"
@@ -98,11 +89,9 @@
   const experiments = ref([])
 
   const columns = [
-    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, sort: (a, b) => a - b },
-    { name: 'draft', label: 'Draft', align: 'left', field: 'draft', sortable: true },
-    { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true },
-    { name: 'entrypoints', label: 'Entry Points', align: 'left', field: 'entrypoints', sortable: true },
-    { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: false },
+    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
+    { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true },
+    { name: 'entrypoints', label: 'Entry Points', align: 'left', field: 'entrypoints', sortable: false },
     { name: 'tags', label: 'Tags', align: 'left', sortable: false },
   ]
 

--- a/src/frontend/src/views/JobsView.vue
+++ b/src/frontend/src/views/JobsView.vue
@@ -88,9 +88,9 @@
 
   const columns = [
     { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
-    { name: 'id', label: 'Job ID', align: 'left', field: 'id', sortable: true, },
-    { name: 'entrypoint', label: 'Entrypoint', align: 'left', field: 'entrypoint', sortable: true, },
-    { name: 'queue', label: 'Queue', align: 'left', field: 'queue', sortable: true, },
+    { name: 'id', label: 'Job ID', align: 'left', field: 'id', sortable: false, },
+    { name: 'entrypoint', label: 'Entrypoint', align: 'left', field: 'entrypoint', sortable: false, },
+    { name: 'queue', label: 'Queue', align: 'left', field: 'queue', sortable: false, },
     { name: 'status', label: 'Status', align: 'left', field: 'status', sortable: true },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
   ]

--- a/src/frontend/src/views/ModelsView.vue
+++ b/src/frontend/src/views/ModelsView.vue
@@ -104,8 +104,9 @@ async function getModels(pagination) {
 
 const columns = [
   { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true,  },
-  { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: false },
-  { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true },
+  { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: true },
+  { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', sortable: true },
+  { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', sortable: true },
   { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
 ]
 

--- a/src/frontend/src/views/PluginFiles.vue
+++ b/src/frontend/src/views/PluginFiles.vue
@@ -67,8 +67,8 @@
 
   const fileColumns = [
     { name: 'filename', label: 'Filename', align: 'left', field: 'filename', sortable: true, },
-    { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: false },
-    { name: 'tasks', label: 'Tasks', align: 'left', field: 'tasks', sortable: true, },
+    { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: true },
+    { name: 'tasks', label: 'Tasks', align: 'left', field: 'tasks', sortable: false, },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
   ]
 

--- a/src/frontend/src/views/PluginParamsView.vue
+++ b/src/frontend/src/views/PluginParamsView.vue
@@ -89,8 +89,9 @@
 
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
-    { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true },
-    { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: false },
+    { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: true },
+    { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', sortable: true },
+    { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', sortable: true },
     { name: 'tags', label: 'Tags', align: 'left', sortable: false },
   ]
 

--- a/src/frontend/src/views/PluginsView.vue
+++ b/src/frontend/src/views/PluginsView.vue
@@ -15,6 +15,9 @@
     <template #body-cell-group="props">
       <div>{{ props.row.group.name }}</div>
     </template>
+    <template #body-cell-files="props">
+      <div>{{ props.row.files?.length }}</div>
+    </template>
     <template #expandedSlot="{ row }">
       <q-btn 
         color="primary" 
@@ -107,10 +110,9 @@
   }
 
   const columns = [
-    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, sort: (a, b) => a - b },
-    { name: 'group', label: 'Group', align: 'left', field: 'group', sortable: true },
-    { name: 'files', label: 'Files', align: 'left', sortable: false },
-    { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: false },
+    { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true },
+    { name: 'description', label: 'Description', field: 'description',align: 'left', sortable: true },
+    { name: 'files', label: 'Number of Files', align: 'left', field: 'files', sortable: false },
     { name: 'tags', label: 'Tags', align: 'left', sortable: false },
   ]
 

--- a/src/frontend/src/views/QueuesView.vue
+++ b/src/frontend/src/views/QueuesView.vue
@@ -89,11 +89,10 @@
 
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true },
-    // { name: 'id', label: 'Queue ID', align: 'left', field: 'id', sortable: true },
-    // { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', format: val => `${formatDate(val)}`, sortable: true },
-    // { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', format: val => `${formatDate(val)}`, sortable: true },
     { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true },
-    { name: 'hasDraft', label: 'hasDraft', align: 'left', field: 'hasDraft', sortable: true },
+    { name: 'hasDraft', label: 'hasDraft', align: 'left', field: 'hasDraft', sortable: false },
+    { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', sortable: true },
+    { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', sortable: true },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
   ]
 
@@ -176,13 +175,6 @@
       notify.error(err.response.data.message)
     }
   }
-
-  function formatDate(dateString) {
-    const options = { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
-    return new Date(dateString).toLocaleString('en-US', options)
-  }
-
-
 
   const editing = ref(false)
 

--- a/src/frontend/src/views/TagsView.vue
+++ b/src/frontend/src/views/TagsView.vue
@@ -61,10 +61,9 @@
 
   const columns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true },
-    { name: 'id', label: 'Tag ID', align: 'left', field: 'id', sortable: true },
-    { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', format: val => `${formatDate(val)}`, sortable: true },
-    { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', format: val => `${formatDate(val)}`, sortable: true },
-    // { name: 'chips', label: 'Custom Column Example',align: 'left', sortable: false },
+    { name: 'id', label: 'Tag ID', align: 'left', field: 'id', sortable: false },
+    { name: 'createdOn', label: 'Created On', align: 'left', field: 'createdOn', sortable: true },
+    { name: 'lastModifiedOn', label: 'Last Modified', align: 'left', field: 'lastModifiedOn', sortable: true },
   ]
 
   async function getTags(pagination) {
@@ -102,11 +101,6 @@
     } catch(err) {
       notify.error(err.response.data.message)
     }
-  }
-
-  function formatDate(dateString) {
-    const options = { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true };
-    return new Date(dateString).toLocaleString('en-US', options);
   }
 
   const selected = ref([])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode
 import pytest
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-v1", action="store_true", default=False, help="run v1 tests"

--- a/tests/unit/restapi/lib/asserts.py
+++ b/tests/unit/restapi/lib/asserts.py
@@ -24,9 +24,7 @@ from dioptra.restapi.routes import V1_ROOT
 from . import actions, helpers
 
 
-def assert_base_resource_contents_match_expectations(
-    response: dict[str, Any]
-) -> None:
+def assert_base_resource_contents_match_expectations(response: dict[str, Any]) -> None:
     assert isinstance(response["id"], int)
     assert isinstance(response["snapshot"], int)
     assert isinstance(response["createdOn"], str)

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -632,6 +632,7 @@ def registered_jobs(
 ) -> dict[str, Any]:
     # Inline import necessary to prevent circular import
     import dioptra.restapi.v1.shared.rq_service as rq_service
+
     monkeypatch.setattr(rq_service, "RQQueue", mock_rq.MockRQQueue)
 
     queue_id = registered_queues["queue1"]["snapshot"]

--- a/tests/unit/restapi/v1/test_experiment.py
+++ b/tests/unit/restapi/v1/test_experiment.py
@@ -251,6 +251,41 @@ def assert_retrieving_all_experiments_works(
     assert response.status_code == 200 and response.get_json()["data"] == expected
 
 
+def assert_sorting_experiment_works(
+    client: FlaskClient,
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Assert that experiments can be sorted by column ascending/descending.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected order of experiment ids after sorting.
+            See test_experiment_sort for expected orders.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    query_string["sortBy"] = sortBy
+    query_string["descending"] = descending
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_EXPERIMENTS_ROUTE}",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    response_data = response.get_json()
+    experiment_ids = [experiment["id"] for experiment in response_data["data"]]
+
+    assert response.status_code == 200 and experiment_ids == expected
+
+
 def assert_experiment_name_matches_expected_name(
     client: FlaskClient, experiment_id: int, expected_name: str
 ) -> None:
@@ -364,6 +399,42 @@ def test_experiment_get_all(
     ]
 
     assert_retrieving_all_experiments_works(client, expected=experiment_expected_list)
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        (None, None, ["experiment1", "experiment2", "experiment3"]),
+        ("name", True, ["experiment3", "experiment2", "experiment1"]),
+        ("name", False, ["experiment1", "experiment2", "experiment3"]),
+        ("createdOn", True, ["experiment3", "experiment2", "experiment1"]),
+        ("createdOn", False, ["experiment1", "experiment2", "experiment3"]),
+    ],
+)
+def test_experiment_sort(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_experiments: dict[str, Any],
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Test that experiments can be sorted by column.
+
+    Given an authenticated user and registered experiments, this test validates the
+      following sequence of actions:
+
+    - A user registers three experiments: "experiment1", "experiment2", "experiment3".
+    - The user is able to retrieve a list of all registered experiments sorted by a
+      column ascending/descending.
+    - The returned list of experiments matches the order in the parametrize lists above.
+    """
+
+    expected_ids = [
+        registered_experiments[expected_name]["id"] for expected_name in expected
+    ]
+    assert_sorting_experiment_works(client, sortBy, descending, expected=expected_ids)
 
 
 def test_experiment_search_query(
@@ -774,7 +845,8 @@ def test_manage_existing_experiment_draft(
     auth_account: dict[str, Any],
     registered_experiments: dict[str, Any],
 ) -> None:
-    """Test that a draft of an existing experiment can be created and managed by the user
+    """Test that a draft of an existing experiment can be created and managed by the
+        user
 
     Given an authenticated user and registered experiments, this test validates the
     following sequence of actions:

--- a/tests/unit/restapi/v1/test_io_file_service.py
+++ b/tests/unit/restapi/v1/test_io_file_service.py
@@ -123,10 +123,7 @@ def test_sanitize_file_path_preserve_windows(
 
 
 def test_unsafe_tarball_path(tmp_path: Path, io_file_service: IOFileService) -> None:
-    unsafe_tar_content = {
-        "/a/b/c": b"123",
-        "/a/../../b/c": b"456"
-    }
+    unsafe_tar_content = {"/a/b/c": b"123", "/a/../../b/c": b"456"}
 
     tarball_bytes = make_tarball_bytes(unsafe_tar_content)
 

--- a/tests/unit/restapi/v1/test_plugin.py
+++ b/tests/unit/restapi/v1/test_plugin.py
@@ -23,6 +23,7 @@ registered, renamed, and deleted as expected through the REST API.
 import textwrap
 from typing import Any, List
 
+import pytest
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.test import TestResponse
@@ -294,6 +295,41 @@ def assert_retrieving_plugins_works(
     assert response.status_code == 200 and response.get_json()["data"] == expected
 
 
+def assert_sorting_plugin_works(
+    client: FlaskClient,
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Assert that plugins can be sorted by column ascending/descending.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected order of plugins ids after sorting.
+            See test_plugin_sort for expected orders.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    query_string["sortBy"] = sortBy
+    query_string["descending"] = descending
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_PLUGINS_ROUTE}",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    response_data = response.get_json()
+    plugin_ids = [plugin["id"] for plugin in response_data["data"]]
+
+    assert response.status_code == 200 and plugin_ids == expected
+
+
 def assert_registering_existing_plugin_name_fails(
     client: FlaskClient, name: str, group_id: int
 ) -> None:
@@ -524,6 +560,41 @@ def assert_retrieving_plugin_files_works(
     assert response.status_code == 200 and response.get_json()["data"] == expected
 
 
+def assert_sorting_plugin_file_works(
+    client: FlaskClient,
+    sortBy: str,
+    descending: bool,
+    plugin_id: int,
+    expected: list[str],
+) -> None:
+    """Assert that plugin files can be sorted by column ascending/descending.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected order of plugins ids after sorting.
+            See test_plugin_file_sort for expected orders.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    query_string["sortBy"] = sortBy
+    query_string["descending"] = descending
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_PLUGINS_ROUTE}/{plugin_id}/files",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    response_data = response.get_json()
+    plugin_ids = [file["id"] for file in response_data["data"]]
+    assert response.status_code == 200 and plugin_ids == expected
+
+
 def assert_registering_existing_plugin_filename_fails(
     client: FlaskClient,
     plugin_id: int,
@@ -731,6 +802,42 @@ def test_plugin_get_all(
     """
     plugin_expected_list = list(registered_plugins.values())
     assert_retrieving_plugins_works(client, expected=plugin_expected_list)
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        (None, None, ["plugin1", "plugin2", "plugin3"]),
+        ("name", True, ["plugin2", "plugin3", "plugin1"]),
+        ("name", False, ["plugin1", "plugin3", "plugin2"]),
+        ("createdOn", True, ["plugin3", "plugin2", "plugin1"]),
+        ("createdOn", False, ["plugin1", "plugin2", "plugin3"]),
+    ],
+)
+def test_plugin_sort(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_plugins: dict[str, Any],
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Test that plugins can be sorted by column.
+
+    Given an authenticated user and registered plugins, this test validates the
+    following sequence of actions:
+
+    - A user registers three plugins, "plugin_one", "plugin_two", "plugin_three".
+    - The user is able to retrieve a list of all registered plugins sorted by a column
+      ascending/descending.
+    - The returned list of plugins matches the order in the parametrize lists above.
+    """
+
+    expected_ids = [
+        registered_plugins[expected_name]["id"] for expected_name in expected
+    ]
+    assert_sorting_plugin_works(client, sortBy, descending, expected=expected_ids)
 
 
 def test_plugin_search_query(
@@ -1025,6 +1132,52 @@ def test_plugin_file_get_all(
         client,
         plugin_id=registered_plugin["id"],
         expected=plugin_file_expected_list,
+    )
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        (None, None, ["plugin_file1", "plugin_file2", "plugin_file3"]),
+        ("filename", True, ["plugin_file2", "plugin_file3", "plugin_file1"]),
+        ("filename", False, ["plugin_file1", "plugin_file3", "plugin_file2"]),
+        ("createdOn", True, ["plugin_file3", "plugin_file2", "plugin_file1"]),
+        ("createdOn", False, ["plugin_file1", "plugin_file2", "plugin_file3"]),
+    ],
+)
+def test_plugin_file_sort(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_plugin_with_files: dict[str, Any],
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Test that plugin files can be sorted by column.
+
+    Given an authenticated user and registered plugin files, this test validates the
+    following sequence of actions:
+
+    - A user registers three plugin files:
+      "plugin_file_one.py",
+      "plugin_file_two.py",
+      "plugin_file_three.py".
+    - The user is able to retrieve a list of all registered plugins files sorted by a
+      column ascending/descending.
+    - The returned list of plugin files matches the order in the parametrize lists
+      above.
+    """
+
+    expected_ids = [
+        registered_plugin_with_files[expected_name]["id"] for expected_name in expected
+    ]
+    assert_sorting_plugin_file_works(
+        client,
+        sortBy,
+        descending,
+        plugin_id=registered_plugin_with_files["plugin"]["id"],
+        expected=expected_ids,
     )
 
 
@@ -1561,8 +1714,8 @@ def test_manage_plugin_snapshots(
 ) -> None:
     """Test that different snapshots of a plugin can be retrieved by the user.
 
-    Given an authenticated user and registered plugins, this test validates the following
-    sequence of actions:
+    Given an authenticated user and registered plugins, this test validates the
+    following sequence of actions:
 
     - The user modifies a plugin
     - The user retrieves information about the original snapshot of the plugin and gets

--- a/tests/unit/restapi/v1/test_plugin_parameter_type.py
+++ b/tests/unit/restapi/v1/test_plugin_parameter_type.py
@@ -128,6 +128,47 @@ def assert_retrieving_plugin_parameter_types_works(
     assert response.status_code == 200 and response.get_json()["data"] == expected
 
 
+def assert_sorting_plugin_parameter_type_works(
+    client: FlaskClient,
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Assert that plugin parameter types can be sorted by column ascending/descending.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected order of type ids after sorting.
+          See test_plugin_parameter_type_sort for expected orders.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    query_string["sortBy"] = sortBy
+    query_string["descending"] = descending
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_PLUGIN_PARAMETER_TYPES_ROUTE}",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    response_data = response.get_json()
+    # remove plugin param types created by default before testing
+    names_to_remove = ["any", "string", "integer", "number", "boolean", "null"]
+    filtered_data = [
+        item for item in response_data["data"] if item["name"] not in names_to_remove
+    ]
+
+    param_ids = [param["id"] for param in filtered_data]
+
+    assert response.status_code == 200 and param_ids == expected
+
+
 def assert_retrieving_plugin_parameter_type_by_id_works(
     client: FlaskClient, id: int, expected: dict[str, Any]
 ) -> None:
@@ -422,6 +463,66 @@ def test_get_all_plugin_parameter_types(
     plugin_param_type_expected_list = list(registered_plugin_parameter_types.values())
     assert_retrieving_plugin_parameter_types_works(
         client, expected=plugin_param_type_expected_list
+    )
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        (
+            None,
+            None,
+            ["plugin_param_type1", "plugin_param_type2", "plugin_param_type3"],
+        ),
+        (
+            "name",
+            True,
+            ["plugin_param_type2", "plugin_param_type3", "plugin_param_type1"],
+        ),
+        (
+            "name",
+            False,
+            ["plugin_param_type1", "plugin_param_type3", "plugin_param_type2"],
+        ),
+        (
+            "createdOn",
+            True,
+            ["plugin_param_type3", "plugin_param_type2", "plugin_param_type1"],
+        ),
+        (
+            "createdOn",
+            False,
+            ["plugin_param_type1", "plugin_param_type2", "plugin_param_type3"],
+        ),
+    ],
+)
+def test_plugin_parameter_type_sort(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_plugin_parameter_types: dict[str, Any],
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Test that plugin param types can be sorted by column.
+
+    Given an authenticated user and registered types, this test validates the following
+    sequence of actions:
+
+    - A user registers three types, "image_shape", "model_output", "model".
+    - The user is able to retrieve a list of all registered types sorted by a column
+      ascending/descending.
+    - The returned list of plugin param types matches the order in the parametrize lists
+      above.
+    """
+
+    expected_ids = [
+        registered_plugin_parameter_types[expected_name]["id"]
+        for expected_name in expected
+    ]
+    assert_sorting_plugin_parameter_type_works(
+        client, sortBy, descending, expected=expected_ids
     )
 
 

--- a/tests/unit/restapi/v1/test_queue.py
+++ b/tests/unit/restapi/v1/test_queue.py
@@ -22,6 +22,7 @@ registered, renamed, deleted, and locked/unlocked as expected through the REST A
 """
 from typing import Any
 
+import pytest
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.test import TestResponse
@@ -209,6 +210,41 @@ def assert_retrieving_queues_works(
     assert response.status_code == 200 and response.get_json()["data"] == expected
 
 
+def assert_sorting_queue_works(
+    client: FlaskClient,
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Assert that queues can be sorted by column ascending/descending.
+
+    Args:
+        client: The Flask test client.
+        expected: The expected order of queue ids after sorting.
+            See test_queue_sort for expected orders.
+
+    Raises:
+        AssertionError: If the response status code is not 200 or if the API response
+            does not match the expected response.
+    """
+
+    query_string: dict[str, Any] = {}
+
+    query_string["sortBy"] = sortBy
+    query_string["descending"] = descending
+
+    response = client.get(
+        f"/{V1_ROOT}/{V1_QUEUES_ROUTE}",
+        query_string=query_string,
+        follow_redirects=True,
+    )
+
+    response_data = response.get_json()
+    queue_ids = [queue["id"] for queue in response_data["data"]]
+
+    assert response.status_code == 200 and queue_ids == expected
+
+
 def assert_registering_existing_queue_name_fails(
     client: FlaskClient, name: str, group_id: int
 ) -> None:
@@ -374,6 +410,42 @@ def test_queue_get_all(
     """
     queue_expected_list = list(registered_queues.values())
     assert_retrieving_queues_works(client, expected=queue_expected_list)
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        (None, None, ["queue1", "queue2", "queue3"]),
+        ("name", True, ["queue2", "queue1", "queue3"]),
+        ("name", False, ["queue3", "queue1", "queue2"]),
+        ("createdOn", True, ["queue3", "queue2", "queue1"]),
+        ("createdOn", False, ["queue1", "queue2", "queue3"]),
+    ],
+)
+def test_queue_sort(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_queues: dict[str, Any],
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    """Test that queues can be sorted by column.
+
+    Given an authenticated user and registered queues, this test validates the following
+    sequence of actions:
+
+    - A user registers three queues, "tensorflow_cpu", "tensorflow_gpu", "pytorch_cpu".
+    - The user is able to retrieve a list of all registered queues sorted by a column
+      ascending/descending.
+    - The returned list of queues matches the order in the parametrize lists above.
+    """
+
+    expected_ids = [
+        registered_queues[expected_name]["id"] for expected_name in expected
+    ]
+    assert_sorting_queue_works(client, sortBy, descending, expected=expected_ids)
 
 
 def test_queue_search_query(

--- a/tests/unit/restapi/v1/test_user.py
+++ b/tests/unit/restapi/v1/test_user.py
@@ -21,7 +21,6 @@ registered, modified, and deleted as expected through the REST API.
 """
 from typing import Any
 
-import pytest
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.test import TestResponse


### PR DESCRIPTION
This PR adds the ability to sort table columns, specifically name, description, createdOn, and lastModified.  Also, jobs are sortable by status and artifacts are sortable by uri.  Not every table has all these columns because of space, but this is easily configurable if we want to change the default columns.

Tests were also added for each resource type to verify sort order.