### PR TITLE
feat: select tag upon create

### DIFF
--- a/src/frontend/src/dialogs/AssignTagsDialog.vue
+++ b/src/frontend/src/dialogs/AssignTagsDialog.vue
@@ -22,7 +22,7 @@
     />
 
     <q-input 
-      v-model="newTag" 
+      v-model="newTagName" 
       outlined 
       dense 
       label="Add new Tag option" 
@@ -76,7 +76,7 @@
       getTags()
     }
     selectedTagIDs.value = []
-    newTag.value = ''
+    newTagName.value = ''
   })
 
   function toggleTag(id) {
@@ -91,18 +91,19 @@
     }
   }
 
-  const newTag = ref('')
+  const newTagName = ref('')
 
   async function addNewTag() {
-    if(!newTag.value.trim().length) return
+    if(!newTagName.value.trim().length) return
     try {
-      await api.addItem('tags', {
-        name: newTag.value,
+      let res = await api.addItem('tags', {
+        name: newTagName.value,
         group: store.loggedInGroup.id
       })
-      notify.success(`Successfully created tag '${newTag.value}'`)
-      newTag.value = ''
-      getTags()
+      notify.success(`Successfully created tag '${newTagName.value}'`)
+      tags.value.push({ name: newTagName.value, id: res.data.id })
+      selectedTagIDs.value.push(res.data.id)
+      newTagName.value = ''
     } catch(err) {
       notify.error(err.response.data.message)
     }


### PR DESCRIPTION
When creating a new tag in the assign tags dialog, it should be selected by default.  You still need to hit confirm to save the selection.