### PR TITLE
fix: return correct createdOn timestamp for all resources

### DIFF
--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -544,7 +544,7 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         "description": experiment.description,
         "user": build_user_ref(experiment.creator),
         "group": build_group_ref(experiment.resource.owner),
-        "created_on": experiment.created_on,
+        "created_on": experiment.resource.created_on,
         "last_modified_on": experiment.resource.last_modified_on,
         "latest_snapshot": experiment.resource.latest_snapshot_id
         == experiment.resource_snapshot_id,
@@ -606,7 +606,7 @@ def build_entrypoint(entrypoint_dict: EntrypointDict) -> dict[str, Any]:
         "task_graph": entrypoint.task_graph,
         "user": build_user_ref(entrypoint.creator),
         "group": build_group_ref(entrypoint.resource.owner),
-        "created_on": entrypoint.created_on,
+        "created_on": entrypoint.resource.created_on,
         "last_modified_on": entrypoint.resource.last_modified_on,
         "latest_snapshot": entrypoint.resource.latest_snapshot_id
         == entrypoint.resource_snapshot_id,
@@ -659,7 +659,7 @@ def build_job(job_dict: JobDict) -> dict[str, Any]:
         "queue": build_queue_snapshot_ref(job.queue_job.queue),
         "experiment": build_experiment_snapshot_ref(job.experiment_job.experiment),
         "entrypoint": build_entrypoint_snapshot_ref(job.entry_point_job.entry_point),
-        "created_on": job.created_on,
+        "created_on": job.resource.created_on,
         "last_modified_on": job.resource.last_modified_on,
         "latest_snapshot": job.resource.latest_snapshot_id == job.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in job.tags],
@@ -709,7 +709,7 @@ def build_model(model_dict: ModelWithVersionDict) -> dict[str, Any]:
         "description": model.description,
         "user": build_user_ref(model.creator),
         "group": build_group_ref(model.resource.owner),
-        "created_on": model.created_on,
+        "created_on": model.resource.created_on,
         "last_modified_on": model.resource.last_modified_on,
         "latest_snapshot": model.resource.latest_snapshot_id
         == model.resource_snapshot_id,
@@ -741,7 +741,7 @@ def build_model_version(model_dict: ModelWithVersionDict) -> dict[str, Any]:
         "description": version.description,
         "version_number": version.version_number,
         "artifact": build_artifact_ref(version.artifact),
-        "created_on": version.created_on,
+        "created_on": version.resource.created_on,
     }
 
 
@@ -756,7 +756,7 @@ def build_artifact(artifact_dict: ArtifactDict) -> dict[str, Any]:
         "description": artifact.description,
         "user": build_user_ref(artifact.creator),
         "group": build_group_ref(artifact.resource.owner),
-        "created_on": artifact.created_on,
+        "created_on": artifact.resource.created_on,
         "last_modified_on": artifact.resource.last_modified_on,
         "latest_snapshot": artifact.resource.latest_snapshot_id
         == artifact.resource_snapshot_id,
@@ -788,7 +788,7 @@ def build_queue(queue_dict: QueueDict) -> dict[str, Any]:
         "description": queue.description,
         "user": build_user_ref(queue.creator),
         "group": build_group_ref(queue.resource.owner),
-        "created_on": queue.created_on,
+        "created_on": queue.resource.created_on,
         "last_modified_on": queue.resource.last_modified_on,
         "latest_snapshot": queue.resource.latest_snapshot_id
         == queue.resource_snapshot_id,
@@ -821,7 +821,7 @@ def build_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str, Any]:
         "description": plugin.description,
         "user": build_user_ref(plugin.creator),
         "group": build_group_ref(plugin.resource.owner),
-        "created_on": plugin.created_on,
+        "created_on": plugin.resource.created_on,
         "last_modified_on": plugin.resource.last_modified_on,
         "latest_snapshot": plugin.resource.latest_snapshot_id
         == plugin.resource_snapshot_id,
@@ -851,7 +851,7 @@ def build_plugin_file(plugin_file_with_plugin: PluginFileDict) -> dict[str, Any]
         "description": plugin_file.description,
         "user": build_user_ref(plugin_file.creator),
         "group": build_group_ref(plugin_file.resource.owner),
-        "created_on": plugin_file.created_on,
+        "created_on": plugin_file.resource.created_on,
         "last_modified_on": plugin_file.resource.last_modified_on,
         "latest_snapshot": plugin_file.resource.latest_snapshot_id
         == plugin_file.resource_snapshot_id,
@@ -923,7 +923,7 @@ def build_plugin_parameter_type(
         "description": plugin_parameter_type.description,
         "user": build_user_ref(plugin_parameter_type.creator),
         "group": build_group_ref(plugin_parameter_type.resource.owner),
-        "created_on": plugin_parameter_type.created_on,
+        "created_on": plugin_parameter_type.resource.created_on,
         "last_modified_on": plugin_parameter_type.resource.last_modified_on,
         "latest_snapshot": plugin_parameter_type.resource.latest_snapshot_id
         == plugin_parameter_type.resource_snapshot_id,


### PR DESCRIPTION
The API was returning the snapshot's created_on timestamp instead of the resource's created_on timestamp. This commit fixes the issue in the response build functions in `restapi/v1/utils.py`.