### PR TITLE
Sync to latest plugin

### DIFF
--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -45,6 +45,13 @@ class EntrypointPluginFileSchema(Schema):
         attribute="snapshot_id",
         metadata=dict(description="Snapshot ID for the PluginFile resource."),
     )
+    latestSnapshot = fields.Boolean(
+        attribute="latest_snapshot",
+        metadata=dict(
+            description=f"Whether or not the {filename} resource is the latest version."
+        ),
+        dump_only=True,
+    )
     url = fields.Url(
         attribute="url",
         metadata=dict(description="URL for accessing the full PluginFile snapshot."),

--- a/src/dioptra/restapi/v1/entrypoints/schema.py
+++ b/src/dioptra/restapi/v1/entrypoints/schema.py
@@ -18,6 +18,7 @@
 from marshmallow import Schema, fields, validate
 
 from dioptra.restapi.v1.queues.schema import QueueRefSchema
+from dioptra.restapi.v1.plugins.schema import PluginTaskSchema
 from dioptra.restapi.v1.schemas import (
     BasePageSchema,
     GroupIdQueryParametersSchema,
@@ -49,6 +50,12 @@ class EntrypointPluginFileSchema(Schema):
         metadata=dict(description="URL for accessing the full PluginFile snapshot."),
         relative=True,
     )
+    tasks = fields.Nested(
+        PluginTaskSchema,
+        attribute="tasks",
+        metadata=dict(description="Tasks associated with the PluginFile resource."),
+        many=True,
+    )
 
 
 class EntrypointPluginSchema(Schema):
@@ -65,6 +72,13 @@ class EntrypointPluginSchema(Schema):
     snapshotId = fields.Integer(
         attribute="snapshot_id",
         metadata=dict(description="Snapshot ID for the Plugin resource."),
+    )
+    latestSnapshot = fields.Boolean(
+        attribute="latest_snapshot",
+        metadata=dict(
+            description=f"Whether or not the {name} resource is the latest version."
+        ),
+        dump_only=True,
     )
     url = fields.Url(
         attribute="url",

--- a/src/dioptra/restapi/v1/plugins/schema.py
+++ b/src/dioptra/restapi/v1/plugins/schema.py
@@ -62,23 +62,6 @@ class PluginSnapshotRefSchema(PluginSnapshotRefBaseSchema):  # type: ignore
     )
 
 
-PluginFileRefBaseSchema = generate_base_resource_ref_schema("PluginFile")
-
-
-class PluginFileRefSchema(PluginFileRefBaseSchema):  # type: ignore
-    """The reference schema for the data stored in a PluginFile."""
-
-    pluginId = fields.Int(
-        attribute="plugin_id",
-        data_key="plugin",
-        metadata=dict(description="ID for the Plugin resource this file belongs to."),
-    )
-    filename = fields.String(
-        attribute="filename",
-        metadata=dict(description="Filename of the PluginFile resource."),
-    )
-
-
 class PluginTaskParameterSchema(Schema):
     """The schema for the data stored in a PluginTaskParameter"""
 
@@ -165,6 +148,29 @@ class PluginTaskSchema(Schema):
         metadata=dict(
             description="List of output PluginTaskParameters in this PluginTask."
         ),
+    )
+
+
+PluginFileRefBaseSchema = generate_base_resource_ref_schema("PluginFile")
+
+
+class PluginFileRefSchema(PluginFileRefBaseSchema):  # type: ignore
+    """The reference schema for the data stored in a PluginFile."""
+
+    pluginId = fields.Int(
+        attribute="plugin_id",
+        data_key="plugin",
+        metadata=dict(description="ID for the Plugin resource this file belongs to."),
+    )
+    filename = fields.String(
+        attribute="filename",
+        metadata=dict(description="Filename of the PluginFile resource."),
+    )
+    tasks = fields.Nested(
+        PluginTaskSchema,
+        attribute="tasks",
+        metadata=dict(description="Tasks associated with the PluginFile resource."),
+        many=True,
     )
 
 

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -313,6 +313,7 @@ def build_plugin_file_ref(plugin_file: models.PluginFile) -> dict[str, Any]:
         "url": build_url(
             f"{PLUGINS}/{plugin_id}/{PLUGIN_FILES}/{plugin_file.resource_id}"
         ),
+        "tasks": [build_plugin_task(task) for task in plugin_file.tasks]
     }
 
 

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -255,6 +255,7 @@ def build_entrypoint_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str,
     return {
         "id": plugin.resource_id,
         "snapshot_id": plugin.resource_snapshot_id,
+        "latest_snapshot": plugin.resource.latest_snapshot_id == plugin.resource_snapshot_id,
         "name": plugin.name,
         "url": build_url(
             f"{PLUGINS}/{plugin.resource_id}/snapshots/{plugin.resource_snapshot_id}"
@@ -268,6 +269,7 @@ def build_entrypoint_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str,
                     f"{PLUGINS}/{plugin.resource_id}/{PLUGIN_FILES}/{plugin_file.resource_id}/"
                     f"snapshots/{plugin_file.resource_snapshot_id}"
                 ),
+                "tasks": [build_plugin_task(task) for task in plugin_file.tasks]
             }
             for plugin_file in plugin_files
         ],

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -252,10 +252,16 @@ def build_entrypoint_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str,
     plugin = plugin_with_files["plugin"]
     plugin_files = plugin_with_files["plugin_files"]
 
+    # Determine if any file does not have the latest snapshot
+    any_file_not_latest = any(
+        plugin_file.resource.latest_snapshot_id != plugin_file.resource_snapshot_id
+        for plugin_file in plugin_files
+    )
+
     return {
         "id": plugin.resource_id,
         "snapshot_id": plugin.resource_snapshot_id,
-        "latest_snapshot": plugin.resource.latest_snapshot_id == plugin.resource_snapshot_id,
+        "latest_snapshot": plugin.resource.latest_snapshot_id == plugin.resource_snapshot_id and not any_file_not_latest,
         "name": plugin.name,
         "url": build_url(
             f"{PLUGINS}/{plugin.resource_id}/snapshots/{plugin.resource_snapshot_id}"
@@ -264,6 +270,7 @@ def build_entrypoint_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str,
             {
                 "id": plugin_file.resource_id,
                 "snapshot_id": plugin_file.resource_snapshot_id,
+                "latest_snapshot": plugin_file.resource.latest_snapshot_id == plugin_file.resource_snapshot_id,
                 "filename": plugin_file.filename,
                 "url": build_url(
                     f"{PLUGINS}/{plugin.resource_id}/{PLUGIN_FILES}/{plugin_file.resource_id}/"

--- a/src/frontend/src/dialogs/AssignPluginsDialog.vue
+++ b/src/frontend/src/dialogs/AssignPluginsDialog.vue
@@ -55,7 +55,11 @@
                 icon="sync"
                 size="sm"
                 @click="syncPlugin(plugin.id, i)"
-              />
+              >
+                <q-tooltip>
+                  Sync to latest version of plugin
+                </q-tooltip>
+              </q-btn>
           </div>
         </div>
       </template>

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -229,7 +229,11 @@
                 icon="sync"
                 size="sm"
                 @click="syncPlugin(plugin.id, i)"
-              />
+              >
+                <q-tooltip>
+                  Sync to latest version of plugin
+                </q-tooltip>
+              </q-btn>
             </div>
           </div>
         </div>

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -167,6 +167,16 @@
           <template v-slot:before>
             <div class="field-label">Queues:</div>
           </template>  
+          <template v-slot:selected-item="scope">
+            <q-chip
+              :label="scope.opt.name"
+              removable
+              @remove="scope.removeAtIndex(scope.index)"
+              :tabindex="scope.tabindex"
+              color="primary"
+              text-color="white"
+            />
+          </template>
         </q-select>
 
         <q-select
@@ -189,6 +199,40 @@
             <div class="field-label">Plugins:</div>
           </template>  
         </q-select>
+        <div class="row" v-if="route.params.id !== 'new'">
+          <label class="field-label q-pt-xs">Plugins:</label>
+          <div 
+            class="col" 
+            style="border: 1px solid lightgray; border-radius: 4px; padding: 5px 8px; margin-left: 6px;"
+          >
+            <div
+              v-for="(plugin, i) in entryPoint.plugins"
+              :key="i"
+            >
+              <q-chip
+                :label="plugin.name"
+                color="secondary"
+                text-color="white"
+              >
+                <q-badge
+                  v-if="!plugin.latestSnapshot" 
+                  color="red" 
+                  label="Outdated" 
+                  rounded
+                  class="q-ml-xs"
+                />
+              </q-chip>
+              <q-btn
+                v-if="!plugin.latestSnapshot"
+                round 
+                color="red" 
+                icon="sync"
+                size="sm"
+                @click="syncPlugin(plugin.id, i)"
+              />
+            </div>
+          </div>
+        </div>
       </div>
       
       <TableComponent
@@ -629,4 +673,15 @@
     confirmLeave.value = true
     router.push(toPath.value)
   }
+  async function syncPlugin(pluginID, index) {
+    console.log(pluginID, index)
+    try {
+      const res = await api.getItem('plugins', pluginID)
+      console.log('plugin = ', res)
+      entryPoint.value.plugins[index] = res.data
+    } catch(err) {
+      console.warn(err)
+    }
+  }
+
 </script>

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -430,7 +430,12 @@
     try {
       const res = await api.getFile(route.params.id, route.params.fileId)
       console.log('getFile = ', res)
-      pluginFile.value = res.data
+      pluginFile.value = {
+        filename: res.data.filename,
+        contents: res.data.contents,
+        tasks: res.data.tasks,
+        description: res.data.description
+      }
       title.value = `Edit ${res.data.filename}`
       pluginFile.value.tasks = res.data.tasks
       pluginFile.value.tasks.forEach((task) => {

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -437,12 +437,12 @@
         description: res.data.description
       }
       title.value = `Edit ${res.data.filename}`
-      pluginFile.value.tasks = res.data.tasks
       pluginFile.value.tasks.forEach((task) => {
-        [...task.inputParams, ... task.outputParams].forEach((param) => {
+        [...task.inputParams, ...task.outputParams].forEach((param) => {
           param.parameterType = param.parameterType.id
         })
       })
+      initialCopy.value = JSON.parse(JSON.stringify(pluginFile.value))
     } catch(err) {
       notify.error(err.response.data.message)
     } 

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -29,21 +29,6 @@
         EMPTY
       </span>
     </template>
-    <template #body-cell-parameterNames="props">
-      <label v-for="(param, i) in props.row.parameters" :key="i">
-        {{ param.name }} <br>
-      </label>
-    </template>
-    <template #body-cell-parameterTypes="props">
-      <label v-for="(param, i) in props.row.parameters" :key="i">
-        {{ param.parameterType }} <br>
-      </label>
-    </template>
-    <template #body-cell-defaultValues="props">
-      <label v-for="(param, i) in props.row.parameters" :key="i">
-        {{ param.defaultValue }} <br>
-      </label>
-    </template>
     <template #expandedSlot="{ row }">
       <CodeEditor v-model="row.taskGraph" language="yaml" />
     </template>
@@ -55,6 +40,13 @@
         text-color="white"
       >
         {{ plugin.name }}
+        <q-badge
+          v-if="!plugin.latestSnapshot" 
+          color="red" 
+          label="Outdated" 
+          rounded
+          class="q-ml-xs"
+        />
       </q-chip>
       <q-btn
         round
@@ -127,9 +119,6 @@
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: true, },
     { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
     { name: 'taskGraph', label: 'Task Graph', align: 'left', field: 'taskGraph',sortable: false, },
-    { name: 'parameterNames', label: 'Parameter Name(s)', align: 'left', sortable: false },
-    { name: 'parameterTypes', label: 'Parameter Type(s)', align: 'left', field: 'parameterTypes', sortable: false },
-    { name: 'defaultValues', label: 'Default Values', align: 'left', field: 'defaultValues', sortable: false },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
     { name: 'plugins', label: 'Plugins', align: 'left', field: 'plugins', sortable: false },
   ]

--- a/src/frontend/src/views/PluginsView.vue
+++ b/src/frontend/src/views/PluginsView.vue
@@ -27,15 +27,27 @@
         class="q-ma-md" 
         @click="router.push(`/plugins/${row.id}/files`)" 
       />
-      <BasicTable
+      <TableComponent
         :columns="fileColumns"
         :rows="row.files"
+        :title="`${row.name} Files`"
         :hideSearch="true"
         :hideEditTable="true"
-        id="fileTable"
-        class="q-mx-md"
-        :title="`${row.name} Files`"
-      />
+        :hideCreateBtn="true"
+        :hideDeleteBtn="true"
+        :hideEditBtn="true"
+        :disableSelect="true"
+        style="margin: 0px 5vw 2vh"
+      >
+        <template #body-cell-filename="props">
+          <RouterLink :to="`/plugins/${row.id}/files/${props.row.id}`">
+            {{ props.row.filename }}
+          </RouterLink>
+        </template>
+        <template #body-cell-tasks="props">
+          <div>{{ props.row.tasks?.length }}</div>
+        </template>
+      </TableComponent>
     </template>
   </TableComponent>
   <q-btn 
@@ -73,7 +85,6 @@
 
 <script setup>
   import TableComponent from '@/components/TableComponent.vue'
-  import BasicTable from '@/components/BasicTable.vue'
   import PluginDialog from '@/dialogs/PluginDialog.vue'
   import DeleteDialog from '@/dialogs/DeleteDialog.vue'
   import { ref, watch } from 'vue'


### PR DESCRIPTION
In the entrypoint table and edit form, plugins should be labeled as outdated if it isn't the latestSnapshot.  Beside each outdated plugin should be a "sync to latest plugin" button that should update the plugin to the latest snapshot.  This is available in the entrypoint edit form and the assign plugins dialog in the entrypoints table.  