### PR TITLE
feat: redirect to login when logged out

### DIFF
--- a/src/frontend/src/components/LoginForm.vue
+++ b/src/frontend/src/components/LoginForm.vue
@@ -2,7 +2,7 @@
   <q-card bordered class="q-pa-lg" style="min-width: 40%;">
     <q-card-section class="text-center">
         <h1 class="q-mt-none q-mb-sm">Login</h1>
-        <p>Login below to access all API endpoints</p>
+        <p>Sign in to access the Dioptra UI</p>
     </q-card-section>
     <q-form @submit="submit()">
       <q-input

--- a/src/frontend/src/components/NavBar.vue
+++ b/src/frontend/src/components/NavBar.vue
@@ -1,6 +1,7 @@
 <template>
   <q-toolbar class="bg-primary text-white">
     <q-btn
+      v-if="store.loggedInUser"
       class="lt-lg"
       icon="menu"
       flat
@@ -45,8 +46,8 @@
         </q-list>
       </q-menu>
     </q-btn>
-    <nav class="gt-md">
-      <q-tabs  no-caps>
+    <nav v-if="store.loggedInUser" class="gt-md">
+      <q-tabs no-caps>
         <q-route-tab label="Home" to="/" />
         <q-route-tab label="Experiments" to="/experiments" />
         <q-route-tab label="Entrypoints" to="/entrypoints" />
@@ -164,10 +165,14 @@
     else return `${store.loggedInUser}`
   }
 
-  // check login status on mounted and reloads
-  router.beforeEach((to, from) => {
+  router.beforeEach(async(to, from) => {
+    // check login status on mounted and reloads
     if (from === START_LOCATION) {
-      callGetLoginStatus()
+      await callGetLoginStatus()
+    }
+    // redirect to login if logged out
+    if(!store.loggedInUser && to.path !== '/login' && to.path !== '/register') {
+      router.push('/login')
     }
   })
 


### PR DESCRIPTION
When a user is not logged in, all requests should redirect to the login page. Additionally, the navigation tabs along the top should be hidden until the user logs in.