### PR TITLE
(GUI) Set a new resource's default group selection to the user's group

### DIFF
--- a/src/frontend/src/dialogs/AddTagsDialog.vue
+++ b/src/frontend/src/dialogs/AddTagsDialog.vue
@@ -75,6 +75,9 @@
       name.value = ''
       locked.value = true
     }
+    if (!group.value) {
+      group.value = store.loggedInGroup.id
+    }
   })
 
   function emitAddOrEdit() {

--- a/src/frontend/src/dialogs/ModelsDialog.vue
+++ b/src/frontend/src/dialogs/ModelsDialog.vue
@@ -88,6 +88,9 @@
       name.value = ''
       description.value = ''
     }
+    if (!group.value) {
+      group.value = store.loggedInGroup.id
+    }
   })
 
   function emitAddOrEdit() {

--- a/src/frontend/src/dialogs/PluginDialog.vue
+++ b/src/frontend/src/dialogs/PluginDialog.vue
@@ -116,6 +116,9 @@
       plugin.value.group = ''
       plugin.value.description = ''
     }
+    if (!plugin.value.group) {
+      plugin.value.group = store.loggedInGroup.id
+    }
   })
 
 </script>

--- a/src/frontend/src/dialogs/PluginParamsDialog.vue
+++ b/src/frontend/src/dialogs/PluginParamsDialog.vue
@@ -159,6 +159,9 @@
       jsonString.value = ''
       uploadedFile.value = null
     }
+    if (!plugin.value.group) {
+      plugin.value.group = store.loggedInGroup.id
+    }
   })
 
   const uploadedFile = ref(null)

--- a/src/frontend/src/dialogs/QueueDialog.vue
+++ b/src/frontend/src/dialogs/QueueDialog.vue
@@ -115,6 +115,9 @@
       description.value = ''
       history.value = false
     }
+    if (!group.value) {
+      group.value = store.loggedInGroup.id
+    }
   })
 
   function emitAddOrEdit() {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -351,7 +351,7 @@
 
   let entryPoint = ref({
     name: '',
-    group: '',
+    group: store.loggedInGroup.id,
     description: '',
     parameters: [],
     taskGraph: '',
@@ -361,7 +361,7 @@
 
   const initialCopy = ref({
     name: '',
-    group: '',
+    group: store.loggedInGroup.id,
     description: '',
     parameters: [],
     taskGraph: '',

--- a/src/frontend/src/views/CreateExperiment.vue
+++ b/src/frontend/src/views/CreateExperiment.vue
@@ -169,7 +169,7 @@
 
   let experiment = ref({
     name: '',
-    group: '',
+    group: store.loggedInGroup.id,
     description: '',
     entrypoints: [],
   })
@@ -201,7 +201,7 @@
 
   let initialCopy = ref({
     name: '',
-    group: '',
+    group: store.loggedInGroup.id,
     description: '',
     entrypoints: [],
   })


### PR DESCRIPTION
This GUI change sets the group field on the different resource creation pages to automatically populate with the user's group.