### PR TITLE
get all data

### DIFF
--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -14,7 +14,7 @@
     dense
     v-model:pagination="pagination"
     @request="onRequest"
-    :rows-per-page-options="[5,10,15,20,25,50]"
+    :rows-per-page-options="[5,10,15,20,25,50,0]"
   >
     <template v-slot:header="props">
       <q-tr :props="props">

--- a/src/frontend/src/dialogs/AssignPluginsDialog.vue
+++ b/src/frontend/src/dialogs/AssignPluginsDialog.vue
@@ -124,7 +124,7 @@
       try {
         const res = await api.getData('plugins', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         pluginOptions.value = res.data.data

--- a/src/frontend/src/dialogs/AssignTagsDialog.vue
+++ b/src/frontend/src/dialogs/AssignTagsDialog.vue
@@ -59,7 +59,7 @@
 
   async function getTags() {
     try {
-      const res = await api.getData('tags', {index: 0, rowsPerPage: 50, search: ''})
+      const res = await api.getData('tags', {index: 0, rowsPerPage: 0, search: ''})
       tags.value = res.data.data
       if(props.editObj.tags.length > 0) {
         props.editObj.tags.forEach((tag) => {

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -128,13 +128,24 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
   const res = await axios.get(`/api/${type}/${showDrafts ? 'drafts/' : ''}`, {
     params: {
       index: pagination.index,
-      pageLength: pagination.rowsPerPage,
+      pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
       search: urlEncode(pagination.search),
       draftType: showDrafts ? 'new' : '',
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     },
   })
+
+  // if GET ALL (rowsPerPage = 0), then keep on getting next page until there is no next
+  if(pagination.rowsPerPage === 0 && res.data.next) {
+    let nextUrl = res.data.next.replace("/v1", "")
+    while (nextUrl) {
+      const response = await axios.get(nextUrl)
+      res.data.data.push(...response.data.data)
+      nextUrl = response.data.next ? response.data.next.replace("/v1", "") : null
+    }
+  }
+
   if(showDrafts && res.data.data) {
     res.data.data.forEach((obj: any) => {
       Object.assign(obj, obj.payload)
@@ -145,15 +156,26 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
 }
 
 export async function getJobs(id: number, pagination: Pagination) {
-  return await axios.get(`/api/experiments/${id}/jobs`, {
+  const res = await axios.get(`/api/experiments/${id}/jobs`, {
     params: {
       index: pagination.index,
-      pageLength: pagination.rowsPerPage,
+      pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
       search: urlEncode(pagination.search),
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     }
   })
+
+  // if GET ALL (rowsPerPage = 0), then keep on getting next page until there is no next
+  if(pagination.rowsPerPage === 0 && res.data.next) {
+    let nextUrl = res.data.next.replace("/v1", "")
+    while (nextUrl) {
+      const response = await axios.get(nextUrl)
+      res.data.data.push(...response.data.data)
+      nextUrl = response.data.next ? response.data.next.replace("/v1", "") : null
+    }
+  }
+  return res
 }
 
 function urlEncode(string: string) {
@@ -230,13 +252,26 @@ export async function deleteDraft<T extends ItemType>(type: T, draftId: number) 
 }
 
 export async function getFiles(id: number, pagination: Pagination) {
-  return await axios.get(`/api/plugins/${id}/files`, {
+  const res =  await axios.get(`/api/plugins/${id}/files`, {
     params: {
-      index: pagination?.index || 0,
-      pageLength: pagination?.rowsPerPage || 100,
-      search: urlEncode(pagination?.search || '')
+      index: pagination.index,
+      pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
+      search: urlEncode(pagination.search),
+      sortBy: pagination.sortBy,
+      descending: pagination.descending,
     }
   })
+
+  // if GET ALL (rowsPerPage = 0), then keep on getting next page until there is no next
+  if(pagination.rowsPerPage === 0 && res.data.next) {
+    let nextUrl = res.data.next.replace("/v1", "")
+    while (nextUrl) {
+      const response = await axios.get(nextUrl)
+      res.data.data.push(...response.data.data)
+      nextUrl = response.data.next ? response.data.next.replace("/v1", "") : null
+    }
+  }
+  return res
 }
 
 export async function getFile(pluginID: string, fileID: string) {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -483,7 +483,7 @@
       try {
         const res = await api.getData('queues', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         queues.value = res.data.data
@@ -498,7 +498,7 @@
       try {
         const res = await api.getData('plugins', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         plugins.value = res.data.data

--- a/src/frontend/src/views/CreateExperiment.vue
+++ b/src/frontend/src/views/CreateExperiment.vue
@@ -228,7 +228,7 @@
       try {
         const res = await api.getData('entrypoints', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         entrypoints.value = res.data.data

--- a/src/frontend/src/views/CreateJob.vue
+++ b/src/frontend/src/views/CreateJob.vue
@@ -238,7 +238,7 @@
       try {
         const res = await api.getData('queues', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         queues.value = res.data.data
@@ -253,7 +253,7 @@
       try {
         const res = await api.getData('entrypoints', {
           search: val,
-          rowsPerPage: 100,
+          rowsPerPage: 0, // get all
           index: 0
         })
         entrypoints.value = res.data.data

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -514,13 +514,12 @@
   ]
 
   async function getPluginParameterTypes(pagination) {
-    console.log('pagination = ', pagination)
+    pagination.rowsPerPage = 0 // get all
     try {
       const res = await api.getData('pluginParameterTypes', pagination)
       pluginParameterTypes.value = res.data.data
       tableRef.value.updateTotalRows(res.data.totalNumResults)
     } catch(err) {
-      console.log('err = ', err)
       notify.error(err.response.data.message)
     } 
   }


### PR DESCRIPTION
This PR adds the ability for the frontend to "get all" data from a GET endpoint, by hitting the `next` url until there is no `next`, and return all the aggregated data.

This fixes the issue where menu selections (such as the assign tags dialog or the various queues, plugins, entrypoint dropdowns) only gets the first "page" of results instead of all results.

This also allows all tables to have an "All" option for rows-per-page.