### PR TITLE
feat: browse queue history

### DIFF
--- a/src/frontend/src/dialogs/DialogComponent.vue
+++ b/src/frontend/src/dialogs/DialogComponent.vue
@@ -1,10 +1,18 @@
 <template>
   <q-dialog v-model="showDialog" aria-labelledby="modalTitle" :persistent="persistent">
-    <q-card style="width: 95%" flat >
+    <q-card flat style="min-width: 500px; max-width: 80%;">
       <q-form @submit="$emit('emitSubmit')">
         <q-card-section class="bg-primary text-white q-mb-md">
-          <div class="text-h6">
+          <div class="text-h6 row justify-between">
             <slot name="title" />
+            <q-toggle
+              v-if="showHistoryToggle"
+              v-model="history"
+              color="orange"
+              left-label
+              label="View History"
+              class="text-body2"
+            />
           </div>
         </q-card-section>
         <q-card-section>
@@ -21,7 +29,7 @@
           />
           <q-space />
           <q-btn color="negative" class="text-white" label="Cancel" @click="$emit('emitCancel')" v-close-popup />
-          <q-btn color="primary" label="Confirm" type="submit" />
+          <q-btn color="primary" label="Confirm" type="submit" :disable="disableConfirm" />
         </q-card-actions>
       </q-form>
     </q-card>
@@ -29,7 +37,11 @@
 </template>
 
 <script setup>
-  const showDialog = defineModel()
+  import { ref } from 'vue'
+  const showDialog = defineModel('showDialog')
   defineEmits(['emitSubmit', 'emitCancel', 'emitSaveDraft'])
-  const props = defineProps(['hideDraftBtn', 'persistent'])
+  const props = defineProps(['hideDraftBtn', 'persistent', 'showHistoryToggle', 'disableConfirm'])
+
+  const history = defineModel('history')
+
 </script>

--- a/src/frontend/src/dialogs/QueueDialog.vue
+++ b/src/frontend/src/dialogs/QueueDialog.vue
@@ -1,68 +1,137 @@
 <template>
   <DialogComponent 
-    v-model="showDialog"
+    v-model:showDialog="showDialog"
+    v-model:history="history"
     @emitSubmit="emitAddOrEdit"
     @emitSaveDraft="saveDraft"
     :hideDraftBtn="editQueue ? true : false"
+    :showHistoryToggle="editQueue && !Object.hasOwn(editQueue, 'payload')"
+    :disableConfirm="history"
   >
     <template #title>
       <label id="modalTitle">
         {{editQueue ? 'Edit Queue' : 'Register Queue'}}
       </label>
     </template>
-    <div class="row items-center">
-      <label class="col-3 q-mb-lg" id="queueName">
-        Queue Name:
-      </label>
-      <q-input 
-        class="col q-mb-xs" 
-        outlined 
-        dense 
-        v-model.trim="name"  
-        autofocus 
-        :rules="[requiredRule]" 
-        aria-labelledby="queueName"
-        aria-required="true"
-      />
-    </div>
-    <div class="row items-center q-mb-xs">
-      <label class="col-3 q-mb-lg" id="pluginGroup">
-        Group:
-      </label>
-      <q-select
-        class="col"
-        outlined 
-        v-model="group" 
-        :options="store.groups"
-        option-label="name"
-        option-value="id"
-        emit-value
-        map-options
-        dense
-        :rules="[requiredRule]"
-        aria-labelledby="pluginGroup"
-        aria-required="true"
-      />
-    </div>
-    <div class="row items-center">
-      <label class="col-3" id="description">
-        Description:
-      </label>
-      <q-input
-        class="col"
-        v-model.trim="description"
-        outlined
-        type="textarea"
-        aria-labelledby="description"
-      />
+    <div class="row no-wrap">
+      <!-- this is the form col -->
+      <div 
+        style="width: 500px;"
+        :style="{ 
+          pointerEvents: history ? 'none' : 'auto', 
+          opacity: history ? .65 : 1, 
+          cursor: history ? 'not-allowed' : 'default' 
+        }"
+      >
+        <div class="row items-center">
+          <label class="col-3 q-mb-lg" id="queueName">
+            Queue Name:
+          </label>
+          <q-input 
+            class="col q-mb-xs" 
+            outlined 
+            dense 
+            v-model.trim="name"  
+            autofocus 
+            :rules="[requiredRule]" 
+            aria-labelledby="queueName"
+            aria-required="true"
+          />
+        </div>
+        <div class="row items-center q-mb-xs">
+          <label class="col-3 q-mb-lg" id="pluginGroup">
+            Group:
+          </label>
+          <q-select
+            class="col"
+            outlined 
+            v-model="group" 
+            :options="store.groups"
+            option-label="name"
+            option-value="id"
+            emit-value
+            map-options
+            dense
+            :rules="[requiredRule]"
+            aria-labelledby="pluginGroup"
+            aria-required="true"
+          />
+        </div>
+        <div class="row items-center">
+          <label class="col-3" id="description">
+            Description:
+          </label>
+          <q-input
+            class="col"
+            v-model.trim="description"
+            outlined
+            type="textarea"
+            aria-labelledby="description"
+          />
+        </div>
+        <!-- <q-inner-loading :showing="history" size="0px" /> -->
+      </div>
+      <!-- this is the history col -->
+      <q-card 
+        v-if="history" 
+        style="width: 240px; max-height: 263px; overflow: auto;"
+        flat
+        bordered
+        class="q-ml-sm col"
+      >
+        <q-list bordered separator>
+          <q-item
+            v-for="(snapshot, i) in snapshots"
+            tag="label" 
+            v-ripple
+            dense
+            clickable
+            @click="loadSnapshot(snapshot, i)"
+            @keydown="keydown"
+            :class="`${getSelectedColor(selectedSnapshotIndex === i)} cursor-pointer` " 
+          >
+            <!-- <q-item-section avatar>
+              <q-radio
+                v-model="selectedSnapshot"
+                :val="snapshot"
+                @update:model-value="loadSnapshot(snapshot)"
+              />
+            </q-item-section> -->
+            <q-item-section>
+              <q-item-label>
+                {{
+                  new Intl.DateTimeFormat('en-US', { 
+                    year: '2-digit', 
+                    month: '2-digit', 
+                    day: '2-digit', 
+                    hour: 'numeric', 
+                    minute: 'numeric', 
+                    hour12: true 
+                  }).format(new Date(snapshot.snapshotCreatedOn))
+                }}
+                <q-chip
+                  v-if="snapshot.latestSnapshot"
+                  label="latest"
+                  size="md"
+                  dense
+                  color="orange"
+                  text-color="white"
+                />
+              </q-item-label>
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card>
     </div>
   </DialogComponent>
 </template>
 
 <script setup>
-  import { ref, watch } from 'vue'
+  import { ref, watch, computed } from 'vue'
   import DialogComponent from './DialogComponent.vue'
   import { useLoginStore } from '@/stores/LoginStore.ts'
+  import * as api from '@/services/dataApi'
+  import { useQuasar } from 'quasar'
 
   const store = useLoginStore()
 
@@ -79,6 +148,13 @@
   const group = ref('')
   const description = ref('')
 
+  function loadSnapshot(snapshot, index) {
+    selectedSnapshotIndex.value = index
+    name.value = snapshot.name
+    group.value = snapshot.group
+    description.value = snapshot.description
+  }
+
   watch(showDialog, (newVal) => {
     if(newVal) {
       name.value = props.editQueue.name
@@ -88,6 +164,8 @@
     else {
       name.value = ''
       description.value = ''
+      history.value = false
+      snapshots.value = []
     }
   })
 
@@ -107,6 +185,60 @@
 
   function saveDraft() {
     emit('saveDraft', name.value, description.value, props.editQueue.id)
+  }
+
+  const history = ref(false)
+
+  const snapshots = ref([])
+  const selectedSnapshot = ref()
+  const selectedSnapshotIndex = ref()
+
+  async function getSnapshots() {
+    try {
+      const res = await api.getSnapshots('queues', props.editQueue.id)
+      snapshots.value = res.data.data.reverse()
+      selectedSnapshot.value = snapshots.value[0]
+      selectedSnapshotIndex.value = 0
+      loadSnapshot(snapshots.value[0], 0)
+    } catch(err) {
+      console.warn(err)
+    }
+  }
+
+  watch(history, (newVal) => {
+    if(newVal) {
+      getSnapshots()
+    } else {
+      selectedSnapshotIndex.value = 0
+      name.value = props.editQueue.name
+      description.value = props.editQueue.description
+      group.value = props.editQueue.group
+    }
+  })
+
+  const $q = useQuasar()
+
+  const darkMode = computed(() => {
+    if($q.dark.mode === 'auto') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    return $q.dark.mode
+  })
+
+  function getSelectedColor(selected) {
+    if(darkMode.value && selected) return 'bg-deep-purple-10'
+    else if(selected) return 'bg-blue-grey-2'
+  }
+
+  function keydown(event) {
+    if(event.key === 'ArrowUp' && selectedSnapshotIndex.value > 0) {
+      const newIndex = selectedSnapshotIndex.value - 1
+      loadSnapshot(snapshots.value[newIndex], newIndex)
+    }
+    else if(event.key === 'ArrowDown' && selectedSnapshotIndex.value < snapshots.value.length - 1) {
+      const newIndex = selectedSnapshotIndex.value + 1
+      loadSnapshot(snapshots.value[newIndex], newIndex)
+    }
   }
 
 

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -155,6 +155,24 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
   return res
 }
 
+export async function getSnapshots<T extends ItemType>(type: T, id: number) {
+  const res =  await axios.get(`/api/${type}/${id}/snapshots`, {
+    params: {
+      pageLength: 100
+    }
+  })
+
+  if(res.data.next) {
+    let nextUrl = res.data.next.replace("/v1", "")
+    while (nextUrl) {
+      const response = await axios.get(nextUrl)
+      res.data.data.push(...response.data.data)
+      nextUrl = response.data.next ? response.data.next.replace("/v1", "") : null
+    }
+  }
+  return res
+}
+
 export async function getJobs(id: number, pagination: Pagination) {
   const res = await axios.get(`/api/experiments/${id}/jobs`, {
     params: {


### PR DESCRIPTION
In the edit queue dialog, add view history toggle to browse snapshots.  Latest snapshot will be selected by default.  Click or tab over to the list, and then you can use up/down arrow keys.  Submit button will be disabled when viewing history.

Timestamps are currently all the same because snapshots inherit timestamp from the parent resource, this will be fixed separately. 