### PR TITLE
feat: links to experiment/entrypoint on job dashboard should be snapshot specific

### DIFF
--- a/src/frontend/src/components/SnapshotList.vue
+++ b/src/frontend/src/components/SnapshotList.vue
@@ -18,39 +18,42 @@
     :disableUnselect="true"
   >
     <template #body-cell-timestamp="props">
-      {{
-        new Intl.DateTimeFormat('en-US', { 
-          year: '2-digit', 
-          month: '2-digit', 
-          day: '2-digit', 
-          hour: 'numeric', 
-          minute: 'numeric', 
-          hour12: true 
-        }).format(new Date(props.row.snapshotCreatedOn))
-      }}
-      <q-chip
-        v-if="props.row.latestSnapshot"
-        label="latest"
-        size="md"
-        dense
-        color="orange"
-        text-color="white"
-      />
+      <div :data-snapshot-id="props.row.snapshot">
+        {{
+          new Intl.DateTimeFormat('en-US', { 
+            year: '2-digit', 
+            month: '2-digit', 
+            day: '2-digit', 
+            hour: 'numeric', 
+            minute: 'numeric', 
+            hour12: true 
+          }).format(new Date(props.row.snapshotCreatedOn))
+        }}
+        <q-chip
+          v-if="props.row.latestSnapshot"
+          label="latest"
+          size="md"
+          dense
+          color="orange"
+          text-color="white"
+        />
+      </div>
     </template>
   </TableComponent>
 </template>
 
 <script setup>
 import { useLoginStore } from '@/stores/LoginStore'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import TableComponent from '@/components/TableComponent.vue'
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick } from 'vue'
 import * as api from '@/services/dataApi'
 
 const props = defineProps(['showDialogHistory', 'type', 'id', 'maxHeight'])
 
 const store = useLoginStore()
 const route = useRoute()
+const router = useRouter()
 
 const snapshots = ref([])
 const selected = ref([])
@@ -59,6 +62,24 @@ async function getSnapshots() {
   try {
     const res = await api.getSnapshots(route.meta.type, route.params.id)
     snapshots.value = res.data.data.reverse()
+    if(res.data.data.length > 0) {
+      if(route.query.snapshotId) {
+        // if snapshotId is provided in url, auto select it
+        let index = res.data.data.findIndex(
+          obj => obj.snapshot === Number(route.query.snapshotId)
+        )
+        selected.value = [snapshots.value[index]]
+      } else {
+        // else auto select the latest snapshot
+        selected.value = [snapshots.value[0]]
+      }
+      // scroll to selected snapshot if needed
+      await nextTick()
+      const el = document.querySelector(
+        `[data-snapshot-id="${selected.value[0]?.snapshot}"]`
+      )
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
     console.log('snapshots = ', snapshots.value)
   } catch(err) {
     console.warn(err)
@@ -69,17 +90,22 @@ async function getDialogSnapshots() {
   try {
     const res = await api.getSnapshots(props.type, props.id)
     snapshots.value = res.data.data.reverse()
+    if(res.data.data.length > 0) {
+      // when viewing history, auto select first (latest) row
+      selected.value = [snapshots.value[0]]
+    }
     console.log('snapshots = ', snapshots.value)
   } catch(err) {
     console.warn(err)
   }
 }
 
-watch(() => store.showRightDrawer, (history) => {
-  if(history) {
+watch(() => store.showRightDrawer, (drawerOpen) => {
+  if(drawerOpen) {
     getSnapshots()
   } else {
     store.selectedSnapshot = null
+    history.replaceState({}, null, route.path)
   }
 })
 
@@ -94,6 +120,11 @@ watch(() => props.showDialogHistory, (history) => {
 watch(selected, (newVal) => {
   if(newVal.length > 0) {
     store.selectedSnapshot = newVal[0]
+    history.replaceState(
+      {},
+      null,
+      route.path + '?snapshotId=' + encodeURIComponent(selected.value[0].snapshot)
+    )
   }
 })
 

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -243,15 +243,6 @@
     emit('delete')
   }
 
-  watch(() => props.rows, (newVal) => {
-    // when viewing history, auto select first (latest) row
-    if (newVal.length > 0 && props.rowKey === 'snapshot') {
-      if (tableRef.value && newVal[0]) {
-        selected.value = [newVal[0]]
-      }
-    }
-  }, { deep: true })
-
   watch(showDrafts, (newVal, oldVal) => {
     if(newVal !== oldVal) selected.value = []
   })

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -46,6 +46,7 @@ const router = createRouter({
         {
           path: '/entrypoints/:id',
           component: () => import('../views/CreateEntryPoint.vue'),
+          meta: { type: 'entrypoints' }
         },
       ]
     },

--- a/src/frontend/src/views/CreateExperiment.vue
+++ b/src/frontend/src/views/CreateExperiment.vue
@@ -128,7 +128,7 @@
             color="grey"
             class="q-mr-sm"
           />
-          <div>Entrypoints are not part of Experiment snapshots</div>
+          <div>Entrypoints are not yet available in Experiment snapshots</div>
         </div>
       </div>
     </fieldset>
@@ -168,7 +168,7 @@
 </template>
 
 <script setup>
-  import { ref, inject, computed, watch } from 'vue'
+  import { ref, inject, computed, watch, onMounted } from 'vue'
   import { useLoginStore } from '@/stores/LoginStore.ts'
   import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
   import * as api from '@/services/dataApi'
@@ -258,7 +258,14 @@
   const title = ref('')
   const showReturnDialog = ref(false)
 
-  getExperiment()
+  onMounted(() => {
+    if(route.query.snapshotId && !store.showRightDrawer) {
+      store.showRightDrawer = true
+    } else {
+      getExperiment()
+    }
+  })
+
   async function getExperiment() {
     if(route.params.id === 'new') {
       title.value = 'Create Experiment'
@@ -380,6 +387,7 @@
         group: newVal.group,
         description: newVal.description
       }
+      title.value = `View ${experiment.value.name}`
     } else {
       getExperiment()
     }

--- a/src/frontend/src/views/JobDashboardView.vue
+++ b/src/frontend/src/views/JobDashboardView.vue
@@ -56,16 +56,16 @@
             />
           </div>
         </template>
-        <template #experiment="{ name = '', id }">
-          <RouterLink :to="`/experiments/${id}`">
+        <template #experiment="{ name = '', id, snapshotId }">
+          <RouterLink :to="`/experiments/${id}?snapshotId=${snapshotId}`">
             {{ name.length < 18 ? name : name.replace(/(.{18})..+/, "$1…") }}
             <q-tooltip v-if="name.length > 18" max-width="30vw" style="overflow-wrap: break-word">
               {{ name }}
             </q-tooltip>
           </RouterLink>
         </template>
-        <template #entrypoint="{ name = '', id }">
-          <RouterLink :to="`/entrypoints/${id}`">
+        <template #entrypoint="{ name = '', id, snapshotId }">
+          <RouterLink :to="`/entrypoints/${id}?snapshotId=${snapshotId}`">
             {{ name.length < 18 ? name : name.replace(/(.{18})..+/, "$1…") }}
             <q-tooltip v-if="name.length > 18" max-width="30vw" style="overflow-wrap: break-word">
               {{ name }}
@@ -288,8 +288,12 @@ const overviewRows = computed(() => [
   { label: 'Status', slot: 'status', props: { status: job.value?.status} },
   { label: 'Created On', value: formatDate(job.value?.createdOn) },
   { label: 'Created by', value: job.value?.user.username },
-  { label: 'Experiment', slot: 'experiment', props: { name: job.value?.experiment.name, id: job.value?.experiment.id } },
-  { label: 'Entrypoint', slot: 'entrypoint', props: { name: job.value?.entrypoint.name, id: job.value?.entrypoint.id } },
+  { label: 'Experiment', slot: 'experiment', 
+    props: { name: job.value?.experiment.name, id: job.value?.experiment.id, snapshotId: job.value?.experiment.snapshotId }
+  },
+  { label: 'Entrypoint', slot: 'entrypoint',
+    props: { name: job.value?.entrypoint.name, id: job.value?.entrypoint.id, snapshotId: job.value?.entrypoint.snapshotId }
+  },
   { label: 'Queue', value: job.value?.queue.name },
   { label: 'Timeout', value: job.value?.timeout },
   { label: 'Tags', slot: 'tags', props: { tags: job.value?.tags }  },


### PR DESCRIPTION
Closes #848 

When clicking on the experiment or entrypoint link on the job dashboard page...

- The resource page that opens should be read-only
- The specific snapshot used when the job ran should be displayed
- The existing history toggle and snapshot sidebar are used