### PR TITLE
Update the list of supported entrypoint parameter types and add workaround to export full list of plugin parameter types

### DIFF
--- a/src/dioptra/restapi/db/alembic/versions/6a75ede23821_update_entry_point_parameter_types_list.py
+++ b/src/dioptra/restapi/db/alembic/versions/6a75ede23821_update_entry_point_parameter_types_list.py
@@ -1,0 +1,125 @@
+"""Update entry point parameter types list
+
+Revision ID: 6a75ede23821
+Revises: 4b2d781f8bb4
+Create Date: 2024-09-10 16:32:40.707231
+
+"""
+
+from typing import Annotated, Optional
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    mapped_column,
+    sessionmaker,
+)
+
+# revision identifiers, used by Alembic.
+revision = "6a75ede23821"
+down_revision = "4b2d781f8bb4"
+branch_labels = None
+depends_on = None
+
+
+# Upgrade and downgrade inserts and deletes
+UPGRADE_INSERTS = ["boolean", "integer", "list", "mapping"]
+UPGRADE_DELETES = ["path", "uri"]
+DOWNGRADE_INSERTS = ["path", "uri"]
+
+
+# Migration data models
+intpk = Annotated[
+    int,
+    mapped_column(sa.BigInteger().with_variant(sa.Integer, "sqlite"), primary_key=True),
+]
+text_ = Annotated[str, mapped_column(sa.Text())]
+bool_ = Annotated[bool, mapped_column(sa.Boolean())]
+optionalstr = Annotated[Optional[str], mapped_column(sa.Text(), nullable=True)]
+
+
+class UpgradeBase(DeclarativeBase, MappedAsDataclass):
+    pass
+
+
+class DowngradeBase(DeclarativeBase, MappedAsDataclass):
+    pass
+
+
+class EntryPointParameterTypeUpgrade(UpgradeBase):
+    __tablename__ = "entry_point_parameter_types"
+
+    parameter_type: Mapped[text_] = mapped_column(primary_key=True)
+
+
+class EntryPointParameterUpgrade(UpgradeBase):
+    __tablename__ = "entry_point_parameters"
+
+    entry_point_resource_snapshot_id: Mapped[intpk] = mapped_column(init=False)
+    parameter_number: Mapped[intpk]
+    parameter_type: Mapped[text_] = mapped_column(nullable=False)
+    name: Mapped[text_] = mapped_column(nullable=False)
+    default_value: Mapped[optionalstr]
+
+
+class EntryPointParameterTypeDowngrade(DowngradeBase):
+    __tablename__ = "entry_point_parameter_types"
+
+    parameter_type: Mapped[text_] = mapped_column(primary_key=True)
+
+
+def upgrade():
+    bind = op.get_bind()
+    Session = sessionmaker(bind=bind)
+
+    with Session() as session:
+        for parameter_type in UPGRADE_INSERTS:
+            stmt = sa.select(EntryPointParameterTypeUpgrade).where(
+                EntryPointParameterTypeUpgrade.parameter_type == parameter_type
+            )
+
+            if session.scalar(stmt) is None:
+                session.add(
+                    EntryPointParameterTypeUpgrade(parameter_type=parameter_type)
+                )
+
+        # Search for any parameters that are of type "path" or "uri" and convert them to
+        # "string"
+        to_string_params_stmt = sa.select(EntryPointParameterUpgrade).where(
+            EntryPointParameterUpgrade.parameter_type.in_(["path", "uri"])
+        )
+
+        for entry_point_parameter in session.execute(to_string_params_stmt):
+            entry_point_parameter.parameter_type = "string"
+
+        for parameter_type in UPGRADE_DELETES:
+            stmt = sa.select(EntryPointParameterTypeUpgrade).where(
+                EntryPointParameterTypeUpgrade.parameter_type == parameter_type
+            )
+            entry_point_parameter_type = session.scalar(stmt)
+
+            if entry_point_parameter_type is not None:
+                session.delete(entry_point_parameter_type)
+
+        session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    Session = sessionmaker(bind=bind)
+
+    with Session() as session:
+        for parameter_type in DOWNGRADE_INSERTS:
+            stmt = sa.select(EntryPointParameterTypeDowngrade).where(
+                EntryPointParameterTypeDowngrade.parameter_type == parameter_type
+            )
+
+            if session.scalar(stmt) is None:
+                session.add(
+                    EntryPointParameterTypeDowngrade(parameter_type=parameter_type)
+                )
+
+        session.commit()

--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -95,7 +95,9 @@ class EntrypointParameterSchema(Schema):
         attribute="parameter_type",
         metadata=dict(description="Data type of the Entrypoint parameter."),
         required=True,
-        validate=validate.OneOf(["string", "float", "path", "uri"]),
+        validate=validate.OneOf(
+            ["string", "float", "integer", "boolean", "list", "mapping"]
+        ),
     )
 
 

--- a/src/dioptra/restapi/v1/workflows/lib/export_task_engine_yaml.py
+++ b/src/dioptra/restapi/v1/workflows/lib/export_task_engine_yaml.py
@@ -173,8 +173,12 @@ def extract_tasks(
         plugin_file = entry_point_plugin_file.plugin_file
 
         for task in plugin_file.tasks:
-            input_parameters = task.input_parameters
-            output_parameters = task.output_parameters
+            input_parameters = sorted(
+                task.input_parameters, key=lambda x: x.parameter_number
+            )
+            output_parameters = sorted(
+                task.output_parameters, key=lambda x: x.parameter_number
+            )
 
             tasks[task.plugin_task_name] = {
                 "plugin": _build_plugin_field(plugin, plugin_file, task),

--- a/src/dioptra/restapi/v1/workflows/lib/package_job_files.py
+++ b/src/dioptra/restapi/v1/workflows/lib/package_job_files.py
@@ -40,6 +40,7 @@ def package_job_files(
     entry_point: models.EntryPoint,
     entry_point_plugin_files: list[models.EntryPointPluginFile],
     job_parameter_values: list[models.EntryPointParameterValue],
+    plugin_parameter_types: list[models.PluginTaskParameterType],
     file_type: FileTypes,
     logger: BoundLogger | None = None,
 ) -> IO[bytes]:
@@ -51,6 +52,8 @@ def package_job_files(
         entry_point: The job's entrypoint.
         entry_point_plugin_files: The job's entrypoint plugin files.
         job_parameter_values: The job's assigned parameter values.
+        plugin_parameter_types: The latest snapshots of the plugin parameter types
+            accessible to the job.
         file_type: The type of file to package the job files into.
         logger: A structlog logger object to use for logging. A new logger will be
             created if None.
@@ -72,6 +75,7 @@ def package_job_files(
         task_engine_yaml_path = export_task_engine_yaml(
             entrypoint=entry_point,
             entry_point_plugin_files=entry_point_plugin_files,
+            plugin_parameter_types=plugin_parameter_types,
             base_dir=base_dir,
             logger=log,
         )

--- a/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
+++ b/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
@@ -26,8 +26,9 @@ from structlog.stdlib import BoundLogger
 
 from dioptra.sdk.utilities.contexts import env_vars
 from dioptra.sdk.utilities.contexts import sys_path_dirs
+from dioptra.task_engine.issues import IssueSeverity
 from dioptra.task_engine.task_engine import run_experiment
-from dioptra.task_engine.validation import is_valid
+from dioptra.task_engine.validation import validate
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 DIOPTRA_JOB_ID = "dioptra.jobId"
@@ -58,12 +59,21 @@ def main(
         log.error("Plugins directory does not exist", plugins_dir=str(plugins_dir))
         raise ValueError(f"Plugins directory {plugins_dir} does not exist")
 
-    job_yaml = _load_job_yaml(JOB_YAML_PATH)
-    job_parameters = _load_job_params(JOB_PARAMS_JSON_PATH)
+    try:
+        job_yaml = _load_job_yaml(JOB_YAML_PATH)
 
-    if not is_valid(job_yaml):
-        log.error("Job YAML was invalid!")
-        raise ValueError("Job YAML was invalid!")
+    except Exception as e:
+        log.exception("Could not load job YAML file")
+        raise e
+
+    try:
+        job_parameters = _load_job_params(JOB_PARAMS_JSON_PATH)
+
+    except Exception as e:
+        log.exception("Could not load parameters JSON file")
+        raise e
+
+    _validate_yaml(job_yaml, log)
 
     if enable_mlflow_tracking:
         if dioptra_client is None:
@@ -163,6 +173,27 @@ def _load_job_params(filepath: str) -> MutableMapping[str, Any]:
     job_params_filepath = Path(filepath)
     with job_params_filepath.open("rt") as f:
         return cast(MutableMapping[str, Any], json.load(f))
+
+
+def _validate_yaml(
+    job_yaml: Mapping[str, Any],
+    logger: BoundLogger | None = None,
+) -> None:
+    log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
+
+    issues = validate(job_yaml)
+    errors: list[str] = []
+
+    for issue in issues:
+        if issue.severity is IssueSeverity.WARNING:
+            log.warn("Found issue with Job YAML", message=issue.message)
+
+        if issue.severity is IssueSeverity.ERROR:
+            log.error("Found error in Job YAML", message=issue.message)
+            errors.append(issue.message)
+
+    if errors:
+        raise ValueError(f"Errors found in Job YAML: {errors}")
 
 
 if __name__ == "__main__":

--- a/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
+++ b/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
@@ -24,6 +24,7 @@ import structlog
 import yaml
 from structlog.stdlib import BoundLogger
 
+from dioptra.sdk.utilities.contexts import env_vars
 from dioptra.sdk.utilities.contexts import sys_path_dirs
 from dioptra.task_engine.task_engine import run_experiment
 from dioptra.task_engine.validation import is_valid
@@ -101,7 +102,7 @@ def _run_job(
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
 
     try:
-        with sys_path_dirs(dirs=(str(plugins_dir),)):
+        with sys_path_dirs(dirs=(str(plugins_dir),)), env_vars({"__JOB_ID": str(JOB_ID)}):
             run_experiment(job_yaml, job_parameters)
 
         log.info("=== Run succeeded ===")
@@ -140,7 +141,7 @@ def _run_mlflow_tracked_job(
         mlflow.log_dict(job_yaml, Path(JOB_YAML_PATH).name)
         mlflow.log_params(job_parameters)
 
-        with sys_path_dirs(dirs=(str(plugins_dir),)):
+        with sys_path_dirs(dirs=(str(plugins_dir),)), env_vars({"__JOB_ID": str(JOB_ID)}):
             run_experiment(job_yaml, job_parameters)
 
         log.info("=== Run succeeded ===")

--- a/src/dioptra/restapi/v1/workflows/lib/type_coercions.py
+++ b/src/dioptra/restapi/v1/workflows/lib/type_coercions.py
@@ -1,0 +1,90 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import json
+from typing import Any, Final, cast
+
+JsonType = dict[str, Any] | list[Any]
+GlobalParameterType = str | float | int | bool | dict[str, Any] | list[Any] | None
+
+
+BOOLEAN_PARAM_TYPE: Final[str] = "boolean"
+FLOAT_PARAM_TYPE: Final[str] = "float"
+INTEGER_PARAM_TYPE: Final[str] = "integer"
+LIST_PARAM_TYPE: Final[str] = "list"
+MAPPING_PARAM_TYPE: Final[str] = "mapping"
+STRING_PARAM_TYPE: Final[str] = "string"
+
+
+def coerce_to_type(x: str | None, type_name: str) -> GlobalParameterType:
+    coerce_fn_registry = {
+        BOOLEAN_PARAM_TYPE: to_boolean_type,
+        FLOAT_PARAM_TYPE: to_float_type,
+        INTEGER_PARAM_TYPE: to_integer_type,
+        LIST_PARAM_TYPE: to_list_type,
+        MAPPING_PARAM_TYPE: to_mapping_type,
+        STRING_PARAM_TYPE: to_string_type,
+    }
+
+    if type_name not in coerce_fn_registry:
+        raise ValueError(f"Invalid parameter type: {type_name}.")
+
+    if x is None:
+        return None
+
+    coerce_fn = coerce_fn_registry[type_name]
+    return cast(GlobalParameterType, coerce_fn(x))
+
+
+def to_string_type(x: str) -> str:
+    return x
+
+
+def to_boolean_type(x: str) -> bool:
+    if x.lower() not in {"true", "false"}:
+        raise ValueError(f"Not a boolean: {x}")
+
+    return x.lower() == "true"
+
+
+def to_float_type(x: str) -> float:
+    # TODO: Handle coercion failures
+    return float(x)
+
+
+def to_integer_type(x: str) -> int:
+    # TODO: Handle coercion failures
+    return int(x)
+
+
+def to_list_type(x: str) -> list[Any]:
+    # TODO: Handle coercion failures
+    x_coerced = cast(JsonType, json.loads(x))
+
+    if not isinstance(x_coerced, list):
+        raise ValueError(f"Not a list: {x}")
+
+    return x_coerced
+
+
+def to_mapping_type(x: str) -> dict[str, Any]:
+    # TODO: Handle coercion failures
+    x_coerced = cast(JsonType, json.loads(x))
+
+    if not isinstance(x_coerced, dict):
+        raise ValueError(f"Not a mapping: {x}")
+
+    return x_coerced

--- a/src/dioptra/restapi/v1/workflows/lib/views.py
+++ b/src/dioptra/restapi/v1/workflows/lib/views.py
@@ -135,3 +135,34 @@ def get_job_parameter_values(
         models.EntryPointParameterValue.job_resource_id == job_id,
     )
     return list(db.session.scalars(entry_point_param_values_stmt).unique().all())
+
+
+def get_plugin_parameter_types(
+    job_id: int, logger: BoundLogger | None = None
+) -> list[models.PluginTaskParameterType]:
+    """Run a query to get the plugin task parameter types for the job.
+
+    Args:
+        job_id: The ID of the job to get the plugin task parameter types for.
+        logger: A structlog logger object to use for logging. A new logger will be
+            created if None.
+
+    Returns:
+        The plugin files for the entrypoint.
+    """
+    log = logger or LOGGER.new()  # noqa: F841
+
+    group_id_stmt = select(models.Resource.group_id).where(
+        models.Resource.resource_id == job_id
+    )
+    plugin_parameter_types_stmt = (
+        select(models.PluginTaskParameterType)
+        .join(models.Resource)
+        .where(
+            models.Resource.is_deleted == False,  # noqa: E712
+            models.Resource.group_id == group_id_stmt.scalar_subquery(),
+            models.Resource.latest_snapshot_id
+            == models.PluginTaskParameterType.resource_snapshot_id,
+        )
+    )
+    return list(db.session.scalars(plugin_parameter_types_stmt).all())

--- a/src/dioptra/restapi/v1/workflows/service.py
+++ b/src/dioptra/restapi/v1/workflows/service.py
@@ -51,12 +51,16 @@ class JobFilesDownloadService(object):
             job_id=job_id, logger=log
         )
         job_parameter_values = views.get_job_parameter_values(job_id=job_id, logger=log)
+        plugin_parameter_types = views.get_plugin_parameter_types(
+            job_id=job_id, logger=log
+        )
         return package_job_files(
             job_id=job_id,
             experiment=experiment,
             entry_point=entry_point,
             entry_point_plugin_files=entry_point_plugin_files,
             job_parameter_values=job_parameter_values,
+            plugin_parameter_types=plugin_parameter_types,
             file_type=file_type,
             logger=log,
         )

--- a/src/dioptra/sdk/utilities/contexts/__init__.py
+++ b/src/dioptra/sdk/utilities/contexts/__init__.py
@@ -14,9 +14,9 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from ._env_vars import env_vars
 from ._plugin_dirs import plugin_dirs
 from ._redirect_print import redirect_print
 from ._sys_path_dirs import sys_path_dirs
-from ._env_vars import env_vars
 
 __all__ = ["plugin_dirs", "redirect_print", "sys_path_dirs", "env_vars"]

--- a/src/dioptra/sdk/utilities/contexts/__init__.py
+++ b/src/dioptra/sdk/utilities/contexts/__init__.py
@@ -17,5 +17,6 @@
 from ._plugin_dirs import plugin_dirs
 from ._redirect_print import redirect_print
 from ._sys_path_dirs import sys_path_dirs
+from ._env_vars import env_vars
 
-__all__ = ["plugin_dirs", "redirect_print", "sys_path_dirs"]
+__all__ = ["plugin_dirs", "redirect_print", "sys_path_dirs", "env_vars"]

--- a/src/dioptra/sdk/utilities/contexts/_env_vars.py
+++ b/src/dioptra/sdk/utilities/contexts/_env_vars.py
@@ -2,6 +2,7 @@ import os
 from contextlib import contextmanager
 from typing import Iterator
 
+
 @contextmanager
 def env_vars(env_updates: dict[str, str]) -> Iterator[None]:
     """Create a context for temporarily updating environment variables.

--- a/src/dioptra/sdk/utilities/contexts/_env_vars.py
+++ b/src/dioptra/sdk/utilities/contexts/_env_vars.py
@@ -1,0 +1,47 @@
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+@contextmanager
+def env_vars(env_updates: dict[str, str]) -> Iterator[None]:
+    """Create a context for temporarily updating environment variables.
+
+    Args:
+        env_updates: A dictionary that maps the environment variables (keys) to a new
+            value. Both the keys and values must be strings.
+
+    Examples:
+        The example below shows how to use env_vars to set/update the value of the
+        environment variable __A within a context block. First, import the os module
+        and check the current value of __A (we provide a a default value because this
+        environment variable should not exist).
+
+        >>> import os
+        >>> print(os.getenv("__A", "default value of __A"))
+        default value of __A
+
+        Next, set up a with statement using env_vars to set a new value for __A confirm
+        that the update worked.
+
+        >>> with env_vars({"__A": "new value of __A"}):
+        ...     print(os.getenv("__A", "default value of A"))
+        new value of __A
+
+        Finally, confirm that __A has been restored to its default value after exiting
+        the with statement.
+
+        >>> print(os.getenv("__A", "default value of __A"))
+        default value of __A
+
+    Note:
+        This code is adapted from https://stackoverflow.com/a/34333710.
+    """
+    original_env = os.environ.copy()
+    os.environ.update(env_updates)
+
+    try:
+        yield
+
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)

--- a/src/frontend/src/dialogs/EditParamDialog.vue
+++ b/src/frontend/src/dialogs/EditParamDialog.vue
@@ -69,8 +69,10 @@
   const typeOptions = reactive([
     'string',
     'float',
-    'path',
-    'url',
+    'integer',
+    'boolean',
+    'list',
+    'mapping',
   ])
 
   watch(showDialog, (newVal) => {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -246,8 +246,10 @@
   const typeOptions = ref([
     'string',
     'float',
-    'path',
-    'uri',
+    'integer',
+    'boolean',
+    'list',
+    'mapping',
   ])
 
   const basicInfoForm = ref(null)

--- a/tests/unit/restapi/lib/db/setup.py
+++ b/tests/unit/restapi/lib/db/setup.py
@@ -24,8 +24,10 @@ from dioptra.restapi.db import models
 ENTRY_POINT_PARAMETER_TYPES: Final[list[dict[str, str]]] = [
     {"parameter_type": "string"},
     {"parameter_type": "float"},
-    {"parameter_type": "path"},
-    {"parameter_type": "uri"},
+    {"parameter_type": "integer"},
+    {"parameter_type": "boolean"},
+    {"parameter_type": "list"},
+    {"parameter_type": "mapping"},
 ]
 JOB_STATUS_TYPES: Final[list[dict[str, str]]] = [
     {"status": "queued"},

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -578,7 +578,17 @@ def registered_entrypoints(
         {
             "name": "entrypoint_param_3",
             "defaultValue": "/path",
-            "parameterType": "path",
+            "parameterType": "string",
+        },
+        {
+            "name": "entrypoint_param_4",
+            "defaultValue": "1",
+            "parameterType": "integer",
+        },
+        {
+            "name": "entrypoint_param_5",
+            "defaultValue": "['a', 'b', {'c': 1}]",
+            "parameterType": "list",
         },
     ]
     plugin_ids = [registered_plugin_with_files["plugin"]["id"]]


### PR DESCRIPTION
**Request: Please do not squash, rebase and merge to dev only.** The commits are different enough in scope and purpose that squashing will obscure the reasons for the various updates.

## Summary of changes

The first commit adds support for the "boolean", "integer", "list", and "mapping" entrypoint parameter types that are already supported by the task execution engine. In addition, the `/workflows/jobFilesDownload` endpoint service has been updated to handle all supported types when creating the parameters.json and task engine YAML files. The "path" and "uri" types have been removed since they were treated the same as strings.

The second commit adds the `env_vars` contextmanager to the Dioptra SDK, which can be used to temporarily update environment variables in a safe and reversible way.

The third commit updates the Worker execution logic to set a `__JOB_ID` environment variable when executing task engine YAML so that its possible to access the job ID using plugins.

The fourth commit adds a workaround to export the full list of registered plugin parameter types to the task engine YAML. **THIS IS A WORKAROUND THAT VIOLATES IDEMPOTENCE/REPRODUCIBILITY!** This workaround allows users to create and use parameter types that are only used indirectly, such as when defining a structured parameter type. This is a "hack" because the indirect parameter types are the latest available snapshots, not the snapshots that were associated with the plugins when the entrypoint was saved/updated. This is in contrast with the parameter types explicitly registered to the plugin task input and output parameters, which are linked to the entrypoint and job by their snapshot id instead of the resource id. This difference means that the task engine YAML files are not 100% reproducible, as any changes to an "indirect" plugin parameter type will be immediately reflected in subsequent download requests made to the job files workflow.

The fifth commit improves the error handling in the Dioptra workers in 2 ways. First, every function that has a possibility of encountering an error has been wrapped in a try/except block, which better ensures that any errors are logged and the job status is properly updated in the Dioptra API. Second, the YAML validation step has been modified to emit warning and error log messages instead of swallowing them silently, and in addition raise a ValueError exception when errors are encountered with a message that details the errors that were encountered. This update implements the request in #604.

The sixth commit is a fix to ensure that the exported job YAML sorts the input and output parameters for the plugin tasks according to their position index.