### PR TITLE
feat: browse experiment history

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,9 +1,28 @@
 <template>
-  <NavBar class="fixed-top" style="z-index: 999;" />
-  <main :class="isMobile ? 'q-ma-md' : 'q-ma-xl'" style="margin-top: 75px;">
+  <q-layout view="hHh lpR fFf">
+
+    <q-header>
+      <NavBar />
+    </q-header>
+
+    <q-drawer v-model="store.showRightDrawer" side="right" bordered :width="240">
+      <SnapshotList />
+    </q-drawer>
+
+    <q-page-container>
+      <div
+        :class="isMobile ? 'q-ma-md' : 'q-ma-xl'" 
+        :style="{ 'margin-top': isMobile ? '10px' : '25px', height: '100' }"
+      >
+        <router-view />
+      </div>
+    </q-page-container>
+
+  </q-layout>
+
+  <!-- <main :class="isMobile ? 'q-ma-md' : 'q-ma-xl'" style="margin-top: 75px;">
     <RouterView />
-  </main>
-  <!-- <AccessibilityTest /> -->
+  </main> -->
 </template>
 
 <script setup lang="ts">
@@ -11,11 +30,19 @@
   import NavBar from '@/components/NavBar.vue'
   import AccessibilityTest from '@/components/AccessibilityTest.vue'
   import { useQuasar } from 'quasar'
-  import { computed, provide } from 'vue'
+  import { computed, provide, watch } from 'vue'
+  import { useLoginStore } from '@/stores/LoginStore'
+  import SnapshotList from './components/SnapshotList.vue'
+
+  const store = useLoginStore()
   
   const route = useRoute()
 
   const $q = useQuasar()
+
+  const isExtraSmall = computed(() => {
+    return $q.screen.xs
+  })
 
   const isMobile = computed(() => {
     return $q.screen.sm || $q.screen.xs
@@ -27,5 +54,14 @@
   
   provide('isMobile', isMobile)
   provide('isMedium', isMedium)
+  provide('isExtraSmall', isExtraSmall)
+
+  watch(route, (to) => {
+    // on every route change, close snapshot drawer if open
+    if(store.showRightDrawer) {
+      store.showRightDrawer = false
+      store.selectedSnapshot = null
+    }
+  })
 
 </script>

--- a/src/frontend/src/assets/main.css
+++ b/src/frontend/src/assets/main.css
@@ -110,6 +110,7 @@ h1 {
   font-size: clamp(1rem, 10vw, 4rem) !important;
   line-height: 1 !important;
   font-weight: 400 !important;
+  margin-top: 0;
 }
 
 h2 {
@@ -120,7 +121,7 @@ h2 {
 
 .field-label {
   width: 100px;
-  font-size: 1rem;
+  font-size: .6em;
   color: black;
 }
 

--- a/src/frontend/src/components/SnapshotList.vue
+++ b/src/frontend/src/components/SnapshotList.vue
@@ -1,0 +1,106 @@
+<template>
+  <TableComponent
+    :rows="snapshots"
+    :columns="columns"
+    v-model:selected="selected"
+    :title="props.maxHeight ? '' : 'Snapshots'"
+    :hideCreateBtn="true"
+    :hideDeleteBtn="true"
+    :hideEditBtn="true"
+    :hideSearch="true"
+    :disableRadio="true"
+    rowKey="snapshot"
+    :showAll="true"
+    :style="{ 
+      marginTop: '0', 
+      maxHeight: props.maxHeight ? props.maxHeight + 'px' : '',
+      height: props.maxHeight ? '' : 'calc(100vh - 50px)'
+    }"
+  >
+    <template #body-cell-timestamp="props">
+      {{
+        new Intl.DateTimeFormat('en-US', { 
+          year: '2-digit', 
+          month: '2-digit', 
+          day: '2-digit', 
+          hour: 'numeric', 
+          minute: 'numeric', 
+          hour12: true 
+        }).format(new Date(props.row.snapshotCreatedOn))
+      }}
+      <q-chip
+        v-if="props.row.latestSnapshot"
+        label="latest"
+        size="md"
+        dense
+        color="orange"
+        text-color="white"
+      />
+    </template>
+  </TableComponent>
+</template>
+
+<script setup>
+import { useLoginStore } from '@/stores/LoginStore'
+import { useRoute } from 'vue-router'
+import TableComponent from '@/components/TableComponent.vue'
+import { ref, watch } from 'vue'
+import * as api from '@/services/dataApi'
+
+const props = defineProps(['showDialogHistory', 'type', 'id', 'maxHeight'])
+
+const store = useLoginStore()
+const route = useRoute()
+
+const snapshots = ref([])
+const selected = ref([])
+
+async function getSnapshots() {
+  try {
+    const res = await api.getSnapshots(route.meta.type, route.params.id)
+    snapshots.value = res.data.data.reverse()
+    console.log('snapshots = ', snapshots.value)
+  } catch(err) {
+    console.warn(err)
+  }
+}
+
+async function getDialogSnapshots() {
+  try {
+    const res = await api.getSnapshots(props.type, props.id)
+    snapshots.value = res.data.data.reverse()
+    console.log('snapshots = ', snapshots.value)
+  } catch(err) {
+    console.warn(err)
+  }
+}
+
+watch(() => store.showRightDrawer, (history) => {
+  if(history) {
+    getSnapshots()
+  } else {
+    store.selectedSnapshot = null
+  }
+})
+
+watch(() => props.showDialogHistory, (history) => {
+  if(history) {
+    getDialogSnapshots()
+  } else {
+    store.selectedSnapshot = null
+  }
+})
+
+watch(selected, (newVal) => {
+  if(newVal.length > 0) {
+    store.selectedSnapshot = newVal[0]
+  }
+})
+
+const columns = [
+  { name: 'timestamp', label: 'Created On', align: 'left', field: 'snapshotCreatedOn', sortable: true, },
+]
+
+
+
+</script>

--- a/src/frontend/src/dialogs/DialogComponent.vue
+++ b/src/frontend/src/dialogs/DialogComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="showDialog" aria-labelledby="modalTitle" :persistent="persistent">
-    <q-card flat style="min-width: 500px; max-width: 80%;">
+    <q-card flat :style="{ 'min-width': isMedium ? '50%' : '30%' }">
       <q-form @submit="$emit('emitSubmit')">
         <q-card-section class="bg-primary text-white q-mb-md">
           <div class="text-h6 row justify-between">
@@ -37,11 +37,13 @@
 </template>
 
 <script setup>
-  import { ref } from 'vue'
+  import { inject } from 'vue'
   const showDialog = defineModel('showDialog')
   defineEmits(['emitSubmit', 'emitCancel', 'emitSaveDraft'])
   const props = defineProps(['hideDraftBtn', 'persistent', 'showHistoryToggle', 'disableConfirm'])
 
   const history = defineModel('history')
+
+  const isMedium = inject('isMedium')
 
 </script>

--- a/src/frontend/src/dialogs/LeaveFormDialog.vue
+++ b/src/frontend/src/dialogs/LeaveFormDialog.vue
@@ -4,7 +4,9 @@
     @emitSubmit="$emit('leaveForm')"
     :hideDraftBtn="true"
   >
-    <template #title>Leave <span class="text-capitalize">{{ type }}</span> Form?</template>
+    <template #title>
+      <span class="text-capitalize">Leave {{ type }} Form?</span>
+    </template>
     <q-card-section class="q-pt-none">
       You are about to leave the {{ type }} form and have unsaved changes. <br>
       All changes will be lost.  Continue?

--- a/src/frontend/src/dialogs/QueueDialog.vue
+++ b/src/frontend/src/dialogs/QueueDialog.vue
@@ -13,127 +13,83 @@
         {{editQueue ? 'Edit Queue' : 'Register Queue'}}
       </label>
     </template>
-    <div class="row no-wrap">
+    <div class="row">
       <!-- this is the form col -->
-      <div 
-        style="width: 500px;"
+      <div
+        :class="`${isExtraSmall ? 'col-12 q-mb-md' : 'col'}`"
         :style="{ 
           pointerEvents: history ? 'none' : 'auto', 
           opacity: history ? .65 : 1, 
           cursor: history ? 'not-allowed' : 'default' 
         }"
+        ref="formCol"
       >
-        <div class="row items-center">
-          <label class="col-3 q-mb-lg" id="queueName">
-            Queue Name:
-          </label>
-          <q-input 
-            class="col q-mb-xs" 
-            outlined 
-            dense 
-            v-model.trim="name"  
-            autofocus 
-            :rules="[requiredRule]" 
-            aria-labelledby="queueName"
-            aria-required="true"
-          />
-        </div>
-        <div class="row items-center q-mb-xs">
-          <label class="col-3 q-mb-lg" id="pluginGroup">
-            Group:
-          </label>
-          <q-select
-            class="col"
-            outlined 
-            v-model="group" 
-            :options="store.groups"
-            option-label="name"
-            option-value="id"
-            emit-value
-            map-options
-            dense
-            :rules="[requiredRule]"
-            aria-labelledby="pluginGroup"
-            aria-required="true"
-          />
-        </div>
-        <div class="row items-center">
-          <label class="col-3" id="description">
-            Description:
-          </label>
-          <q-input
-            class="col"
-            v-model.trim="description"
-            outlined
-            type="textarea"
-            aria-labelledby="description"
-          />
-        </div>
-        <!-- <q-inner-loading :showing="history" size="0px" /> -->
+        <q-input 
+          class="q-mb-xs" 
+          outlined 
+          dense 
+          v-model.trim="name"  
+          autofocus 
+          :rules="[requiredRule]" 
+          id="queueName"
+          aria-required="true"
+        >
+          <template #before>
+            <label for="queueName" class="field-label">Queue Name:</label>
+          </template>
+        </q-input>
+        <q-select
+          class="q-mb-xs"
+          outlined 
+          v-model="group" 
+          :options="store.groups"
+          option-label="name"
+          option-value="id"
+          emit-value
+          map-options
+          dense
+          :rules="[requiredRule]"
+          id="pluginGroup"
+          aria-required="true"
+        >
+          <template #before>
+            <label for="pluginGroup" class="field-label">Group:</label>
+          </template>
+        </q-select>
+        <q-input
+          v-model.trim="description"
+          outlined
+          type="textarea"
+          id="description"
+          dense
+        >
+          <template #before>
+            <label for="description" class="field-label">Description:</label>
+          </template>
+        </q-input>
       </div>
       <!-- this is the history col -->
-      <q-card 
-        v-if="history" 
-        style="width: 240px; max-height: 263px; overflow: auto;"
-        flat
-        bordered
-        class="q-ml-sm col"
-      >
-        <q-list bordered separator>
-          <q-item
-            v-for="(snapshot, i) in snapshots"
-            tag="label" 
-            v-ripple
-            dense
-            clickable
-            @click="loadSnapshot(snapshot, i)"
-            @keydown="keydown"
-            :class="`${getSelectedColor(selectedSnapshotIndex === i)} cursor-pointer` " 
-          >
-            <!-- <q-item-section avatar>
-              <q-radio
-                v-model="selectedSnapshot"
-                :val="snapshot"
-                @update:model-value="loadSnapshot(snapshot)"
-              />
-            </q-item-section> -->
-            <q-item-section>
-              <q-item-label>
-                {{
-                  new Intl.DateTimeFormat('en-US', { 
-                    year: '2-digit', 
-                    month: '2-digit', 
-                    day: '2-digit', 
-                    hour: 'numeric', 
-                    minute: 'numeric', 
-                    hour12: true 
-                  }).format(new Date(snapshot.snapshotCreatedOn))
-                }}
-                <q-chip
-                  v-if="snapshot.latestSnapshot"
-                  label="latest"
-                  size="md"
-                  dense
-                  color="orange"
-                  text-color="white"
-                />
-              </q-item-label>
-            </q-item-section>
-          </q-item>
-        </q-list>
-      </q-card>
+      <SnapshotList 
+        v-show="history"
+        :showDialogHistory="history"
+        type="queues"
+        :id="props.editQueue.id"
+        :maxHeight="formCol?.clientHeight"
+        :class="`${isExtraSmall ? 'col-12' : 'col-sm-auto q-ml-md'}`"
+      />
     </div>
   </DialogComponent>
 </template>
 
 <script setup>
-  import { ref, watch, computed } from 'vue'
+  import { ref, watch, inject } from 'vue'
   import DialogComponent from './DialogComponent.vue'
   import { useLoginStore } from '@/stores/LoginStore.ts'
-  import * as api from '@/services/dataApi'
-  import { useQuasar } from 'quasar'
+  import SnapshotList from '../components/SnapshotList.vue'
 
   const store = useLoginStore()
+
+  const isExtraSmall = inject('isExtraSmall')
 
   const props = defineProps(['editQueue'])
   const emit = defineEmits(['addQueue', 'updateQueue', 'saveDraft'])
@@ -148,13 +104,6 @@
   const group = ref('')
   const description = ref('')
 
-  function loadSnapshot(snapshot, index) {
-    selectedSnapshotIndex.value = index
-    name.value = snapshot.name
-    group.value = snapshot.group
-    description.value = snapshot.description
-  }
-
   watch(showDialog, (newVal) => {
     if(newVal) {
       name.value = props.editQueue.name
@@ -165,7 +114,6 @@
       name.value = ''
       description.value = ''
       history.value = false
-      snapshots.value = []
     }
   })
 
@@ -189,57 +137,18 @@
 
   const history = ref(false)
 
-  const snapshots = ref([])
-  const selectedSnapshot = ref()
-  const selectedSnapshotIndex = ref()
-
-  async function getSnapshots() {
-    try {
-      const res = await api.getSnapshots('queues', props.editQueue.id)
-      snapshots.value = res.data.data.reverse()
-      selectedSnapshot.value = snapshots.value[0]
-      selectedSnapshotIndex.value = 0
-      loadSnapshot(snapshots.value[0], 0)
-    } catch(err) {
-      console.warn(err)
-    }
-  }
-
-  watch(history, (newVal) => {
+  watch(() => store.selectedSnapshot, (newVal) => {
     if(newVal) {
-      getSnapshots()
+      name.value = newVal.name
+      group.value = newVal.group
+      description.value = newVal.description
     } else {
-      selectedSnapshotIndex.value = 0
       name.value = props.editQueue.name
-      description.value = props.editQueue.description
       group.value = props.editQueue.group
+      description.value = props.editQueue.description
     }
   })
 
-  const $q = useQuasar()
-
-  const darkMode = computed(() => {
-    if($q.dark.mode === 'auto') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches
-    }
-    return $q.dark.mode
-  })
-
-  function getSelectedColor(selected) {
-    if(darkMode.value && selected) return 'bg-deep-purple-10'
-    else if(selected) return 'bg-blue-grey-2'
-  }
-
-  function keydown(event) {
-    if(event.key === 'ArrowUp' && selectedSnapshotIndex.value > 0) {
-      const newIndex = selectedSnapshotIndex.value - 1
-      loadSnapshot(snapshots.value[newIndex], newIndex)
-    }
-    else if(event.key === 'ArrowDown' && selectedSnapshotIndex.value < snapshots.value.length - 1) {
-      const newIndex = selectedSnapshotIndex.value + 1
-      loadSnapshot(snapshots.value[newIndex], newIndex)
-    }
-  }
-
+  const formCol = ref()
 
 </script>

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -54,7 +54,8 @@ const router = createRouter({
     },
     {
       path: '/experiments/:id',
-      component: () => import('../views/CreateExperiment.vue')
+      component: () => import('../views/CreateExperiment.vue'),
+      meta: { type: 'experiments' }
     },
     {
       path: '/groups',

--- a/src/frontend/src/stores/LoginStore.ts
+++ b/src/frontend/src/stores/LoginStore.ts
@@ -44,11 +44,13 @@ export const useLoginStore = defineStore('login', () => {
     files: {},
   })
   
+  const showRightDrawer = ref(false)
+  const selectedSnapshot = ref()
 
   // computed()'s are getters
 
   // function()'s are actions
   
 
-  return { loggedInUser, loggedInGroup, groups, users, savedForms };
+  return { loggedInUser, loggedInGroup, groups, users, savedForms, showRightDrawer, selectedSnapshot };
 })

--- a/src/frontend/src/views/CreateJob.vue
+++ b/src/frontend/src/views/CreateJob.vue
@@ -193,7 +193,7 @@
     </fieldset>
   </div>
 
-  <div :class="`${isMobile ? '' : 'q-mx-xl'} float-right q-mb-lg`">
+  <div :class="`float-right q-mb-lg`">
       <q-btn  
         :to="expJobOrAllJobs === 'allJobs' ? `/jobs` : `/experiments/${route.params.id}/jobs`"
         color="negative" 


### PR DESCRIPTION
Add ability for user to browse Experiment history in the edit form.  Clicking the toggle will bring out the right drawer containing the snapshot list, which can eventually be used in other form pages.  Selecting a row loads the values into the form.  Up/down keyboard navigation should work when you are clicked into the table.  Table can be sorted.  The queue dialog was also updated to use this SnapshotList component.  