### PR TITLE
Respect package-lock.json when building the frontend with init-deployment.sh

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/scripts/init-frontend.sh
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/scripts/init-frontend.sh
@@ -289,6 +289,7 @@ prepare_build_dir() {
     "public"
     "index.html"
     "package.json"
+    "package-lock.json"
     "tsconfig.json"
     "tsconfig.app.json"
     "tsconfig.node.json"
@@ -351,10 +352,10 @@ copy_dist_to_output() {
 compile_vue_js_frontend() {
   cd "${BUILD_DIR}"
 
-  log_info "Installing node packages using npm install"
+  log_info "Installing node packages using npm ci"
 
-  if ! npm install; then
-    log_error "Installing node modules using npm install failed, exiting..."
+  if ! npm ci; then
+    log_error "Installing node modules using npm ci failed, exiting..."
     exit 1
   fi
 


### PR DESCRIPTION
This updates the init-deployment.sh script so that it copies the frontend's package-lock.json file into the build context. The command "npm install" is replaced with "npm ci", which will do a "clean install" of the exact versions in package-lock.json and will fail if anything breaks.

Closes #662