### PR TITLE
refactor: change .get() calls to .get_one() in services

### DIFF
--- a/src/dioptra/restapi/v1/experiments/service.py
+++ b/src/dioptra/restapi/v1/experiments/service.py
@@ -91,9 +91,7 @@ class ExperimentService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        owner = self._uow.group_repo.get(group_id, DeletionPolicy.NOT_DELETED)
-        if not owner:
-            raise EntityDoesNotExistError("group", group_id=group_id)
+        owner = self._uow.group_repo.get_one(group_id, DeletionPolicy.NOT_DELETED)
 
         resource = models.Resource(RESOURCE_TYPE, owner)
         new_experiment = models.Experiment(
@@ -534,11 +532,10 @@ class ExperimentIdEntrypointsService(object):
         """
         log: BoundLogger = kwargs.get("log", LOGGER.new())
 
-        experiment = self._uow.experiment_repo.get(
-            experiment_id, DeletionPolicy.NOT_DELETED
+        experiment = self._uow.experiment_repo.get_one(
+            experiment_id,
+            DeletionPolicy.NOT_DELETED,
         )
-        if not experiment:
-            raise EntityDoesNotExistError("experiment", resource_id=experiment_id)
 
         entrypoint_ids = [child.resource_id for child in experiment.children]
 

--- a/src/dioptra/restapi/v1/groups/service.py
+++ b/src/dioptra/restapi/v1/groups/service.py
@@ -242,10 +242,7 @@ class GroupIdService(object):
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.debug("Delete group", group_id=group_id)
 
-        group = self._uow.group_repo.get(group_id, DeletionPolicy.NOT_DELETED)
-
-        if group is None:
-            raise EntityDoesNotExistError(GROUP_TYPE, group_id=group_id)
+        group = self._uow.group_repo.get_one(group_id, DeletionPolicy.NOT_DELETED)
 
         with self._uow:
             self._uow.group_repo.delete(group)

--- a/src/dioptra/restapi/v1/plugin_parameter_types/service.py
+++ b/src/dioptra/restapi/v1/plugin_parameter_types/service.py
@@ -95,9 +95,9 @@ class PluginParameterTypeService(object):
             )
             raise PluginParameterTypeMatchesBuiltinTypeError
 
-        group = self._uow.group_repo.get(group_id, repoutils.DeletionPolicy.NOT_DELETED)
-        if not group:
-            raise EntityDoesNotExistError("group", group_id=group_id)
+        group = self._uow.group_repo.get_one(
+            group_id, repoutils.DeletionPolicy.NOT_DELETED
+        )
 
         resource = models.Resource(resource_type=RESOURCE_TYPE, owner=group)
         new_plugin_parameter_type = models.PluginTaskParameterType(

--- a/src/dioptra/restapi/v1/shared/drafts/service.py
+++ b/src/dioptra/restapi/v1/shared/drafts/service.py
@@ -123,9 +123,7 @@ class ResourceDraftsService(object):
         if base_resource_id is None:
             if group_id is None:
                 raise MalformedDraftResourceError()
-            owner = self._uow.group_repo.get(group_id, DeletionPolicy.ANY)
-            if not owner:
-                raise EntityDoesNotExistError("group", group_id=group_id)
+            owner = self._uow.group_repo.get_one(group_id, DeletionPolicy.ANY)
         else:
             base_resource = self._uow.drafts_repo.get_resource(
                 base_resource_id, DeletionPolicy.ANY


### PR DESCRIPTION
Fixes #877 .

... where possible.  Also remove some mypy type guard asserts in queue services which are no longer necessary. Changing .get() method signature to an `@overload` style helped mypy understand it better, so the type guards became superfluous.