### PR TITLE
fix: add more get_one() methods, ensure they raise the right exceptions

### DIFF
--- a/src/dioptra/restapi/db/repository/drafts.py
+++ b/src/dioptra/restapi/db/repository/drafts.py
@@ -283,6 +283,41 @@ class DraftsRepository:
 
         return draft
 
+    def get_one(
+        self,
+        draft_id: int,
+        resource_type: str | None = None,
+        creator: User | int | None = None,
+    ) -> DraftResource:
+        """
+        Get a draft (either kind) by ID.  Analogous to .get(), but raises
+        an exception instead of returning None.
+
+        Args:
+            draft_id: The ID of a draft
+            resource_type: A resource type, used to pretend an existing draft
+                doesn't exist if it's for the wrong type of resource; None to
+                not filter by resource type
+            creator: A User object or user_id integer primary key value, used
+                to pretend an existing draft doesn't exist if it was created
+                by the wrong user; None to not filter by user creator
+
+        Returns:
+            A DraftResource object
+
+        Raises:
+            EntityDoesNotExistError: if a creator user is given but it does not
+                exist
+            EntityDeletedError: if a creator user is given but it is deleted
+            DraftDoesNotExistError: if the draft is not found
+        """
+
+        draft = self.get(draft_id, resource_type, creator)
+        if not draft:
+            raise DraftDoesNotExistError(draft_resource_id=draft_id)
+
+        return draft
+
     def get_resource(
         self,
         resource_id: int,
@@ -586,7 +621,7 @@ class DraftsRepository:
             draft: An existing or ID of an existing DraftResource
 
         Raises:
-            EntityDoesNotExistError: if the draft does not exist
+            DraftDoesNotExistError: if the draft does not exist
         """
 
         if draft_exists(self._session, draft):

--- a/src/dioptra/restapi/db/repository/experiments.py
+++ b/src/dioptra/restapi/db/repository/experiments.py
@@ -157,7 +157,12 @@ class ExperimentRepository:
             An Experiment object
 
         Raises:
-            EntityDoesNotExistError: if the resource is not found
+            EntityDoesNotExistError: if the experiment does not exist in the
+                database (deleted or not)
+            EntityExistsError: if the experiment exists and is not deleted, but
+                policy was to find a deleted experiment
+            EntityDeletedError: if the experiment is deleted, but policy was to
+                find a non-deleted experiment
         """
         return utils.get_one_latest_snapshot(
             self.session, Experiment, resource_id, deletion_policy

--- a/src/dioptra/restapi/db/repository/queues.py
+++ b/src/dioptra/restapi/db/repository/queues.py
@@ -181,7 +181,12 @@ class QueueRepository:
             A Queue object
 
         Raises:
-            EntityDoesNotExistError: if the resource is not found
+            EntityDoesNotExistError: if the queue does not exist in the
+                database (deleted or not)
+            EntityExistsError: if the queue exists and is not deleted, but
+                policy was to find a deleted queue
+            EntityDeletedError: if the queue is deleted, but policy was to find
+                a non-deleted queue
         """
         return utils.get_one_latest_snapshot(
             self.session, Queue, resource_id, deletion_policy

--- a/src/dioptra/restapi/db/repository/types.py
+++ b/src/dioptra/restapi/db/repository/types.py
@@ -165,7 +165,12 @@ class TypeRepository:
             A PluginTaskParameterType object
 
         Raises:
-            EntityDoesNotExistError: if the resource is not found
+            EntityDoesNotExistError: if the type does not exist in the database
+                (deleted or not)
+            EntityExistsError: if the type exists and is not deleted, but
+                policy was to find a deleted type
+            EntityDeletedError: if the type is deleted, but policy was to find
+                a non-deleted type
         """
         return utils.get_one_latest_snapshot(
             self.session, PluginTaskParameterType, resource_id, deletion_policy

--- a/tests/unit/restapi/test_drafts_repository.py
+++ b/tests/unit/restapi/test_drafts_repository.py
@@ -836,6 +836,18 @@ def test_drafts_get(db, drafts_repo, draft_stuff):
     assert found_draft.draft_resource_id == draft.draft_resource_id
 
 
+def test_drafts_get_one(drafts_repo, draft_stuff):
+    draft = draft_stuff["draft_resources"][0]
+
+    found_draft = drafts_repo.get_one(draft.draft_resource_id)
+    assert draft == found_draft
+
+
+def test_drafts_get_one_not_exist(drafts_repo):
+    with pytest.raises(e.DraftDoesNotExistError):
+        drafts_repo.get_one(999999)
+
+
 def test_drafts_get_user_not_exist(db, drafts_repo, draft_stuff):
 
     draft = draft_stuff["draft_mods"][0]


### PR DESCRIPTION
This PR adds get_one() methods to user, group, draft repositories. Exception behavior is updated across all implementations to ensure the correct exceptions are thrown, depending on existence and deletion policy.  Unit tests are added/updated.

These changes are necessary to address #877 .

(Also fixed a minor docstring bug in the drafts repo.)