### PR TITLE
fix: allow empty dict to come in as value in job creation. fixes #711

### DIFF
--- a/src/dioptra/restapi/v1/jobs/schema.py
+++ b/src/dioptra/restapi/v1/jobs/schema.py
@@ -202,6 +202,7 @@ class JobSchema(JobBaseSchema):  # type: ignore
                 "A dictionary of keyword arguments to pass to the Job's Entrypoint."
             ),
         ),
+        load_default=dict,
     )
     timeout = fields.String(
         attribute="timeout",

--- a/tests/unit/restapi/lib/actions.py
+++ b/tests/unit/restapi/lib/actions.py
@@ -64,9 +64,9 @@ def register_entrypoint(
     description: str,
     group_id: int,
     task_graph: str,
-    parameters: list[dict[str, Any]],
-    plugin_ids: list[int],
-    queue_ids: list[int],
+    parameters: list[dict[str, Any]]| None,
+    plugin_ids: list[int]| None,
+    queue_ids: list[int]| None,
 ) -> TestResponse:
     """Register an entrypoint using the API.
 

--- a/tests/unit/restapi/v1/conftest.py
+++ b/tests/unit/restapi/v1/conftest.py
@@ -639,10 +639,21 @@ def registered_entrypoints(
         plugin_ids=plugin_ids,
         queue_ids=queue_ids,
     ).get_json()
+    entrypoint_no_params = actions.register_entrypoint(
+        client,
+        name="entrypoint_no_params",
+        description="No params Entry-Point.",
+        group_id=auth_account["groups"][0]["id"],
+        task_graph=task_graph,
+        parameters=[],
+        plugin_ids=plugin_ids,
+        queue_ids=queue_ids,
+    ).get_json()
     return {
         "entrypoint1": entrypoint1_response,
         "entrypoint2": entrypoint2_response,
         "entrypoint3": entrypoint3_response,
+        "entrypoint_no_params": entrypoint_no_params
     }
 
 

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -611,7 +611,8 @@ def test_entrypoint_get_all(
     - The user is able to retrieve a list of all registered entrypoints.
     - The returned list of entrypoints matches the full list of registered entrypoints.
     """
-    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    all_entrypoints_count = len(registered_entrypoints)
+    entrypoint_expected_list = list(registered_entrypoints.values())[:all_entrypoints_count]
     assert_retrieving_entrypoints_works(
         dioptra_client, expected=entrypoint_expected_list
     )
@@ -620,11 +621,11 @@ def test_entrypoint_get_all(
 @pytest.mark.parametrize(
     "sortBy, descending , expected",
     [
-        (None, None, ["entrypoint1", "entrypoint2", "entrypoint3"]),
-        ("name", True, ["entrypoint2", "entrypoint3", "entrypoint1"]),
-        ("name", False, ["entrypoint1", "entrypoint3", "entrypoint2"]),
-        ("createdOn", True, ["entrypoint3", "entrypoint2", "entrypoint1"]),
-        ("createdOn", False, ["entrypoint1", "entrypoint2", "entrypoint3"]),
+        (None, None, ["entrypoint1", "entrypoint2", "entrypoint3", "entrypoint_no_params"]),
+        ("name", True, ["entrypoint2", "entrypoint3", "entrypoint1", "entrypoint_no_params"]),
+        ("name", False, ["entrypoint_no_params", "entrypoint1", "entrypoint3", "entrypoint2", ]),
+        ("createdOn", True, ["entrypoint_no_params", "entrypoint3", "entrypoint2", "entrypoint1"]),
+        ("createdOn", False, ["entrypoint1", "entrypoint2", "entrypoint3", "entrypoint_no_params"]),
     ],
 )
 def test_entrypoint_sort(
@@ -679,7 +680,8 @@ def test_entrypoint_search_query(
         expected=entrypoint_expected_list,
         search="description:*entrypoint*",
     )
-    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    all_entrypoints_count = len(registered_entrypoints)
+    entrypoint_expected_list = list(registered_entrypoints.values())[:all_entrypoints_count]
     assert_retrieving_entrypoints_works(
         dioptra_client, expected=entrypoint_expected_list, search="*"
     )
@@ -701,7 +703,8 @@ def test_entrypoint_group_query(
     - The returned list of entrypoints matches the expected list owned by the default
       group.
     """
-    entrypoint_expected_list = list(registered_entrypoints.values())[:3]
+    all_entrypoints_count = len(registered_entrypoints)
+    entrypoint_expected_list = list(registered_entrypoints.values())[:all_entrypoints_count]
     assert_retrieving_entrypoints_works(
         dioptra_client,
         expected=entrypoint_expected_list,
@@ -785,6 +788,7 @@ def test_rename_entrypoint(
         modified_entrypoint,
         registered_entrypoints["entrypoint2"],
         registered_entrypoints["entrypoint3"],
+        registered_entrypoints["entrypoint_no_params"],
     ]
     assert_retrieving_entrypoints_works(
         dioptra_client, expected=entrypoint_expected_list

--- a/tests/unit/restapi/v1/test_job.py
+++ b/tests/unit/restapi/v1/test_job.py
@@ -20,6 +20,7 @@ This module contains a set of tests that validate the CRUD operations and additi
 functionalities for the job entity. The tests ensure that the queues can be
 registered, renamed, queried, and deleted as expected through the REST API.
 """
+import textwrap
 from http import HTTPStatus
 from typing import Any
 
@@ -431,6 +432,117 @@ def test_create_job(
     expected: The response from the calling get on the database should match
       the response of the actions.py::register_job()
     """
+    assert_retrieving_job_by_id_works(
+        dioptra_client, job_id=job_response["id"], expected=job_response
+    )
+
+
+def test_create_job_with_empty_values(
+    dioptra_client: DioptraClient[DioptraResponseProtocol],
+    auth_account: dict[str, Any],
+    registered_queues: dict[str, Any],
+    registered_experiments: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """ Test that new job can be create with EMPTY values using API
+
+    Args:
+        dioptra_client (DioptraClient[DioptraResponseProtocol]): _description_
+        auth_account (dict[str, Any]): _description_
+        registered_queues (dict[str, Any]): _description_
+        registered_experiments (dict[str, Any]): _description_
+        registered_entrypoints (dict[str, Any]): _description_
+        monkeypatch (MonkeyPatch): _description_
+    """    
+
+    ''' Test that jobs (!!! with no-params !!!) can be correctly registered and retrieved using the API.
+
+    General plan:
+    Given an authenticated user, registered queues, registered experiments, and
+    registered entrypoints, this test validates the following sequence of actions:
+
+    - The user registers an entry point with no queues, no plugins, and no params.
+    - The user registers a job.
+    - The response is valid and matches the expected values given the registration
+      request.
+    - The user is able to retrieve information about the job using the job id.
+    '''
+    # Begin with registering the entry-point with empty parameters, queues, and plugins 
+    import dioptra.restapi.v1.shared.rq_service as rq_service
+    monkeypatch.setattr(rq_service, "RQQueue", mock_rq.MockRQQueue)
+
+    entrypoint_name = "entrypoint_no_params"
+    description = "The new job."
+    queue_id = registered_queues["queue1"]["id"]
+    experiment_id = registered_experiments["experiment1"]["id"]
+    entrypoint_id = registered_entrypoints[entrypoint_name]["id"]
+    values = {}
+    timeout = "24h"
+   
+    '''
+    Register a Job
+    ==============
+
+    actions.py::register_job(*args: JobSchema)):
+      JobSchema:
+        From base resource schema:
+          - group_id: The ID of the group the job belongs to.
+        From job schema:
+          - description: The description of the job
+          - queue_id: The ID of queue the job is to run on.
+          - experiment_id: The ID of the experiment the job belongs to.
+          - entrypoint_id: The ID of the entrypoint that the job calls.
+          - values: The values the job supplies to the entrypoint
+          - timeout: The timeout value for the job to terminate if not completed by.
+    '''
+    job_response = dioptra_client.experiments.jobs.create(
+        experiment_id=experiment_id,
+        entrypoint_id=entrypoint_id,
+        queue_id=queue_id,
+        values=values,
+        timeout=timeout,
+        description=description,
+    ).json()
+
+    """
+    Validate the response matches the expected contents
+    ===================================================
+
+    response: The response from actions.py::register_job()
+    expected_contents: The raw data passed to actions.py::register_job() as *args
+      *Note: group_id is given as an arg for registration in the service layer
+    """
+    (queue_snapshot_id, 
+     queue_id) = (registered_queues["queue1"]["snapshot"], 
+                  registered_queues["queue1"]["id"])
+    
+    (experiment_snapshot_id, 
+     experiment_id, 
+     group_id) = (registered_experiments["experiment1"]["snapshot"], 
+                  registered_experiments["experiment1"]["id"], 
+                  registered_experiments["experiment1"]["group"]["id"])
+    
+    (entrypoint_snapshot_id, 
+     entrypoint_id)  = (registered_entrypoints[entrypoint_name]["snapshot"], 
+                        registered_entrypoints[entrypoint_name]["id"])
+
+    assert_job_response_contents_matches_expectations(
+        response=job_response,
+        expected_contents={
+            "description": description,
+            "timeout": timeout,
+            "values": values,
+            "user_id": auth_account["id"],
+            "group_id": group_id,
+            "queue_id": queue_id,
+            "experiment_id": experiment_id,
+            "entrypoint_id": entrypoint_id,
+            "queue_snapshot_id": queue_snapshot_id,
+            "experiment_snapshot_id": experiment_snapshot_id,
+            "entrypoint_snapshot_id": entrypoint_snapshot_id,
+        },
+    )
     assert_retrieving_job_by_id_works(
         dioptra_client, job_id=job_response["id"], expected=job_response
     )


### PR DESCRIPTION
The seemingly large fix updates tests and test fixtures to allow empty "values" parameter to be passed at the job creation. Also as entry-point "parameters" map into the new job's "values" had to modify fixtures to include the no-params-entrypoint into fixtures.