### PR TITLE
fix(restapi): allow name conflicts with deleted resources/snapshots

### DIFF
--- a/src/dioptra/restapi/db/repository/utils/checks.py
+++ b/src/dioptra/restapi/db/repository/utils/checks.py
@@ -1227,6 +1227,7 @@ def assert_resource_name_available(
             resource_type_class.resource_snapshot_id == m.Resource.latest_snapshot_id,
             # Dunno why mypy has trouble with this expression...
             m.Resource.owner == snap.resource.owner,  # type: ignore
+            m.Resource.is_deleted == False,  # noqa: E712
         )
     )
 
@@ -1276,6 +1277,7 @@ def assert_snapshot_name_available(
             resource_type_class.resource_snapshot_id == m.Resource.latest_snapshot_id,
             # Dunno why mypy has trouble with this expression...
             m.Resource.owner == snap.resource.owner,  # type: ignore
+            m.Resource.is_deleted == False,  # noqa: E712
             resource_type_class.resource_id != snap.resource_id,
         )
     )

--- a/tests/unit/restapi/v1/workflows/test_resource_import.py
+++ b/tests/unit/restapi/v1/workflows/test_resource_import.py
@@ -86,7 +86,11 @@ def assert_resource_import_overwrite_works(
     group_id: int,
     archive_file: DioptraFile,
 ):
+    dioptra_client.entrypoints.create(
+        group_id=group_id, name="Hello World", task_graph=""
+    )
     dioptra_client.plugins.create(group_id=group_id, name="hello_world")
+    dioptra_client.plugin_parameter_types.create(group_id=group_id, name="message")
     response = dioptra_client.workflows.import_resources(
         group_id=group_id,
         source=archive_file,


### PR DESCRIPTION
This commit allows for new resources and resource snapshots to be created with the name of a previously deleted resource. It applies to resources that are using the new repository pattern implementations, reverting the behavior back to how name conflicts were previously handled.

It fixes the issue where if a resource was deleted, that resource's name could never be used again. This issue was especially prevalent when using the resource import workflow to overwrite (delete and re-create) existing resources.

It updates a resource import workflow test by first creating resources with conflicting names before importing resources with the overwrite strategy.