### PR TITLE
feat: add snapshot_created_on field to resource response schemas

### DIFF
--- a/src/dioptra/restapi/v1/schemas.py
+++ b/src/dioptra/restapi/v1/schemas.py
@@ -67,6 +67,13 @@ def generate_base_resource_schema(name: str, snapshot: bool) -> type[Schema]:
             ),
             dump_only=True,
         ),
+        "snapshotCreatedOn": fields.DateTime(
+            attribute="snapshot_created_on",
+            metadata=dict(
+                description=f"Timestamp when the {name} resource snapshot was created."
+            ),
+            dump_only=True,
+        ),
         "lastModifiedOn": fields.DateTime(
             attribute="last_modified_on",
             metadata=dict(

--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -546,6 +546,7 @@ def build_experiment(experiment_dict: ExperimentDict) -> dict[str, Any]:
         "group": build_group_ref(experiment.resource.owner),
         "created_on": experiment.resource.created_on,
         "last_modified_on": experiment.resource.last_modified_on,
+        "snapshot_created_on": experiment.created_on,
         "latest_snapshot": experiment.resource.latest_snapshot_id
         == experiment.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in experiment.tags],
@@ -608,6 +609,7 @@ def build_entrypoint(entrypoint_dict: EntrypointDict) -> dict[str, Any]:
         "group": build_group_ref(entrypoint.resource.owner),
         "created_on": entrypoint.resource.created_on,
         "last_modified_on": entrypoint.resource.last_modified_on,
+        "snapshot_created_on": entrypoint.created_on,
         "latest_snapshot": entrypoint.resource.latest_snapshot_id
         == entrypoint.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in entrypoint.tags],
@@ -675,6 +677,7 @@ def build_job(job_dict: JobDict) -> dict[str, Any]:
         "entrypoint": build_entrypoint_snapshot_ref(job.entry_point_job.entry_point),
         "created_on": job.resource.created_on,
         "last_modified_on": job.resource.last_modified_on,
+        "snapshot_created_on": job.created_on,
         "latest_snapshot": job.resource.latest_snapshot_id == job.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in job.tags],
     }
@@ -725,6 +728,7 @@ def build_model(model_dict: ModelWithVersionDict) -> dict[str, Any]:
         "group": build_group_ref(model.resource.owner),
         "created_on": model.resource.created_on,
         "last_modified_on": model.resource.last_modified_on,
+        "snapshot_created_on": model.created_on,
         "latest_snapshot": model.resource.latest_snapshot_id
         == model.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in model.tags],
@@ -772,6 +776,7 @@ def build_artifact(artifact_dict: ArtifactDict) -> dict[str, Any]:
         "group": build_group_ref(artifact.resource.owner),
         "created_on": artifact.resource.created_on,
         "last_modified_on": artifact.resource.last_modified_on,
+        "snapshot_created_on": artifact.created_on,
         "latest_snapshot": artifact.resource.latest_snapshot_id
         == artifact.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in artifact.tags],
@@ -804,6 +809,7 @@ def build_queue(queue_dict: QueueDict) -> dict[str, Any]:
         "group": build_group_ref(queue.resource.owner),
         "created_on": queue.resource.created_on,
         "last_modified_on": queue.resource.last_modified_on,
+        "snapshot_created_on": queue.created_on,
         "latest_snapshot": queue.resource.latest_snapshot_id
         == queue.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in queue.tags],
@@ -837,6 +843,7 @@ def build_plugin(plugin_with_files: PluginWithFilesDict) -> dict[str, Any]:
         "group": build_group_ref(plugin.resource.owner),
         "created_on": plugin.resource.created_on,
         "last_modified_on": plugin.resource.last_modified_on,
+        "snapshot_created_on": plugin.created_on,
         "latest_snapshot": plugin.resource.latest_snapshot_id
         == plugin.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in plugin.tags],
@@ -867,6 +874,7 @@ def build_plugin_file(plugin_file_with_plugin: PluginFileDict) -> dict[str, Any]
         "group": build_group_ref(plugin_file.resource.owner),
         "created_on": plugin_file.resource.created_on,
         "last_modified_on": plugin_file.resource.last_modified_on,
+        "snapshot_created_on": plugin_file.created_on,
         "latest_snapshot": plugin_file.resource.latest_snapshot_id
         == plugin_file.resource_snapshot_id,
         "contents": plugin_file.contents,
@@ -943,6 +951,7 @@ def build_plugin_parameter_type(
         "group": build_group_ref(plugin_parameter_type.resource.owner),
         "created_on": plugin_parameter_type.resource.created_on,
         "last_modified_on": plugin_parameter_type.resource.last_modified_on,
+        "snapshot_created_on": plugin_parameter_type.created_on,
         "latest_snapshot": plugin_parameter_type.resource.latest_snapshot_id
         == plugin_parameter_type.resource_snapshot_id,
         "tags": [build_tag_ref(tag) for tag in plugin_parameter_type.tags],

--- a/tests/unit/restapi/lib/asserts.py
+++ b/tests/unit/restapi/lib/asserts.py
@@ -31,11 +31,13 @@ def assert_base_resource_contents_match_expectations(response: dict[str, Any]) -
     assert isinstance(response["id"], int)
     assert isinstance(response["snapshot"], int)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
 

--- a/tests/unit/restapi/v1/test_artifact.py
+++ b/tests/unit/restapi/v1/test_artifact.py
@@ -55,6 +55,7 @@ def assert_artifact_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -70,6 +71,7 @@ def assert_artifact_response_contents_matches_expectations(
     assert isinstance(response["uri"], str)
     assert isinstance(response["description"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -78,6 +80,7 @@ def assert_artifact_response_contents_matches_expectations(
     assert response["description"] == expected_contents["description"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -55,6 +55,7 @@ def assert_entrypoint_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -74,6 +75,7 @@ def assert_entrypoint_response_contents_matches_expectations(
     assert isinstance(response["name"], str)
     assert isinstance(response["description"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -83,6 +85,7 @@ def assert_entrypoint_response_contents_matches_expectations(
     assert response["taskGraph"] == expected_contents["task_graph"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate PluginRef structure

--- a/tests/unit/restapi/v1/test_experiment.py
+++ b/tests/unit/restapi/v1/test_experiment.py
@@ -53,6 +53,7 @@ def assert_experiment_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -69,6 +70,7 @@ def assert_experiment_response_contents_matches_expectations(
     assert isinstance(response["name"], str)
     assert isinstance(response["description"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
 
@@ -76,6 +78,7 @@ def assert_experiment_response_contents_matches_expectations(
     assert response["description"] == expected_contents["description"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure

--- a/tests/unit/restapi/v1/test_job.py
+++ b/tests/unit/restapi/v1/test_job.py
@@ -54,6 +54,7 @@ def assert_job_response_contents_matches_expectations(
         "id",
         "snapshot",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",

--- a/tests/unit/restapi/v1/test_model.py
+++ b/tests/unit/restapi/v1/test_model.py
@@ -56,6 +56,7 @@ def assert_model_response_contents_matches_expectations(
         "user",
         "versions",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",

--- a/tests/unit/restapi/v1/test_plugin.py
+++ b/tests/unit/restapi/v1/test_plugin.py
@@ -56,6 +56,7 @@ def assert_plugin_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -72,6 +73,7 @@ def assert_plugin_response_contents_matches_expectations(
     assert isinstance(response["name"], str)
     assert isinstance(response["description"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -80,6 +82,7 @@ def assert_plugin_response_contents_matches_expectations(
     assert response["description"] == expected_contents["description"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure
@@ -312,6 +315,7 @@ def assert_plugin_file_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -331,6 +335,7 @@ def assert_plugin_file_response_contents_matches_expectations(
     assert isinstance(response["description"], str)
     assert isinstance(response["contents"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -340,6 +345,7 @@ def assert_plugin_file_response_contents_matches_expectations(
     assert response["contents"] == expected_contents["contents"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure

--- a/tests/unit/restapi/v1/test_plugin_parameter_type.py
+++ b/tests/unit/restapi/v1/test_plugin_parameter_type.py
@@ -322,6 +322,7 @@ def assert_plugin_parameter_type_content_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -339,6 +340,7 @@ def assert_plugin_parameter_type_content_matches_expectations(
     assert isinstance(response["structure"], (dict, type(None)))
     assert isinstance(response["description"], (str, type(None)))
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -348,6 +350,7 @@ def assert_plugin_parameter_type_content_matches_expectations(
     assert response["description"] == expected_contents["description"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure

--- a/tests/unit/restapi/v1/test_queue.py
+++ b/tests/unit/restapi/v1/test_queue.py
@@ -54,6 +54,7 @@ def assert_queue_response_contents_matches_expectations(
         "group",
         "user",
         "createdOn",
+        "snapshotCreatedOn",
         "lastModifiedOn",
         "latestSnapshot",
         "hasDraft",
@@ -69,6 +70,7 @@ def assert_queue_response_contents_matches_expectations(
     assert isinstance(response["name"], str)
     assert isinstance(response["description"], str)
     assert isinstance(response["createdOn"], str)
+    assert isinstance(response["snapshotCreatedOn"], str)
     assert isinstance(response["lastModifiedOn"], str)
     assert isinstance(response["latestSnapshot"], bool)
     assert isinstance(response["hasDraft"], bool)
@@ -77,6 +79,7 @@ def assert_queue_response_contents_matches_expectations(
     assert response["description"] == expected_contents["description"]
 
     assert helpers.is_iso_format(response["createdOn"])
+    assert helpers.is_iso_format(response["snapshotCreatedOn"])
     assert helpers.is_iso_format(response["lastModifiedOn"])
 
     # Validate the UserRef structure


### PR DESCRIPTION
This commit adds the snapshot_created_on datetime field to all Resource response schemas. It also updates the `build_` helper functions to include the field in responses and updates the test suite to validate the updated response schemas.