### PR TITLE
feat(restapi): add metrics capabilities to RESTAPI

### DIFF
--- a/src/dioptra/client/experiments.py
+++ b/src/dioptra/client/experiments.py
@@ -31,6 +31,7 @@ from .snapshots import SnapshotsSubCollectionClient
 from .tags import TagsSubCollectionClient
 
 ARTIFACTS: Final[str] = "artifacts"
+METRICS: Final[str] = "metrics"
 MLFLOW_RUN: Final[str] = "mlflowRun"
 STATUS: Final[str] = "status"
 
@@ -702,3 +703,47 @@ class ExperimentsCollectionClient(CollectionClient[T]):
             The response from the Dioptra API.
         """
         return self._session.delete(self.url, str(experiment_id))
+
+    def get_metrics_by_id(
+        self,
+        experiment_id: str | int,
+        index: int = 0,
+        page_length: int = 10,
+        sort_by: str | None = None,
+        descending: bool | None = None,
+        search: str | None = None,
+    ) -> T:
+        """Get the metrics for the jobs in this experiment.
+
+        Args:
+            experiment_id: The experiment id, an integer.
+            index: The paging index. Optional, defaults to 0.
+            page_length: The maximum number of experiments to return in the paged
+                response. Optional, defaults to 10.
+            sort_by: The field to use to sort the returned list. Optional, defaults to
+                None.
+            descending: Sort the returned list in descending order. Optional, defaults
+                to None.
+            search: Search for jobs using the Dioptra API's query language.
+                Optional, defaults to None.
+
+        Returns:
+            The response from the Dioptra API.
+        """
+
+        params: dict[str, Any] = {
+            "experiment_id": experiment_id,
+            "index": index,
+            "pageLength": page_length,
+        }
+
+        if sort_by is not None:
+            params["sortBy"] = sort_by
+
+        if descending is not None:
+            params["descending"] = descending
+
+        if search is not None:
+            params["search"] = search
+
+        return self._session.get(self.url, str(experiment_id), METRICS, params=params)

--- a/src/dioptra/restapi/errors.py
+++ b/src/dioptra/restapi/errors.py
@@ -332,6 +332,13 @@ class UserPasswordError(DioptraError):
         super().__init__(message)
 
 
+class MLFlowError(DioptraError):
+    """MLFlow Error."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
 def error_result(
     error: DioptraError, status: http.HTTPStatus, detail: dict[str, typing.Any]
 ) -> tuple[dict[str, typing.Any], int]:
@@ -430,6 +437,11 @@ def register_error_handlers(api: Api, **kwargs) -> None:  # noqa: C901
     def handle_user_password_error(error: UserPasswordError):
         log.debug(error.to_message())
         return error_result(error, http.HTTPStatus.UNAUTHORIZED, {})
+
+    @api.errorhandler(MLFlowError)
+    def handle_mlflow_error(error: MLFlowError):
+        log.debug(error.to_message())
+        return error_result(error, http.HTTPStatus.INTERNAL_SERVER_ERROR, {})
 
     @api.errorhandler(DioptraError)
     def handle_base_error(error: DioptraError):

--- a/src/dioptra/restapi/v1/experiments/schema.py
+++ b/src/dioptra/restapi/v1/experiments/schema.py
@@ -117,6 +117,14 @@ class ExperimentPageSchema(BasePageSchema):
     )
 
 
+class ExperimentMetricsGetQueryParameters(
+    PagingQueryParametersSchema,
+    SearchQueryParametersSchema,
+    SortByGetQueryParametersSchema,
+):
+    """The query parameters for the GET method of the /experiments/{id}/metrics"""
+
+
 class ExperimentGetQueryParameters(
     PagingQueryParametersSchema,
     GroupIdQueryParametersSchema,

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -631,11 +631,25 @@ def build_entrypoint(entrypoint_dict: EntrypointDict) -> dict[str, Any]:
     return data
 
 
+def build_metrics_snapshots(metrics_snapshots_dict: dict[str, Any]) -> dict[str, Any]:
+    """Build a Metrics Snapshot response dictionary.
+
+    Args:
+        metrics_snapshots_dict: The Metrics Snapshots object to convert
+        into a dictionary.
+
+    Returns:
+        The Metric Snapshots response dictionary.
+    """
+    # no changes currently
+    return metrics_snapshots_dict
+
+
 def build_job(job_dict: JobDict) -> dict[str, Any]:
     """Build a Job response dictionary.
 
     Args:
-        job: The Job object to convert into a job response dictionary.
+        job_dict: The Job object to convert into a job response dictionary.
 
     Returns:
         The Job response dictionary.

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -768,3 +768,71 @@ def remove_tag(
         f"/{V1_ROOT}/{resource_route}/{resource_id}/tags/{tag_id}",
         follow_redirects=True,
     )
+
+def post_metrics(
+    client: FlaskClient, job_id: int, metric_name: str, metric_value: float
+) -> TestResponse:
+    """Remove tag from the resource with the provided unique ID.
+
+    Args:
+        client: The Flask test client.
+        job_id: The id of the Job to post metrics to.
+        metric_name: The name of the metric.
+        metric_value: The value of the metric.
+
+    Returns:
+        The response from the API.
+    """
+
+    return client.post(
+        f"/{V1_ROOT}/{V1_JOBS_ROUTE}/{job_id}/metrics",
+        json={"name": metric_name, "value": metric_value},
+    )
+
+
+def post_mlflowrun(
+    client: FlaskClient, job_id: int, mlflow_run_id: str
+) -> TestResponse:
+    """Add an mlflow run id to a job.
+
+    Args:
+        client: The Flask test client.
+        job_id: The id of the Job.
+        mlflow_run_id: The id of the mlflow run.
+    Returns:
+        The response from the API.
+
+    """
+    payload = {"mlflowRunId": mlflow_run_id}
+    response = client.post(
+        f"/{V1_ROOT}/{V1_JOBS_ROUTE}/{job_id}/mlflowRun",
+        json=payload,
+        follow_redirects=True,
+    )
+    return response
+
+
+def post_mlflowruns(
+    client: FlaskClient, mlflowruns: dict[str, Any], registered_jobs: dict[str, Any]
+) -> dict[str, Any]:
+    """Add mlflow run ids to multiple jobs.
+
+    Args:
+        client: The Flask test client.
+        mlflowruns: A dictionary mapping job key to mlflow run id.
+        registered_jobs: A dictionary of registered jobs.
+
+    Returns:
+        The responses from the API.
+    """
+
+    responses = {}
+
+    for key in mlflowruns.keys():
+        job_id = registered_jobs[key]["id"]
+        mlflowrun_response = post_mlflowrun(
+            client=client, job_id=job_id, mlflow_run_id=mlflowruns[key].hex
+        ).get_json()
+        responses[key] = mlflowrun_response
+
+    return responses

--- a/tests/unit/restapi/lib/asserts.py
+++ b/tests/unit/restapi/lib/asserts.py
@@ -57,7 +57,7 @@ def assert_group_ref_contents_matches_expectations(
     assert group["id"] == expected_group_id
 
 
-def assert_tag_ref_contents_matches_expectations(tags: dict[str, Any]) -> None:
+def assert_tag_ref_contents_matches_expectations(tags: list[dict[str, Any]]) -> None:
     for tag in tags:
         assert isinstance(tag["id"], int)
         assert isinstance(tag["name"], str)

--- a/tests/unit/restapi/lib/mock_mlflow.py
+++ b/tests/unit/restapi/lib/mock_mlflow.py
@@ -1,0 +1,190 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+LOGGER: BoundLogger = structlog.stdlib.get_logger()
+
+active_runs: dict[str, list[MockMlflowMetric]] = {}
+
+
+class MockMlflowClient(object):
+    def __init__(self) -> None:
+        LOGGER.info(
+            "Mocking mlflow.tracking.MlflowClient instance",
+        )
+
+    def get_run(self, id: str) -> MockMlflowRun:
+        # Note: In Mlflow, this function would usually throw an MlflowException
+        # if the run id is not found. For simplicity this is left out in favor of
+        # assuming the run should exist in this mock instance.
+
+        LOGGER.info("Mocking MlflowClient.get_run() function")
+        if id not in active_runs:
+            active_runs[id] = []
+
+        run = MockMlflowRun(id)
+        metrics: list[MockMlflowMetric] = active_runs[id]
+        output_metrics: dict[str, MockMlflowMetric] = {}
+        for metric in metrics:
+            # find the latest metric for each metric name
+            if (
+                metric.key not in output_metrics
+                or metric.timestamp > output_metrics[metric.key].timestamp
+            ):
+                output_metrics[metric.key] = metric
+
+        # remove step and timestamp information
+        for output in output_metrics.keys():
+            run.data.metrics[output] = output_metrics[output].value
+        return run
+
+    def log_metric(
+        self, id: str, key: str, value: float, step: Optional[int] = None, timestamp: Optional[int] = None
+    ):
+        if id not in active_runs:
+            active_runs[id] = []
+        if timestamp is None:
+            timestamp = time.time_ns() // 1000000
+        active_runs[id] += [
+            MockMlflowMetric(
+                key=key,
+                value=value,
+                step=0 if step is None else step,
+                timestamp=timestamp,
+            )
+        ]
+
+    def get_metric_history(self, run_id: str, key: str):
+        return [metric for metric in active_runs[run_id] if metric.key == key]
+
+
+class MockMlflowRun(object):
+    def __init__(
+        self,
+        id: str,
+    ) -> None:
+        LOGGER.info("Mocking mlflow.entities.Run class")
+        self._id = id
+        self.data = MockMlflowRunData()
+
+    @property
+    def id(self) -> str:
+        LOGGER.info("Mocking mlflow.entities.Run.id getter")
+        return self._id
+
+    @id.setter
+    def id(self, value: str) -> None:
+        LOGGER.info("Mocking mlflow.entities.Run.id setter", value=value)
+        self._id = value
+
+    @property
+    def data(self) -> MockMlflowRunData:
+        LOGGER.info("Mocking mlflow.entities.Run.data getter")
+        return self._data
+
+    @data.setter
+    def data(self, value: MockMlflowRunData) -> None:
+        LOGGER.info("Mocking mlflow.entities.Run.data setter", value=value)
+        self._data = value
+
+
+class MockMlflowRunData(object):
+    def __init__(
+        self,
+    ) -> None:
+        LOGGER.info("Mocking mlflow.entities.RunData class")
+        self._metrics: dict[str, Any] = {}
+
+    @property
+    def metrics(self) -> dict[str, Any]:
+        LOGGER.info("Mocking mlflow.entities.RunData.metrics getter")
+        return self._metrics
+
+    @metrics.setter
+    def metrics(self, value: dict[str, Any]) -> None:
+        LOGGER.info("Mocking mlflow.entities.RunData.metrics setter", value=value)
+        self._metrics = value
+
+
+class MockMlflowMetric(object):
+    def __init__(
+        self,
+        key: str,
+        value: float,
+        step: int,
+        timestamp: int,
+    ) -> None:
+        LOGGER.info("Mocking mlflow.entities.Metric class")
+        self._key = key
+        self._value = value
+        self._step = step
+        self._timestamp = timestamp
+
+    @property
+    def key(self) -> str:
+        LOGGER.info("Mocking mlflow.entities.Metric.key getter")
+        return self._key
+
+    @key.setter
+    def key(self, value: str) -> None:
+        LOGGER.info("Mocking mlflow.entities.Metric.key setter", value=value)
+        self._key = value
+
+    @property
+    def value(self) -> float:
+        LOGGER.info("Mocking mlflow.entities.Metric.value getter")
+        return self._value
+
+    @value.setter
+    def value(self, value: float) -> None:
+        LOGGER.info("Mocking mlflow.entities.Metric.value setter", value=value)
+        self._value = value
+
+    @property
+    def step(self) -> int:
+        LOGGER.info("Mocking mlflow.entities.Metric.step getter")
+        return self._step
+
+    @step.setter
+    def step(self, value: int) -> None:
+        LOGGER.info("Mocking mlflow.entities.Metric.step setter", value=value)
+        self._step = value
+
+    @property
+    def timestamp(self) -> int:
+        LOGGER.info("Mocking mlflow.entities.Metric.timestamp getter")
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, value: int) -> None:
+        LOGGER.info("Mocking mlflow.entities.Metric.timestamp setter", value=value)
+        self._timestamp = value
+
+
+class MockMlflowException(Exception):
+    def __init__(
+        self,
+        text: str,
+    ) -> None:
+        LOGGER.info("Mocking mlflow.exceptions.MlflowException class")
+        super().__init__(text)

--- a/tests/unit/restapi/test_utils.py
+++ b/tests/unit/restapi/test_utils.py
@@ -16,8 +16,6 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode
 from __future__ import annotations
 
-import pytest
-
 from dioptra.restapi.utils import find_non_unique
 
 

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -21,6 +21,7 @@ from http import HTTPStatus
 from typing import Any, cast
 
 import pytest
+import uuid
 from flask import Flask
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
@@ -684,3 +685,38 @@ def registered_jobs(
         "job2": job2_response,
         "job3": job3_response,
     }
+
+
+@pytest.fixture
+def registered_mlflowrun(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_jobs: dict[str, Any],
+) -> dict[str, Any]:
+    mlflowruns = {"job1": uuid.uuid4(), "job2": uuid.uuid4(), "job3": uuid.uuid4()}
+
+    responses = actions.post_mlflowruns(
+        client=client, mlflowruns=mlflowruns, registered_jobs=registered_jobs
+    )
+
+    return responses
+
+
+@pytest.fixture
+def registered_mlflowrun_incomplete(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    auth_account: dict[str, Any],
+    registered_jobs: dict[str, Any],
+) -> dict[str, Any]:
+    mlflowruns = {
+        "job1": uuid.uuid4(),
+        "job2": uuid.uuid4(),
+    }  # leave job3 out so we can use that in test_mlflowrun()
+
+    responses = actions.post_mlflowruns(
+        client=client, mlflowruns=mlflowruns, registered_jobs=registered_jobs
+    )
+
+    return responses


### PR DESCRIPTION
Closes #671.

Additionally:
Fixes some incorrect function descriptions.
Fixes some mypy linting issues in related files.
Adds a restapi test for the /jobs/{id}/mlflowRun endpoint using a fixture added to help the metrics test.