### PR TITLE
feat(restapi): add snapshot id to draft modifications PUT endpoints

### DIFF
--- a/src/dioptra/client/drafts.py
+++ b/src/dioptra/client/drafts.py
@@ -373,11 +373,14 @@ class ModifyResourceDraftsSubCollectionClient(SubCollectionClient[T]):
             json_=self._validate_fields(kwargs),
         )
 
-    def modify(self, *resource_ids: str | int, **kwargs) -> T:
+    def modify(
+        self, *resource_ids: str | int, resource_snapshot_id: str | int, **kwargs
+    ) -> T:
         """Modify a resource modification draft.
 
         Args:
             *resource_ids: The parent resource ids that own the sub-collection.
+            resource_snapshot_id: The resource snapshot id the draft is based on.
             **kwargs: The draft fields to modify.
 
         Returns:
@@ -389,7 +392,10 @@ class ModifyResourceDraftsSubCollectionClient(SubCollectionClient[T]):
         """
         return self._session.put(
             self.build_sub_collection_url(*resource_ids),
-            json_=self._validate_fields(kwargs),
+            json_={
+                "resourceSnapshot": int(resource_snapshot_id),
+                "resourceData": self._validate_fields(kwargs),
+            },
         )
 
     def delete(self, *resource_ids: str | int) -> T:

--- a/src/dioptra/client/entrypoints.py
+++ b/src/dioptra/client/entrypoints.py
@@ -350,7 +350,10 @@ class EntrypointsCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/entrypoints/1/draft
             client.entrypoints.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description"
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description"
             )
 
             # POST /api/v1/entrypoints/1/draft

--- a/src/dioptra/client/experiments.py
+++ b/src/dioptra/client/experiments.py
@@ -509,7 +509,10 @@ class ExperimentsCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/experiments/1/draft
             client.experiments.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description"
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description"
             )
 
             # POST /api/v1/experiments/1/draft

--- a/src/dioptra/client/models.py
+++ b/src/dioptra/client/models.py
@@ -255,7 +255,10 @@ class ModelsCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/models/1/draft
             client.models.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description"
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description"
             )
 
             # POST /api/v1/models/1/draft

--- a/src/dioptra/client/plugin_parameter_types.py
+++ b/src/dioptra/client/plugin_parameter_types.py
@@ -118,7 +118,11 @@ class PluginParameterTypesCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/pluginParameterTypes/1/draft
             client.plugin_parameter_types.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description", structure=None
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description",
+                structure=None
             )
 
             # POST /api/v1/pluginParameterTypes/1/draft

--- a/src/dioptra/client/plugins.py
+++ b/src/dioptra/client/plugins.py
@@ -160,6 +160,7 @@ class PluginFilesSubCollectionClient(SubCollectionClient[T]):
             client.plugins.files.modify_resource_drafts.modify(
                 1,
                 2,
+                resource_snapshot_id=1,
                 filename="new_name.py",
                 contents="",
                 tasks=[],
@@ -465,7 +466,10 @@ class PluginsCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/plugins/1/draft
             client.plugins.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description"
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description"
             )
 
             # POST /api/v1/plugins/1/draft

--- a/src/dioptra/client/queues.py
+++ b/src/dioptra/client/queues.py
@@ -113,7 +113,10 @@ class QueuesCollectionClient(CollectionClient[T]):
 
             # PUT /api/v1/queues/1/draft
             client.queues.modify_resource_drafts.modify(
-                1, name="new-name", description="new-description"
+                1,
+                resource_snapshot_id=1,
+                name="new-name",
+                description="new-description"
             )
 
             # POST /api/v1/queues/1/draft

--- a/src/dioptra/restapi/errors.py
+++ b/src/dioptra/restapi/errors.py
@@ -206,6 +206,20 @@ class DraftAlreadyExistsError(DioptraError):
         self.resource_id = id
 
 
+class InvalidDraftBaseResourceSnapshotError(DioptraError):
+    """The draft's base snapshot identifier is invalid."""
+
+    def __init__(
+        self,
+        message: str,
+        base_resource_snapshot_id: int,
+        provided_resource_snapshot_id: int,
+    ):
+        super().__init__(message)
+        self.base_resource_snapshot_id = base_resource_snapshot_id
+        self.provided_resource_snapshot_id = provided_resource_snapshot_id
+
+
 class SortParameterValidationError(DioptraError):
     """The sort parameters are not valid."""
 
@@ -417,6 +431,20 @@ def register_error_handlers(api: Api, **kwargs) -> None:  # noqa: C901
     def handle_draft_already_exists(error: DraftAlreadyExistsError):
         log.debug(error.to_message())
         return error_result(error, http.HTTPStatus.BAD_REQUEST, {})
+
+    @api.errorhandler(InvalidDraftBaseResourceSnapshotError)
+    def handle_invalid_draft_base_resource_snapshot(
+        error: InvalidDraftBaseResourceSnapshotError,
+    ):
+        log.debug(error.to_message())
+        return error_result(
+            error,
+            http.HTTPStatus.BAD_REQUEST,
+            {
+                "base_resource_snapshot_id": error.base_resource_snapshot_id,
+                "provided_resource_snapshot_id": error.provided_resource_snapshot_id,
+            },
+        )
 
     @api.errorhandler(LockError)
     def handle_lock_error(error: LockError):

--- a/src/dioptra/restapi/v1/shared/drafts/schema.py
+++ b/src/dioptra/restapi/v1/shared/drafts/schema.py
@@ -108,6 +108,13 @@ class DraftSchema(Schema):
     )
 
 
+class ModifyDraftBaseSchema(Schema):
+    resourceSnapshot = fields.Integer(
+        attribute="resource_snapshot_id",
+        metadata=dict(description="ID of the resource snapshot this draft modifies."),
+    )
+
+
 class DraftPageSchema(BasePageSchema):
     """The paged schema for the data stored in a Draft."""
 

--- a/src/frontend/src/dialogs/QueueDraftDialog.vue
+++ b/src/frontend/src/dialogs/QueueDraftDialog.vue
@@ -107,7 +107,7 @@
 
   function emitAddOrEdit() {
     if(props.queueToDraft.hasDraft) {
-      emit('updateDraftLinkedToQueue', props.queueToDraft.id, name.value, description.value)
+      emit('updateDraftLinkedToQueue', props.queueToDraft.id, name.value, description.value, props.queueToDraft.snapshot)
     } else {
       emit('addQueue', name.value, description.value, props.queueToDraft.id)
     }

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -257,8 +257,14 @@ export async function updateDraft<T extends ItemType>(type: T, draftId: string, 
   return await axios.put(`/api/${type}/drafts/${draftId}`, params)
 }
 
-export async function updateDraftLinkedtoQueue(queueId: number, name: string, description: string) {
-  return await axios.put(`/api/queues/${queueId}/draft`, { name, description })
+export async function updateDraftLinkedtoQueue(queueId: number, name: string, description: string, snapshotId: number) {
+  return await axios.put(`/api/queues/${queueId}/draft`, { 
+    resourceSnapshot: snapshotId,
+    resourceData: {
+      name, 
+      description,
+    }
+   })
 }
 
 export async function deleteItem<T extends ItemType>(type: T, id: number) {

--- a/src/frontend/src/views/QueuesView.vue
+++ b/src/frontend/src/views/QueuesView.vue
@@ -167,9 +167,9 @@
     }
   }
 
-  async function updateDraftLinkedToQueue(queueId, name, description) {
+  async function updateDraftLinkedToQueue(queueId, name, description, snapshotId) {
     try {
-      await api.updateDraftLinkedtoQueue(queueId, name, description)
+      await api.updateDraftLinkedtoQueue(queueId, name, description, snapshotId)
       notify.success(`Successfully updated '${name}'`)
       showDraftDialog.value = false
     } catch(err) {

--- a/tests/unit/restapi/lib/asserts.py
+++ b/tests/unit/restapi/lib/asserts.py
@@ -121,7 +121,6 @@ def assert_draft_response_contents_matches_expectations(
     Args:
         response: The actual response from the API.
         expected_contents: The expected response from the API.
-        existing_draft: If the draft is of an existing resource or not.
 
     Raises:
         AssertionError: If the API response does not match the expected response

--- a/tests/unit/restapi/lib/routines.py
+++ b/tests/unit/restapi/lib/routines.py
@@ -105,7 +105,9 @@ def run_existing_resource_drafts_tests(
     )
 
     # Modify operation tests
-    response = client.modify(*resource_ids, **draft_mod).json()
+    response = client.modify(
+        *resource_ids, resource_snapshot_id=response["resourceSnapshot"], **draft_mod
+    ).json()
     asserts.assert_draft_response_contents_matches_expectations(
         response, draft_mod_expected
     )


### PR DESCRIPTION
This commit adds an optional query parameter for changing a draft modifications base snapshot ID to the PUT endpoint. If a snapshot ID is provided the value is updated, otherwise it is left unchanged.

This feature is designed to enable the reconciliation of drafts by allowing the user to signal that their changes are based on a more recent snapshot.

An existing test is modified to test this feature.