### PR TITLE
V1 fix entrypoint schema

### DIFF
--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -154,8 +154,10 @@ class EntrypointMutableFieldsSchema(Schema):
         fields.Integer(),
         attribute="queue_ids",
         data_key="queues",
+        allow_none=True,
         metadata=dict(description="The queue for the entrypoint."),
         load_only=True,
+        load_default=list(),
     )
 
 

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -66,7 +66,7 @@ def register_entrypoint(
     task_graph: str,
     parameters: list[dict[str, Any]],
     plugin_ids: list[int],
-    queue_ids: list[int],
+    queue_ids: list[int] | None = None,
 ) -> TestResponse:
     """Register an entrypoint using the API.
 
@@ -87,8 +87,10 @@ def register_entrypoint(
         "taskGraph": task_graph,
         "parameters": parameters,
         "plugins": plugin_ids,
-        "queues": queue_ids,
     }
+
+    if queue_ids:
+        payload["queues"] = queue_ids
 
     if description:
         payload["description"] = description

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -549,6 +549,21 @@ def test_create_entrypoint(
         queue_ids=queue_ids,
     )
 
+    # Testing that queue_ids feild can be excluded
+    entrypoint_response = actions.register_entrypoint(
+        client,
+        name="queues_not_included",
+        description=description,
+        group_id=group_id,
+        task_graph=task_graph,
+        parameters=parameters,
+        plugin_ids=plugin_ids,
+    )
+    entrypoint_expected = entrypoint_response.get_json()
+    assert_retrieving_entrypoint_by_id_works(
+        client, entrypoint_id=entrypoint_expected["id"], expected=entrypoint_expected
+    )
+
 
 def test_entrypoint_get_all(
     dioptra_client: DioptraClient[DioptraResponseProtocol],


### PR DESCRIPTION
Allows for registration of entrypoints without including queues in request. Test coverage added.