### PR TITLE
fix: choose latest added metric if their timestamps are the same

### DIFF
--- a/tests/unit/restapi/lib/mock_mlflow.py
+++ b/tests/unit/restapi/lib/mock_mlflow.py
@@ -49,7 +49,9 @@ class MockMlflowClient(object):
             # find the latest metric for each metric name
             if (
                 metric.key not in output_metrics
-                or metric.timestamp > output_metrics[metric.key].timestamp
+                # use >= here since we append to the list in log_metric and want to make sure we 
+                # return the latest metric available if they have the same timestamp
+                or metric.timestamp >= output_metrics[metric.key].timestamp 
             ):
                 output_metrics[metric.key] = metric
 


### PR DESCRIPTION
This should fix at least one of the scenarios that could cause #724, by ensuring that we choose the metric most recently added to the list if two of them have the same timestamp.