### PR TITLE
Add a MultiFileUpload custom Marshmallow Schema Field type

### DIFF
--- a/src/dioptra/restapi/custom_schema_fields.py
+++ b/src/dioptra/restapi/custom_schema_fields.py
@@ -22,3 +22,7 @@ from marshmallow.fields import Field
 
 class FileUpload(Field):
     """A field that represents a file upload."""
+
+
+class MultiFileUpload(Field):
+    """A field that represents uploading multiple files."""

--- a/src/dioptra/restapi/utils.py
+++ b/src/dioptra/restapi/utils.py
@@ -42,7 +42,7 @@ from werkzeug.datastructures import FileStorage
 
 from dioptra.restapi.v1.shared.request_scope import set_request_scope_callbacks
 
-from .custom_schema_fields import FileUpload
+from .custom_schema_fields import FileUpload, MultiFileUpload
 
 
 class ParametersSchema(TypedDict, total=False):
@@ -54,6 +54,7 @@ class ParametersSchema(TypedDict, total=False):
     required: bool
     default: Any | None
     help: str
+    action: str
 
 
 def as_api_parser(
@@ -155,6 +156,9 @@ def create_parameters_schema(
         location=location,
         required=field.required,
     )
+
+    if type(field) is MultiFileUpload:
+        parameters_schema["action"] = "append"
 
     if operation == "load" and field.load_default is not missing:
         parameters_schema["default"] = field.load_default
@@ -307,6 +311,7 @@ TYPE_MAP_MA_TO_REQPARSE = {
     ma.Dict: dict,
     ma.Email: str,
     FileUpload: FileStorage,
+    MultiFileUpload: FileStorage,
     ma.Float: float,
     ma.Function: str,
     ma.Int: int,


### PR DESCRIPTION
This update adds a new Marshmallow Schema Field type to handle scenarios where multiple files need to be uploaded through the REST API. The changes include:

- A new MultiFileUpload field class in custom_schema_fields.py
- An update to the parameter schema generation logic that sets the "action" parameter to "append" when the field type is MultiFileUpload.
- A new entry for the MultiFileUpload type in the TYPE_MAP_MA_TO_REQPARSE dictionary, mapping it to werkzeug's FileStorage type.