### PR TITLE
refactor: remove name method from ArtifactTaskInterface

### DIFF
--- a/docs/source/reference/task-engine-reference.rst
+++ b/docs/source/reference/task-engine-reference.rst
@@ -668,9 +668,10 @@ Artifact outputs are declared and can use the result of any other artifact, para
 task as input for serialization. All artifacts are serialized at the end of the job. The
 value of the top-level ``artifact_outputs`` key must be a mapping.  The keys 
 of the mapping are the names of the artifacts to be serialized and the values are the
-declarative description for what should be the ``contents``, the ``name`` of the
-``ArtifactTaskHandler`` which should be used to serialize and deserialize the artifact,
-and any optional ``args`` that should be passed to the serialize method for the handler.
+declarative description for what should be the ``contents``, the ``name`` of the class
+implementing ``ArtifactTaskInterface`` which should be used to serialize and
+deserialize the artifact, and any optional ``args`` that should be passed to the
+serialize method for the handler.
 
 For example:
 
@@ -680,14 +681,15 @@ For example:
         artifact1:
             contents: $task1.result2
             task:
-                name: result2_serializer
+                name: Result2Serializer
                 args:
                     foo: arg1
 
 Here, ``artifact1`` is the name of an artifact that has as its ``contents`` the value of
-``result2`` from the output of ``task1``. The ``name`` of the ``ArtifactTaskHandler``
-to use is called ``result2_serializer`` and this particular serializer has a single extra
-argument called ``foo`` and a value of ``arg1`` has been provided in this example.
+``result2`` from the output of ``task1``. The ``name`` of the ``ArtifactTaskInterface``
+to use is a class called ``Result2Serializer`` and this particular implementation has a
+single extra argument called ``foo`` and a value of ``arg1`` which has been provided in
+this example.
 
 Type Validation
 ===============

--- a/extra/entrypoints/hello-world.yaml
+++ b/extra/entrypoints/hello-world.yaml
@@ -2,7 +2,7 @@ artifacts:
   output:
     contents: $goodbye_step.greeting
     task:
-      name: string_artifact
+      name: StringArtifactTask
       args:
         type: txt
 

--- a/extra/entrypoints/sklearn-classification.yaml
+++ b/extra/entrypoints/sklearn-classification.yaml
@@ -2,15 +2,15 @@ artifacts:
   model:
     contents: $model
     task:
-      name: pkl_artifact
+      name: PickleArtifactTask
   predictions:
     contents: $predictions
     task:
-      name: npy_artifact
+      name: NumpyArrayArtifactTask
   metrics:
     contents: $metrics
     task:
-      name: dataframe_artifact
+      name: DataframeArtifactTask
       args:
         format: csv
 

--- a/extra/plugins/artifacts/tasks.py
+++ b/extra/plugins/artifacts/tasks.py
@@ -59,10 +59,6 @@ class StringArtifactTask(ArtifactTaskInterface):
     def validation() -> dict[str, Any] | None:
         return {"type": {"type": "string"}}
 
-    @staticmethod
-    def name() -> str:
-        return "string_artifact"
-
 
 class BytesArtifactTask(ArtifactTaskInterface):
     @staticmethod
@@ -82,10 +78,6 @@ class BytesArtifactTask(ArtifactTaskInterface):
     def validation() -> dict[str, Any] | None:
         return {"type": {"type": "string"}}
 
-    @staticmethod
-    def name() -> str:
-        return "bytes_artifact"
-
 
 class FileArtifactTask(ArtifactTaskInterface):
     @staticmethod
@@ -103,10 +95,6 @@ class FileArtifactTask(ArtifactTaskInterface):
     @staticmethod
     def validation() -> dict[str, Any] | None:
         return None
-
-    @staticmethod
-    def name() -> str:
-        return "file_artifact"
 
 
 class DirectoryArtifactTask(ArtifactTaskInterface):
@@ -154,10 +142,6 @@ class DirectoryArtifactTask(ArtifactTaskInterface):
     @staticmethod
     def validation() -> dict[str, Any]:
         return {"tarball_write_mode": {"enum": ["w", "w:", "w:gz", "x:bz2", "w:xz"]}}
-
-    @staticmethod
-    def name() -> str:
-        return "directory_artifact"
 
 
 class DataframeArtifactTask(ArtifactTaskInterface):
@@ -266,10 +250,6 @@ class DataframeArtifactTask(ArtifactTaskInterface):
             }
         }
 
-    @staticmethod
-    def name() -> str:
-        return "dataframe_artifact"
-
 
 class NumpyArrayArtifactTask(ArtifactTaskInterface):
     @staticmethod
@@ -285,10 +265,6 @@ class NumpyArrayArtifactTask(ArtifactTaskInterface):
     @staticmethod
     def validation() -> dict[str, Any] | None:
         return None
-
-    @staticmethod
-    def name() -> str:
-        return "npy_artifact"
 
 
 class PickleArtifactTask(ArtifactTaskInterface):
@@ -307,7 +283,3 @@ class PickleArtifactTask(ArtifactTaskInterface):
     @staticmethod
     def validation() -> dict[str, Any] | None:
         return None
-
-    @staticmethod
-    def name() -> str:
-        return "pkl_artifact"

--- a/src/dioptra/sdk/api/artifact.py
+++ b/src/dioptra/sdk/api/artifact.py
@@ -99,14 +99,3 @@ class ArtifactTaskInterface(abc.ABCMeta):
             to serialize or `None` if no extra keyword arguments are used.
         """
         raise NotImplementedError
-
-    @staticmethod
-    @abc.abstractmethod
-    def name() -> str:
-        """
-        The name of the artifact task.
-
-        Returns:
-            The name of this particular artifact task instance.
-        """
-        raise NotImplementedError

--- a/src/dioptra/sdk/utilities/run_dioptra_job.py
+++ b/src/dioptra/sdk/utilities/run_dioptra_job.py
@@ -472,7 +472,7 @@ def _build_artifact_tasks(
                         )
                         exit(1)
                     if issubclass(task, ArtifactTaskInterface):
-                        result[task.name()] = ArtifactTaskEntry(
+                        result[task.__name__] = ArtifactTaskEntry(
                             task=task,
                             plugin_snapshot_id=plugin["snapshotId"],
                             task_id=artifact_task["id"],
@@ -502,13 +502,13 @@ def _create_engine_schema(
                         )
                         exit(1)
                     if issubclass(task, ArtifactTaskInterface):
-                        task_names.append(task.name())
+                        task_names.append(task.__name__)
                         validation = task.validation()
                         if validation is not None:
                             allof.append(
                                 {
                                     "if": {
-                                        "properties": {"name": {"const": task.name()}}
+                                        "properties": {"name": {"const": task.__name__}}
                                     },
                                     "then": {
                                         "properties": {


### PR DESCRIPTION
- Remove name() from ArtifactTaskInterface
- Updated code to use the name of the class in place of the result from name() method
- Updated implementations in extra/plugins/artifacts/tasks.py
- Updated Examples