### PR TITLE
fix: avoid error if last character of search is colon or comma

### DIFF
--- a/docs/source/reference/resource-search-language-reference.rst
+++ b/docs/source/reference/resource-search-language-reference.rst
@@ -78,7 +78,7 @@ Search terms can be combined using commas.
 
 Example usage:
     * ``search_term_1, search_terms_*, "search_term_3"`` - will search for all text fields that
-    match either ``search_term_1``, start with ``search_terms_`` or match ``search_term_3``.
+    match ``search_term_1``, start with ``search_terms_`` and match ``search_term_3``.
 
 
 Searching by Field Name ``field:``

--- a/src/dioptra/restapi/db/repository/utils/search.py
+++ b/src/dioptra/restapi/db/repository/utils/search.py
@@ -50,6 +50,8 @@ def _construct_sql_search_value(search_term: str) -> str:
         search_term = search_term.replace(r"\\", "\\")
         search_term = search_term.replace(r"\*", "*")
         search_term = search_term.replace(r"\?", "?")
+        search_term = search_term.replace(r"\:", ":")
+        search_term = search_term.replace(r"\,", ",")
         search_term = search_term.replace(r"\"", '"')
         search_term = search_term.replace(r"\'", "'")
         search_term = search_term.replace(r"\n", "\n")

--- a/src/dioptra/restapi/v1/shared/search_parser.py
+++ b/src/dioptra/restapi/v1/shared/search_parser.py
@@ -44,7 +44,7 @@ def _define_query_grammar() -> pp.ParserElement:
     wildcard = ~pp.Literal("\\") + (pp.Literal("*") | pp.Literal("?"))
 
     # An escaped character is a '\' followed by a character that needs to be escaped
-    escape = pp.Literal("\\") + pp.Word("\\?*\"'n", exact=1)
+    escape = pp.Literal("\\") + pp.Word("\\?*\"'n:,", exact=1)
 
     # Spaces are allowed in unquoted searches, but not when a field is specified
     space = pp.Literal(" ")

--- a/src/frontend/src/notify.ts
+++ b/src/frontend/src/notify.ts
@@ -12,9 +12,9 @@ export function success(message: string) {
 export function error(message: string) {
   return Notify.create({
     color: 'red-5',
-      textColor: 'white',
-      icon: 'warning',
-      message: message
+    textColor: 'white',
+    icon: 'warning',
+    message: message
   });
 }
 
@@ -24,6 +24,6 @@ export function wait(message: string) {
       textColor: 'white',
       spinner: true,
       message: message,
-	  timeout: 0 //intended to be dismissed manually
+	    timeout: 0 //intended to be dismissed manually
   });
 }

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -141,7 +141,7 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: processSearch(pagination.search),
+      search: pagination.search,
       draftType: showDrafts ? 'new' : '',
       sortBy: pagination.sortBy,
       descending: pagination.descending,
@@ -221,7 +221,7 @@ export async function getJobs(id: number, pagination: Pagination) {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: processSearch(pagination.search),
+      search: pagination.search,
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     }
@@ -243,34 +243,6 @@ export async function getJobMetrics(id: number) {
   return await axios.get(`/api/jobs/${id}/metrics`)
 
 }
-
-function processSearch(string: string) {
-  // Trim trailing spaces for evaluation
-  const trimmed = string.trimEnd()
-
-  // If ends with colon and second to last char is not escaped or a colon
-  if (
-    trimmed.length > 1 &&
-    trimmed.endsWith(':') &&
-    trimmed[trimmed.length - 2] !== '\\' &&
-    trimmed[trimmed.length - 2] !== ':'
-  ) {
-    return ''
-  }
-
-  // If ends with comma and second to last char is not a comma
-  if (
-    trimmed.length > 1 &&
-    trimmed.endsWith(',') &&
-    trimmed[trimmed.length - 2] !== '\\' &&
-    trimmed[trimmed.length - 2] !== ','
-  ) {
-    return trimmed.slice(0, -1)
-  }
-
-  return string
-}
-
 
 export async function getItem<T extends ItemType>(type: T, id: number, isDraft: boolean = false) {
   const res =  await axios.get(`/api/${type}/${id}${isDraft ? '/draft' : ''}`)
@@ -345,7 +317,7 @@ export async function getFiles(id: number, pagination: Pagination) {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: processSearch(pagination.search),
+      search: pagination.search,
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     }

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -141,7 +141,7 @@ export async function getData<T extends ItemType>(type: T, pagination: Paginatio
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: urlEncode(pagination.search),
+      search: processSearch(pagination.search),
       draftType: showDrafts ? 'new' : '',
       sortBy: pagination.sortBy,
       descending: pagination.descending,
@@ -221,7 +221,7 @@ export async function getJobs(id: number, pagination: Pagination) {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: urlEncode(pagination.search),
+      search: processSearch(pagination.search),
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     }
@@ -244,16 +244,33 @@ export async function getJobMetrics(id: number) {
 
 }
 
-function urlEncode(string: string) {
-  if(!string.trim()) return ''
-  if(string.includes(':')) {
-    const words = string.split(':')
-    console.log('words = ', words)
-    return `${words[0]}:"${words[1]}"`
-  } else {
-    return `"${string}"`
+function processSearch(string: string) {
+  // Trim trailing spaces for evaluation
+  const trimmed = string.trimEnd()
+
+  // If ends with colon and second to last char is not escaped or a colon
+  if (
+    trimmed.length > 1 &&
+    trimmed.endsWith(':') &&
+    trimmed[trimmed.length - 2] !== '\\' &&
+    trimmed[trimmed.length - 2] !== ':'
+  ) {
+    return ''
   }
+
+  // If ends with comma and second to last char is not a comma
+  if (
+    trimmed.length > 1 &&
+    trimmed.endsWith(',') &&
+    trimmed[trimmed.length - 2] !== '\\' &&
+    trimmed[trimmed.length - 2] !== ','
+  ) {
+    return trimmed.slice(0, -1)
+  }
+
+  return string
 }
+
 
 export async function getItem<T extends ItemType>(type: T, id: number, isDraft: boolean = false) {
   const res =  await axios.get(`/api/${type}/${id}${isDraft ? '/draft' : ''}`)
@@ -328,7 +345,7 @@ export async function getFiles(id: number, pagination: Pagination) {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
-      search: urlEncode(pagination.search),
+      search: processSearch(pagination.search),
       sortBy: pagination.sortBy,
       descending: pagination.descending,
     }


### PR DESCRIPTION
Closes #859 

There already is a 300ms debounce on the search field.  The issue is that when searching with a colon, it naturally takes longer and thus you see the error.  The same issue happens when using a comma.  The fix in this PR is to pass in an empty string whenever the last character of the search is a colon.  Similarly if the last character is a comma, it will strip out that trailing comma.  Now the user wont see an error until they finish typing their search.  I'm not sure this workaround is better because it gives the user a technically wrong result and assume they're gonna continue typing after the colon or comma, but let me know what you think.  Another idea is to have an "advanced search" button next to the search field which brings up a modal where you build these more advance searches through a form.

Other fixes in this PR:
- Remove unnecessary parsing done on the search string in the frontend.
- Currently the \ escape character can't be used to escape a colon or comma.  This adds those as escapable characters.
- In the docs, clarify that using commas searches by AND and not OR

Note: Currently experiments. queues, and param types return a 500 when the user inputs an invalid search string, unlike the other types that return a 422 with a message.  I'm assuming this is part of the ongoing migration to the repository pattern.