### PR TITLE
fix: some resources are unable to search by tag (#896)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ honor_noqa = true
 [tool.mypy]
 python_version = "3.11"
 platform = "linux"
-mypy_path = "src,task-plugins"
+mypy_path = "src,tests"
 explicit_package_bases = true
 namespace_packages = true
 show_column_numbers = true
@@ -302,7 +302,7 @@ exclude = [
 plugins = "numpy.typing.mypy_plugin"
 
 [tool.pyright]
-include = ["src"]
+include = ["src", "tests"]
 exclude = [
     "**/.ipynb_checkpoints",
     "**/__pycache__",

--- a/src/dioptra/restapi/v1/artifacts/service.py
+++ b/src/dioptra/restapi/v1/artifacts/service.py
@@ -48,8 +48,9 @@ LOGGER: BoundLogger = structlog.stdlib.get_logger()
 
 RESOURCE_TYPE: Final[str] = "artifact"
 SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
-    "uri": lambda x: models.Artifact.uri.like(x, escape="/"),
+    "artifactUri": lambda x: models.Artifact.uri.like(x, escape="/"),
     "description": lambda x: models.Artifact.description.like(x, escape="/"),
+    "tag": lambda x: models.Artifact.tags.any(models.Tag.name.like(x, escape="/")),
 }
 SORTABLE_FIELDS: Final[dict[str, Any]] = {
     "uri": models.Artifact.uri,

--- a/src/dioptra/restapi/v1/entrypoints/service.py
+++ b/src/dioptra/restapi/v1/entrypoints/service.py
@@ -54,6 +54,8 @@ SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "name": lambda x: models.EntryPoint.name.like(x, escape="/"),
     "description": lambda x: models.EntryPoint.description.like(x, escape="/"),
     "task_graph": lambda x: models.EntryPoint.task_graph.like(x, escape="/"),
+    "artifact_graph": lambda x: models.EntryPoint.artifact_graph.like(x, escape="/"),
+    "tag": lambda x: models.EntryPoint.tags.any(models.Tag.name.like(x, escape="/")),
 }
 SORTABLE_FIELDS: Final[dict[str, Any]] = {
     "name": models.EntryPoint.name,

--- a/src/dioptra/restapi/v1/models/service.py
+++ b/src/dioptra/restapi/v1/models/service.py
@@ -44,9 +44,13 @@ MODEL_VERSION_RESOURCE_TYPE: Final[str] = "ml_model_version"
 MODEL_SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "name": lambda x: models.MlModel.name.like(x, escape="/"),
     "description": lambda x: models.MlModel.description.like(x, escape="/"),
+    "tag": lambda x: models.MlModel.tags.any(models.Tag.name.like(x, escape="/")),
 }
 MODEL_VERSION_SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "description": lambda x: models.MlModelVersion.description.like(x, escape="/"),
+    "tag": lambda x: models.MlModelVersion.tags.any(
+        models.Tag.name.like(x, escape="/")
+    ),
 }
 MODEL_SORTABLE_FIELDS: Final[dict[str, Any]] = {
     "name": models.MlModel.name,

--- a/src/dioptra/restapi/v1/plugins/service.py
+++ b/src/dioptra/restapi/v1/plugins/service.py
@@ -51,11 +51,13 @@ PLUGIN_TASK_RESOURCE_TYPE: Final[str] = "plugin_task"
 PLUGIN_SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "name": lambda x: models.Plugin.name.like(x, escape="/"),
     "description": lambda x: models.Plugin.description.like(x, escape="/"),
+    "tag": lambda x: models.Plugin.tags.any(models.Tag.name.like(x, escape="/")),
 }
 PLUGIN_FILE_SEARCHABLE_FIELDS: Final[dict[str, Any]] = {
     "filename": lambda x: models.PluginFile.filename.like(x, escape="/"),
     "description": lambda x: models.PluginFile.description.like(x, escape="/"),
     "contents": lambda x: models.PluginFile.contents.like(x, escape="/"),
+    "tag": lambda x: models.PluginFile.tags.any(models.Tag.name.like(x, escape="/")),
 }
 PLUGIN_SORTABLE_FIELDS: Final[dict[str, Any]] = {
     "name": models.Plugin.name,

--- a/src/dioptra/restapi/v1/shared/search_parser.py
+++ b/src/dioptra/restapi/v1/shared/search_parser.py
@@ -20,6 +20,8 @@ A module for Dioptra's REST API query language.
 This module is responsible for defining the query language and providing a parser.
 It parses syntactically correct search queries into a list of search terms. It also
 provides support for constructing sqlalchemy WHERE clauses from a parsed query.
+
+See test_grammar in unit tests for example grammar usage
 """
 
 from typing import Any
@@ -166,6 +168,7 @@ def construct_sql_query_filters(search_string: str, searchable_fields: dict[str,
 
     Args:
         search_string: A string conforming to the search grammar.
+        searchable_fields: A mapping of field names to SQL Alchemy filter functions
 
     Returns:
         A filter that can be used in a sqlalchemy query.
@@ -192,55 +195,3 @@ def construct_sql_query_filters(search_string: str, searchable_fields: dict[str,
         query_filters.append(filter)
 
     return and_(*query_filters)
-
-
-if __name__ == "__main__":
-    """
-    A simple demonstration of the query grammar with sample queries.
-    """
-
-    DIOPTRA_QUERY_GRAMMAR.run_tests(
-        r"""
-        # search all text fields matching 'search_*'
-        search_*
-        # search all text the exactly match 'search_*'
-        search_\*
-        # a quoted search term can contain spaces and other characters
-        "search \"this\", and 'that'"
-        # multiple search terms can be provided via a comma-separated list
-        "search=this", 'and, how about "this\?"',this_too
-        # search tags whose name matches 'classification' exactly
-        tag:classification
-        # search tags whose name starts with 'class'
-        tag:class*
-        # search descriptions containing mnist and whose tag name matches 'cv' exactly
-        description:*mnist*,tag:cv
-        # search for name starting with 'trial_' and ending with two valid characters
-        name:trial_??
-        # search for literal '*'
-        \*
-        # multi-word search
-        search all for this
-        # field multi-word search
-        field:"search all for this"
-        """,
-        full_dump=False,
-    )
-
-    DIOPTRA_QUERY_GRAMMAR.run_tests(
-        r"""
-        # invalid multi word field search
-        field:search all for this
-        # incorrect assignment character used
-        bad=assignment
-        # invalid characters in field name
-        bad-name:classification
-        # invalid delimiter between search terms
-        description:bad_delim|tag:cv
-        # missing closing quote
-        "forgot to close this quote
-        # tried to escape an unescapable character
-        \q
-        """,
-        full_dump=False,
-    )

--- a/tests/unit/restapi/test_type_repository.py
+++ b/tests/unit/restapi/test_type_repository.py
@@ -15,6 +15,7 @@
 # ACCESS THE FULL CC BY 4.0 LICENSE HERE:
 # https://creativecommons.org/licenses/by/4.0/legalcode
 import pytest
+from freezegun import freeze_time
 from sqlalchemy.orm.session import Session as DBSession
 
 import dioptra.restapi.db.models as models
@@ -44,7 +45,6 @@ def point_type(db_session: DBSession, account):
 
 
 def test_type_create_not_exist(db_session: DBSession, account, type_repo):
-
     res = models.Resource("plugin_task_parameter_type", account.group)
     type_ = models.PluginTaskParameterType(
         "a type", res, account.user, "test_type", {"some": "structure"}
@@ -153,7 +153,6 @@ def test_type_create_user_not_member(
 def test_type_create_wrong_resource_type(
     db_session: DBSession, fake_data, account, type_repo
 ):
-
     res = models.Resource("queue", account.group)
     type_ = models.PluginTaskParameterType(
         "a type", res, account.user, "test_type", {"some": "structure"}
@@ -168,7 +167,6 @@ def test_type_create_wrong_resource_type(
 
 
 def test_type_create_name_collision(account, type_repo, point_type):
-
     res = models.Resource("plugin_task_parameter_type", account.group)
     type_ = models.PluginTaskParameterType(
         "a type", res, account.user, "point", {"some": "structure"}
@@ -179,7 +177,6 @@ def test_type_create_name_collision(account, type_repo, point_type):
 
 
 def test_type_create_name_reuse(db_session: DBSession, account, type_repo, point_type):
-
     lock = models.ResourceLock(resource_lock_types.DELETE, point_type.resource)
     db_session.add(lock)
     db_session.commit()
@@ -212,6 +209,7 @@ def test_type_create_snapshot_exists(
         type_repo.create_snapshot(type_)
 
 
+@freeze_time("Apr 1st, 2025", auto_tick_seconds=1)
 def test_type_create_snapshot_not_exist(
     db_session: DBSession, fake_data, account, type_repo
 ):
@@ -247,7 +245,6 @@ def test_type_create_snapshot_resource_not_exist(fake_data, account, type_repo):
 
 
 def test_type_create_snapshot_user_not_exist(type_repo, point_type):
-
     user2 = models.User("user2", "pass2", "user2@example.org")
     point_type_v2 = models.PluginTaskParameterType(
         point_type.description, point_type.resource, user2, "point2", None
@@ -260,7 +257,6 @@ def test_type_create_snapshot_user_not_exist(type_repo, point_type):
 def test_type_create_snapshot_user_deleted(
     db_session: DBSession, type_repo, point_type
 ):
-
     lock = models.UserLock(user_lock_types.DELETE, point_type.creator)
     db_session.add(lock)
     db_session.commit()
@@ -276,7 +272,6 @@ def test_type_create_snapshot_user_deleted(
 def test_type_create_snapshot_user_not_member(
     db_session: DBSession, type_repo, point_type
 ):
-
     user2 = models.User("user2", "pass2", "user2@example.org")
     group2 = models.Group("group2", user2)
     db_session.add_all((user2, group2))
@@ -305,7 +300,6 @@ def test_type_create_snapshot_user_not_member(
 def test_type_create_snapshot_name_collision(
     db_session: DBSession, fake_data, account, type_repo, point_type
 ):
-
     type_ = fake_data.plugin_task_parameter_type(account.user, account.group, "my_type")
     db_session.add(type_)
     db_session.commit()
@@ -323,7 +317,6 @@ def test_type_create_snapshot_name_collision(
 
 
 def test_type_get_by_name_exists(type_repo, point_type, deletion_policy):
-
     found = type_repo.get_by_name("point", point_type.resource.owner, deletion_policy)
     expected_list = helpers.find_expected_snaps_for_deletion_policy(
         (point_type,), deletion_policy
@@ -344,7 +337,6 @@ def test_type_get_by_name_not_exist(type_repo, account, deletion_policy):
 def test_type_get_by_name_deleted(
     db_session: DBSession, type_repo, point_type, deletion_policy
 ):
-
     lock = models.ResourceLock(resource_lock_types.DELETE, point_type.resource)
     db_session.add(lock)
     db_session.commit()

--- a/tests/unit/restapi/test_utils.py
+++ b/tests/unit/restapi/test_utils.py
@@ -77,6 +77,21 @@ def assert_retrieving_resource_works(
     )
 
 
+def assert_searchable_field_works(
+    dioptra_client: SubCollectionClient[DioptraResponseProtocol],
+    term: str,
+    value: str,
+    expected_count: int,
+    context: dict[str, Any] | None = None,
+) -> None:
+    if context is None:
+        context = {}
+    response = dioptra_client.get(**context, search=f'{term}:"{value}"')
+    assert response.status_code == HTTPStatus.OK
+    json_response = response.json()
+    assert json_response["totalNumResults"] == expected_count
+
+
 def match_normalized_json(
     original_entity: DioptraResponseProtocol | list[dict[str, Any]],
     expected_json_entity: DioptraResponseProtocol | list[dict[str, Any]],

--- a/tests/unit/restapi/v1/shared/test_search_parser.py
+++ b/tests/unit/restapi/v1/shared/test_search_parser.py
@@ -1,0 +1,150 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""Test suite for search parser operations.
+
+This module contains a set of tests that validates the module responsible for defining
+the query language used for search queries.
+"""
+
+import pytest
+
+from dioptra.restapi.errors import SearchParseError
+from dioptra.restapi.v1.shared.search_parser import (
+    DIOPTRA_QUERY_GRAMMAR,
+    construct_sql_query_filters,
+    construct_sql_search_value,
+    parse_search_text,
+)
+
+
+def test_grammar() -> None:
+    """
+    A simple demonstration of the query grammar with sample queries.
+    """
+    DIOPTRA_QUERY_GRAMMAR.run_tests(
+        r"""
+    # search all text fields matching 'search_*'
+    search_*
+    # search all text the exactly match 'search_*'
+    search_\*
+    # a quoted search term can contain spaces and other characters
+    "search \"this\", and 'that'"
+    # multiple search terms can be provided via a comma-separated list
+    "search=this", 'and, how about "this\?"',this_too
+    # search tags whose name matches 'classification' exactly
+    tag:classification
+    # search tags whose name starts with 'class'
+    tag:class*
+    # search descriptions containing mnist and whose tag name matches 'cv' exactly
+    description:*mnist*,tag:cv
+    # search for name starting with 'trial_' and ending with two valid characters
+    name:trial_??
+    # search for literal '*'
+    \*
+    # multi-word search
+    search all for this
+    # field multi-word search
+    field:"search all for this"
+    """,
+        full_dump=False,
+    )
+
+    DIOPTRA_QUERY_GRAMMAR.run_tests(
+        r"""
+        # invalid multi word field search -- needs to be quoted
+        field:search all for this
+        # incorrect assignment character used
+        bad=assignment
+        # invalid characters in field name
+        bad-name:classification
+        # invalid delimiter between search terms
+        description:bad_delim|tag:cv
+        # missing closing quote
+        "forgot to close this quote
+        # tried to escape an unescapable character
+        \q
+        """,
+        full_dump=False,
+    )
+
+
+def test_parse_search_text() -> None:
+    assert parse_search_text(search_text="") == []
+    assert parse_search_text(
+        search_text='description:"my value",tag:something,name:else,extra'
+    ) == [
+        {"field": "description", "value": ["my value"]},
+        {"field": "tag", "value": ["something"]},
+        {"field": "name", "value": ["else"]},
+        {"field": None, "value": ["extra"]},
+    ]
+
+
+@pytest.mark.parametrize(
+    "term_list, fuzzy, expected",
+    [
+        (["te/st"], False, "te//st"),
+        (["tes%t"], False, "tes/%t"),
+        (["tes_t"], False, "tes/_t"),
+        (["*"], False, "%"),
+        (["?"], False, "_"),
+        (["value", "?"], False, "value_"),
+        (["value", "*"], False, "value%"),
+        (["tes\\\\t"], False, "tes\\t"),
+        (["tes\\*t"], False, "tes*t"),
+        (["tes\\?t"], False, "tes?t"),
+        (['tes\\"t'], False, 'tes"t'),
+        (["tes't"], False, "tes't"),
+        (["tes\\nt"], False, "tes\nt"),
+        (["tes't"], True, "%tes't%"),
+        (["test", "value"], False, "testvalue"),
+        (["test", "value"], True, "%test%value%"),
+    ],
+)
+def test_construct_sql_search_value(
+    term_list: list[str], fuzzy: bool, expected: str
+) -> None:
+    assert construct_sql_search_value(search_term=term_list, fuzzy=fuzzy) == expected
+
+
+def test_construct_sql_query_filters() -> None:
+    # using queues for testing this functionality since it is relatively simple
+    from dioptra.restapi.db.repository.queues import QueueRepository
+
+    assert construct_sql_query_filters(
+        search_string="",
+        searchable_fields=QueueRepository.SEARCHABLE_FIELDS,
+    )
+    # just test that it works
+    construct_sql_query_filters(
+        search_string='description:"my value",tag:something,name:else,extra',
+        searchable_fields=QueueRepository.SEARCHABLE_FIELDS,
+    )
+
+    # invalid -- no quotes around multi word query
+    with pytest.raises(SearchParseError):
+        construct_sql_query_filters(
+            search_string="description:my value",
+            searchable_fields=QueueRepository.SEARCHABLE_FIELDS,
+        )
+
+    # invalid - unknown field
+    with pytest.raises(SearchParseError):
+        construct_sql_query_filters(
+            search_string="test:some_value",
+            searchable_fields=QueueRepository.SEARCHABLE_FIELDS,
+        )

--- a/tests/unit/restapi/v1/test_artifact.py
+++ b/tests/unit/restapi/v1/test_artifact.py
@@ -20,6 +20,7 @@ This module contains a set of tests that validate the CRUD operations and additi
 functionalities for the model entity. The tests ensure that the models can be
 registered, renamed, deleted, and locked/unlocked as expected through the REST API.
 """
+
 from http import HTTPStatus
 from typing import Any
 
@@ -29,7 +30,7 @@ from dioptra.client.base import DioptraResponseProtocol
 from dioptra.client.client import DioptraClient
 
 from ..lib import helpers
-from ..test_utils import assert_retrieving_resource_works
+from ..test_utils import assert_retrieving_resource_works, assert_searchable_field_works
 
 # -- Assertions ------------------------------------------------------------------------
 
@@ -259,6 +260,32 @@ def test_artifacts_get_all(
     """
     artifacts_expected_list = list(registered_artifacts.values())
     assert_retrieving_artifacts_works(dioptra_client, expected=artifacts_expected_list)
+
+
+@pytest.mark.parametrize(
+    "field, value, expected_count",
+    [
+        ("artifactUri", None, 1),
+        ("description", None, 1),
+        ("tag", "Foo", 0),
+    ],
+)
+def test_artifact_searchable_fields(
+    dioptra_client: DioptraClient[DioptraResponseProtocol],
+    auth_account: dict[str, Any],
+    registered_artifacts: dict[str, Any],
+    field: str,
+    value: str | None,
+    expected_count: int,
+) -> None:
+    artifact = registered_artifacts["artifact1"]
+    search_value = artifact[field] if value is None else value
+    assert_searchable_field_works(
+        dioptra_client=dioptra_client.artifacts,
+        term=field,
+        value=search_value,
+        expected_count=expected_count,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/restapi/v1/test_entrypoint.py
+++ b/tests/unit/restapi/v1/test_entrypoint.py
@@ -31,7 +31,7 @@ from dioptra.client.base import DioptraResponseProtocol, FieldNameCollisionError
 from dioptra.client.client import DioptraClient
 
 from ..lib import helpers, routines
-from ..test_utils import assert_retrieving_resource_works
+from ..test_utils import assert_retrieving_resource_works, assert_searchable_field_works
 
 # -- Assertions ------------------------------------------------------------------------
 
@@ -593,6 +593,34 @@ def test_entrypoint_get_all(
     entrypoint_expected_list = list(registered_entrypoints.values())
     assert_retrieving_entrypoints_works(
         dioptra_client, expected=entrypoint_expected_list
+    )
+
+
+@pytest.mark.parametrize(
+    "field, value, expected_count",
+    [
+        ("name", None, 1),
+        ("description", None, 1),
+        ("task_graph", "*my_entrypoint*", 4),
+        ("artifact_graph", "Foo", 0),
+        ("tag", "Foo", 0),
+    ],
+)
+def test_entrypoint_searchable_fields(
+    dioptra_client: DioptraClient[DioptraResponseProtocol],
+    auth_account: dict[str, Any],
+    registered_entrypoints: dict[str, Any],
+    field: str,
+    value: str | None,
+    expected_count: int,
+) -> None:
+    entrypoint = registered_entrypoints["entrypoint1"]
+    search_value = entrypoint[field] if value is None else value
+    assert_searchable_field_works(
+        dioptra_client=dioptra_client.entrypoints,
+        term=field,
+        value=search_value,
+        expected_count=expected_count,
     )
 
 


### PR DESCRIPTION
closes #896
In addition to fixing #896 

- moved search parser grammar tests and added additional tests to expand coverage
- updated pyproject.toml so that it will include the tests source code 
      - flagging this change for @jkglasbrenner
      - adding the tests source code directory makes searching and "find all references" behave better in vscode as vscode uses the settings in pyproject.toml to determine what directories will be used. I am unsure of whether there are other side effects, but everything seems to be ok.
 
