### PR TITLE
fix: make a task engine job stoppable (rebased version)

### DIFF
--- a/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
+++ b/src/dioptra/restapi/v1/workflows/lib/run_dioptra_job.py.tmpl
@@ -28,6 +28,8 @@ from dioptra.sdk.utilities.contexts import env_vars, sys_path_dirs
 from dioptra.task_engine.issues import IssueSeverity
 from dioptra.task_engine.task_engine import run_experiment
 from dioptra.task_engine.validation import validate
+from dioptra.rq.tasks.run_task_engine_stoppable import run_experiment_stoppable
+
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
 DIOPTRA_JOB_ID = "dioptra.jobId"
@@ -44,7 +46,7 @@ def main(
     enable_mlflow_tracking: bool = False,
     dioptra_client: DioptraClient[dict[str, Any]] | None = None,
     logger: BoundLogger | None = None,
-) -> None:
+) -> bool:
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
 
     if not Path(plugins_dir).exists():
@@ -90,7 +92,7 @@ def _run_job(
     job_yaml: Mapping[str, Any],
     job_parameters: MutableMapping[str, Any],
     logger: BoundLogger | None = None,
-) -> None:
+) -> bool:
     """Run the job.
 
     Args:
@@ -100,14 +102,22 @@ def _run_job(
             parameter name to value
         logger: A structlog logger instance. If not provided, a new logger
             will be created
+
+    Returns:
+        True if the experiment was stopped prematurely; False if not
     """
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
 
     try:
         with sys_path_dirs(dirs=(str(plugins_dir),)), env_vars({"__JOB_ID": str(JOB_ID)}):
-            run_experiment(job_yaml, job_parameters)
+            was_stopped = run_experiment_stoppable(job_yaml, job_parameters)
 
-        log.info("=== Run succeeded ===")
+        if was_stopped:
+            log.info("=== Run stopped ===")
+        else:
+            log.info("=== Run succeeded ===")
+
+        return was_stopped
 
     except Exception as e:
         log.exception("=== Run failed ===")
@@ -120,7 +130,7 @@ def _run_mlflow_tracked_job(
     job_yaml: Mapping[str, Any],
     job_parameters: MutableMapping[str, Any],
     logger: BoundLogger | None = None,
-) -> None:
+) -> bool:
     """Run the job and start tracking the run in MLflow tracking server.
 
     Args:
@@ -131,6 +141,9 @@ def _run_mlflow_tracked_job(
             parameter name to value
         logger: A structlog logger instance. If not provided, a new logger
             will be created
+
+    Returns:
+        True if the experiment was stopped prematurely; False if not
     """
     log = logger or LOGGER.new(job_id=JOB_ID, experiment_id=EXPERIMENT_ID)  # noqa: F841
     active_run = mlflow.start_run()
@@ -144,10 +157,16 @@ def _run_mlflow_tracked_job(
         mlflow.log_params(job_parameters)
 
         with sys_path_dirs(dirs=(str(plugins_dir),)), env_vars({"__JOB_ID": str(JOB_ID)}):
-            run_experiment(job_yaml, job_parameters)
+            was_stopped = run_experiment_stoppable(job_yaml, job_parameters)
 
-        log.info("=== Run succeeded ===")
-        mlflow.end_run()
+        if was_stopped:
+            log.info("=== Run stopped ===")
+            mlflow.end_run("KILLED")
+        else:
+            log.info("=== Run succeeded ===")
+            mlflow.end_run()
+
+        return was_stopped
 
     except Exception as e:
         log.exception("=== Run failed ===")

--- a/src/dioptra/rq/tasks/run_task_engine_stoppable.py
+++ b/src/dioptra/rq/tasks/run_task_engine_stoppable.py
@@ -1,0 +1,151 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import multiprocessing as mp
+import signal
+from typing import Any, Mapping, MutableMapping
+
+import structlog
+
+from dioptra.task_engine.task_engine import request_stop, run_experiment
+
+# Which endpoint to poll
+_POLL_URL = "http://dioptra-deployment-restapi:5000/something"
+
+
+# Web server endpoint poll interval, in seconds
+_POLL_INTERVAL = 3
+
+
+def _get_logger() -> Any:
+    """
+    Get a logger for this module.
+
+    Returns:
+        A logger object
+    """
+    return structlog.get_logger(__name__)
+
+
+def run_experiment_stoppable(
+    experiment_desc: Mapping[str, Any], global_parameters: MutableMapping[str, Any]
+) -> bool:
+    """
+    Run an experiment via the task engine.  This implementation runs it in a
+    sub-process.  The parent process will poll an endpoint for a shutdown
+    instruction which will cause us to stop the experiment early.
+
+    Args:
+        experiment_desc: A declarative experiment description, as a mapping
+        global_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+
+    Returns:
+        True if the process was stopped prematurely; False if not
+    """
+    child_process = mp.Process(
+        target=_run_experiment_child_process, args=(experiment_desc, global_parameters)
+    )
+
+    child_process.start()
+
+    was_stopped = _monitor_process(child_process)
+
+    child_process.close()
+
+    return was_stopped
+
+
+def _run_experiment_child_process(
+    experiment_desc: Mapping[str, Any], global_parameters: MutableMapping[str, Any]
+) -> None:
+    """
+    Simple wrapper around run_experiment() which arranges for SIGTERM to
+    request graceful termination of the experiment.
+
+    Args:
+        experiment_desc: A declarative experiment description, as a mapping
+        global_parameters: Global parameters for this run, as a mapping from
+            parameter name to value
+    """
+
+    signal.signal(signal.SIGTERM, lambda *args: request_stop())
+
+    run_experiment(experiment_desc, global_parameters)
+
+
+def _monitor_process(child_process: mp.Process) -> bool:
+    """
+    Watch the given child process while polling for a shutdown request.
+    If shutdown is requested, shut down the child process early.
+
+    This function blocks until the child process terminates.
+
+    Args:
+        child_process: The child process to watch
+
+    Returns:
+        True if the process was stopped prematurely; False if not
+    """
+    log = _get_logger()
+    log.debug("Monitoring task engine process: %d", child_process.pid)
+
+    should_stop = False
+    while child_process.is_alive():
+        should_stop = _should_stop()
+
+        if should_stop:
+            log.warning("Attempting to stop pid: %d", child_process.pid)
+            # Send a SIGTERM to attempt a graceful shutdown
+            child_process.terminate()
+
+            # Wait one poll interval to see if it stops.  If not, forcibly
+            # kill it.
+            child_process.join(_POLL_INTERVAL)
+
+            # Docs describe checking .exitcode, not .is_alive().
+            if child_process.exitcode is None:
+                log.warning(
+                    "Graceful shutdown failed; killing pid: %d", child_process.pid
+                )
+                child_process.kill()
+                child_process.join()
+
+        else:
+            # Wait until next poll
+            child_process.join(_POLL_INTERVAL)
+
+    return should_stop
+
+
+def _should_stop() -> bool:
+    """
+    Determine whether the current experiment should be stopped.
+
+    Returns:
+        True if it should be stopped; False if not
+    """
+    # resp = requests.get(_POLL_URL)
+    # if resp.ok:
+    #     # Depends on what the endpoint returns
+    #     value = cast(bool, resp.json())
+    #
+    # else:
+    #     log.warning("Polling endpoint returned http status: %d", resp.status_code)
+    #     value = False
+
+    value = False
+    return value


### PR DESCRIPTION
This a kind of "rebase" of #444 (see that PR for technical details), but not simply a `git rebase` since dev branch has changed so much since the original changes were made.  I just made the changes by hand, based on the older branch.  run_task_engine_stoppable.py is brought forward unchanged, and the same updates were applied to task_engine.py to add the stop flag.  But the integration into the job execution procedure is changed to work with current dev branch.

Calls to run_experiment() were replaced with run_experiment_stoppable(), but the change was made in run_dioptra_job.py.tmpl.  Its main() function now propagates the stopped flag back to run_v1_dioptra_job.py, where the dioptra job status is set.

Normal job execution was tested with the hello world example.  Premature stopping was not tested since we still don't have a mechanism to signal a job to stop (I did test this in the original branch, but had to make some awkward contrivances to do so).