### PR TITLE
Add standard interface for handling file uploads in the Dioptra client

### DIFF
--- a/src/dioptra/client/__init__.py
+++ b/src/dioptra/client/__init__.py
@@ -14,14 +14,19 @@
 #
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
+from .base import DioptraFile
 from .client import (
     DioptraClient,
     connect_json_dioptra_client,
     connect_response_dioptra_client,
 )
+from .utils import select_files_in_directory, select_one_or_more_files
 
 __all__ = [
     "connect_response_dioptra_client",
     "connect_json_dioptra_client",
+    "select_files_in_directory",
+    "select_one_or_more_files",
     "DioptraClient",
+    "DioptraFile",
 ]

--- a/src/dioptra/client/utils.py
+++ b/src/dioptra/client/utils.py
@@ -1,0 +1,172 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import os
+import re
+from pathlib import Path
+
+from .base import DioptraFile
+
+
+def select_files_in_directory(
+    dir_path: str | Path,
+    recursive: bool = False,
+    include_pattern: str | re.Pattern | None = None,
+) -> list[DioptraFile]:
+    """Select files in a directory.
+
+    Args:
+        dir_path: The path to the root directory to search for files.
+        recursive: If True, search for files recursively in subdirectories.
+            Defaults to False.
+        include_pattern: A string or compiled regular expression pattern to use to
+            filter files by name. If None, then all files are included. Defaults to
+            None.
+
+    Returns:
+        A list of DioptraFile objects representing the selected files.
+
+    Raises:
+        FileNotFoundError: If the specified `dir_path` does not exist.
+        NotADirectoryError: If `dir_path` is not a directory.
+        IOError: If a file cannot be opened.
+    """
+    root_dir = Path(dir_path)
+
+    # Ensure the root path exists and is a directory
+    if not root_dir.is_dir():
+        if not root_dir.exists():
+            raise FileNotFoundError(
+                f"Invalid directory path (reason: dir_path does not exist): {root_dir}"
+            )
+
+        raise NotADirectoryError(
+            f"Invalid directory path (reason: dir_path is not a directory): {root_dir}"
+        )
+
+    # If provided, ensure that the include_pattern regular expression is compiled
+    if include_pattern is not None and not isinstance(include_pattern, re.Pattern):
+        include_pattern = re.compile(include_pattern)
+
+    dioptra_files: list[DioptraFile] = []
+
+    # Walk through the directory (optionally recursively)
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        if not recursive:
+            dirnames.clear()  # Prevent descending into subdirectories if not recursive
+
+        current_dir = Path(dirpath)
+
+        for filename in filenames:
+            # Filter files based on the include_pattern, if provided
+            if include_pattern is not None and not include_pattern.match(filename):
+                continue  # Skip files that do not match the pattern
+
+            current_file = current_dir / filename
+
+            try:
+                stream = open(current_file, "rb")
+
+            except IOError as err:
+                raise IOError(
+                    f"File opening failed (reason: {err.strerror}): {current_file}"
+                ) from err
+
+            # Compute the relative path from the root directory
+            relative_file_path = current_file.relative_to(root_dir)
+
+            dioptra_files.append(
+                DioptraFile(
+                    filename=relative_file_path.as_posix(),  # Ensure POSIX-style paths
+                    stream=stream,
+                    content_type=None,
+                )
+            )
+
+    return dioptra_files
+
+
+def select_one_or_more_files(
+    file_paths: list[str | Path], renames: dict[str | Path, str] | None = None
+) -> list[DioptraFile]:
+    """Select one or more files.
+
+    Unlike `select_files_in_directory`, this is a flattening operation that only
+    preserves each file's filename. The list of filenames must be unique.
+
+    The `renames` dictionary is used to rename files, and can be used to ensure that the
+    filenames are unique. Each key in the dictionary must exactly match one of the paths
+    listed in `file_paths` (the paths are not resolved prior to matching).
+
+    Args:
+        file_paths: A list of file paths.
+        renames: A dictionary mapping original file paths to new filenames. Only the
+            file paths that are included will be renamed, the rest will be kept as-is.
+            If None, then no renaming is performed. Defaults to None.
+
+    Returns:
+        A list of DioptraFile objects representing the selected files.
+
+    Raises:
+        ValueError: If a filename is not unique after applying `renames`.
+        IOError: If a file cannot be opened.
+    """
+    dioptra_files: list[DioptraFile] = []
+    filenames_seen: set[str] = set()  # Keep track of filenames to ensure uniqueness
+
+    # Convert renames to a dictionary with Path objects as keys
+    rename_mapping: dict[Path, str] = {}
+    if renames is not None:
+        for key, value in renames.items():
+            rename_mapping[Path(key)] = value  # Ensure consistent key type
+
+    for file_path in file_paths:
+        current_file = Path(file_path)
+
+        try:
+            stream = open(current_file, "rb")
+
+        except IOError as err:
+            raise IOError(
+                f"File opening failed (reason: {err.strerror}): {current_file}"
+            ) from err
+
+        # Determine the filename, applying renaming if specified
+        current_filename = rename_mapping.get(current_file, current_file.name)
+
+        # Ensure the filename is unique, raising an error if there's a conflict
+        if current_filename in filenames_seen:
+            if current_filename != current_file.name:
+                raise ValueError(
+                    "Invalid filename (reason: renamed filename is not unique): "
+                    f"{current_file.name} -> {current_filename}"
+                )
+
+            raise ValueError(
+                "Invalid filename (reason: filename is not unique, try renaming it): "
+                f"{current_filename}"
+            )
+
+        filenames_seen.add(current_filename)  # Record the filename as seen
+        dioptra_files.append(
+            DioptraFile(
+                filename=current_filename,
+                stream=stream,
+                content_type=None,
+            )
+        )
+
+    return dioptra_files

--- a/tests/unit/client/test_utils.py
+++ b/tests/unit/client/test_utils.py
@@ -1,0 +1,184 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import re
+from pathlib import Path
+
+import pytest
+
+from dioptra.client import (
+    DioptraFile,
+    select_files_in_directory,
+    select_one_or_more_files,
+)
+
+
+@pytest.fixture
+def fake_directory(tmp_path: Path) -> Path:
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "subdir2").mkdir()
+    (tmp_path / "subdir" / "file1.txt").write_text("Content of file1")
+    (tmp_path / "subdir" / "file2.txt").write_text("Content of file2")
+    (tmp_path / "subdir" / "subdir2" / "file1.txt").write_text("Content of file1")
+    (tmp_path / "subdir" / "subdir2" / "file3.md").write_text("# Content of file3")
+    (tmp_path / "file4.txt").write_text("Content of file4")
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "recursive, include_pattern, expected_filenames",
+    [
+        (False, None, {"file4.txt"}),
+        (
+            True,
+            None,
+            {
+                "file4.txt",
+                "subdir/file1.txt",
+                "subdir/file2.txt",
+                "subdir/subdir2/file1.txt",
+                "subdir/subdir2/file3.md",
+            },
+        ),
+        (True, r".*\.md", {"subdir/subdir2/file3.md"}),
+        (True, re.compile(r".*\.md"), {"subdir/subdir2/file3.md"}),
+        (
+            True,
+            r".*\.txt",
+            {
+                "file4.txt",
+                "subdir/file1.txt",
+                "subdir/file2.txt",
+                "subdir/subdir2/file1.txt",
+            },
+        ),
+    ],
+)
+def test_select_files_in_directory(
+    fake_directory: Path,
+    recursive: bool,
+    include_pattern: str | re.Pattern | None,
+    expected_filenames: set[str],
+) -> None:
+    # Select the files from the temporary directory
+    selected_files = select_files_in_directory(
+        fake_directory, recursive=recursive, include_pattern=include_pattern
+    )
+
+    # Extract filenames to validate their paths
+    filenames = [dioptra_file.filename for dioptra_file in selected_files]
+
+    # Validate that all filenames match the expected relative POSIX paths
+    assert set(filenames) == expected_filenames
+
+    # Verify DioptraFile structure
+    for dioptra_file in selected_files:
+        assert isinstance(dioptra_file, DioptraFile)
+        assert dioptra_file.stream.readable()
+
+
+@pytest.mark.parametrize(
+    "relative_file_paths, renames, expected_filenames",
+    [
+        (["file4.txt"], None, {"file4.txt"}),
+        (
+            [
+                "file4.txt",
+                "subdir/file1.txt",
+                "subdir/file2.txt",
+                "subdir/subdir2/file3.md",
+            ],
+            None,
+            {"file4.txt", "file1.txt", "file2.txt", "file3.md"},
+        ),
+        (["subdir/subdir2/file3.md"], None, {"file3.md"}),
+        (["subdir/subdir2/file3.md", "file4.txt"], None, {"file3.md", "file4.txt"}),
+        (
+            ["file4.txt", "subdir/file1.txt", "subdir/subdir2/file1.txt"],
+            {"subdir/subdir2/file1.txt": "file1_copy.txt"},
+            {"file1.txt", "file4.txt", "file1_copy.txt"},
+        ),
+    ],
+)
+def test_select_one_or_more_files(
+    fake_directory: Path,
+    relative_file_paths: list[str],
+    renames: dict[str | Path, str] | None,
+    expected_filenames: set[str],
+) -> None:
+    file_paths: list[str | Path] = [
+        fake_directory / file_path for file_path in relative_file_paths
+    ]
+    if renames is not None:
+        renames = {
+            str(fake_directory / relative_path): new_filename
+            for relative_path, new_filename in renames.items()
+        }
+
+    # Select the files from the temporary directory
+    selected_files = select_one_or_more_files(file_paths, renames=renames)
+
+    # Extract filenames for validation
+    filenames = [dioptra_file.filename for dioptra_file in selected_files]
+
+    # Validate that list of selected filenames match the expected ones after renaming
+    assert set(filenames) == set(expected_filenames)
+
+    # Verify DioptraFile structure
+    for dioptra_file in selected_files:
+        assert isinstance(dioptra_file, DioptraFile)
+        assert dioptra_file.stream.readable()
+
+
+def test_select_one_or_more_with_duplicate_filename_fails(
+    fake_directory: Path,
+) -> None:
+    relative_file_paths = ["file4.txt", "subdir/file1.txt", "subdir/subdir2/file1.txt"]
+    file_paths: list[str | Path] = [
+        fake_directory / file_path for file_path in relative_file_paths
+    ]
+
+    with pytest.raises(ValueError):
+        select_one_or_more_files(file_paths)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "/home/username/script.py",
+        "../script.py",
+        ".../script.py",
+        "..../script.py",
+        "../a/./script.py",
+        "../a/.../script.py",
+        "./a/script.py",
+        "a//script.py",
+        "a/.../script.py",
+        "a/b/",
+        "a/b/../script.py",
+        "a\\script.py",
+        "a\\..\\script.py",
+        "a\\b/script.py",
+        "C:\\Users\\username\\script.py",
+    ],
+)
+def test_invalid_dioptra_filenames_fail(filename: str) -> None:
+    with pytest.raises(ValueError):
+        DioptraFile(
+            filename=filename,
+            stream=None,  # type: ignore[arg-type]
+            content_type=None,
+        )


### PR DESCRIPTION
Addresses client-side solution for #694 

Added requests-toolbelt as a new project dependency to support streaming of multi-file uploads.

This branch does not include any new unit tests for this new functionality, as it will start being exercised via the REST API integration tests once we integrate the solutions for #694 with #658. However, in the interest of verifying this new feature for the client works, I created this branch, https://github.com/usnistgov/dioptra/tree/test-client-uploading-support, that adds a simple `/echoes` endpoint that allows you to upload files, and the server echoes back the name and size of the files you upload. I tested it locally and I also created two simple REST API integration tests based on this endpoint to validate the test client implementation. Both seem to be working as expected.

## Todos

- [x] Add a utility that scans a directory, either with or without recursion, and builds up a list of `DioptraFile` objects for upload. The filenames will retain relative filepaths with respect to the source directory's root path, and be standardized in the POSIX format.
- [x] Add a utility that accepts a filepath/list of filepaths and converts them into a `DioptraFile` object/list of `DioptraFile` objects to upload. The filenames will be stripped of any directory paths.