### PR TITLE
fix: yaml in entrypoints table should be readonly

### DIFF
--- a/src/frontend/src/components/CodeEditor.vue
+++ b/src/frontend/src/components/CodeEditor.vue
@@ -7,6 +7,7 @@
       :indent-with-tab="true"
       :tab-size="2"
       :extensions="extensions"
+      :disabled="readOnly"
       @ready="handleReady"
       @update="highlightPlaceholder"
       :style="{ 'min-height': '250px', 'max-height': '70vh',
@@ -30,7 +31,6 @@
   import { linter, lintGutter } from "@codemirror/lint"
   import parser from "js-yaml"
   import { python } from '@codemirror/lang-python'
-  import { EditorState } from '@codemirror/state'
   import { CompletionContext, autocompletion, startCompletion } from '@codemirror/autocomplete'
   import YAML from 'yaml'
 
@@ -173,7 +173,6 @@
       oneDark,
       yamlLinter,
       lintGutter(),
-      EditorState.readOnly.of(props.readOnly),
       autocompletion({ override: [myCompletions] }),
     ]
   })

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -45,7 +45,7 @@
       </label>
     </template>
     <template #expandedSlot="{ row }">
-      <CodeEditor v-model="row.taskGraph" language="yaml" />
+      <CodeEditor v-model="row.taskGraph" language="yaml" :readOnly="true" />
     </template>
     <template #body-cell-plugins="props">
       <q-chip


### PR DESCRIPTION
Issue: https://github.com/usnistgov/dioptra/issues/564

In the entrypoints table, the code editor in the "View YAML" popup and the expanded row should be readonly.  This was working previously but got broken again somehow.  This PR fixes it using a disabled prop.