### PR TITLE
Forward worker job logs to api

### DIFF
--- a/src/dioptra/rq/tasks/run_v1_dioptra_job.py
+++ b/src/dioptra/rq/tasks/run_v1_dioptra_job.py
@@ -20,6 +20,7 @@ import structlog
 from structlog.stdlib import BoundLogger
 
 import dioptra.sdk.utilities.run_dioptra_job as run_dioptra_job
+from dioptra.sdk.utilities.logging import forward_job_logs_to_api
 from dioptra.sdk.utilities.paths import set_cwd
 
 LOGGER: BoundLogger = structlog.stdlib.get_logger()
@@ -35,7 +36,11 @@ def run_v1_dioptra_job(job_id: int, experiment_id: int) -> None:  # noqa: C901
     log = LOGGER.new(job_id=job_id, experiment_id=experiment_id)  # noqa: F841
 
     # Set up a temporary directory and set it as the current working directory
-    with tempfile.TemporaryDirectory() as tempdir, set_cwd(tempdir):
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        set_cwd(tempdir),
+        forward_job_logs_to_api(job_id),
+    ):
         run_dioptra_job.main(
             job_id=job_id,
             experiment_id=experiment_id,

--- a/src/dioptra/sdk/utilities/logging/__init__.py
+++ b/src/dioptra/sdk/utilities/logging/__init__.py
@@ -18,6 +18,8 @@ from .config import (
     attach_stdout_stream_handler,
     clear_logger_handlers,
     configure_structlog,
+    configure_structlog_for_worker,
+    forward_job_logs_to_api,
     set_logging_level,
 )
 from .log_stream import StderrLogStream, StdoutLogStream
@@ -26,6 +28,8 @@ __all__ = [
     "attach_stdout_stream_handler",
     "clear_logger_handlers",
     "configure_structlog",
+    "configure_structlog_for_worker",
+    "forward_job_logs_to_api",
     "set_logging_level",
     "StderrLogStream",
     "StdoutLogStream",

--- a/src/dioptra/sdk/utilities/logging/filters.py
+++ b/src/dioptra/sdk/utilities/logging/filters.py
@@ -1,0 +1,102 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+
+import logging
+import re
+import urllib.parse
+from typing import Final
+
+CLIENT_SESSIONS_MODULE: Final[str] = "dioptra.client.sessions"
+JOB_LOG_PATH_RE: Final = re.compile(r"^/api/v1/jobs/\d+/log/?$")
+
+
+class LibraryFilter(logging.Filter):
+    """Filter to disallow log records based on the logger name."""
+
+    def __init__(self, library_names: list[str]) -> None:
+        """Initialize the filter.
+
+        Args:
+            library_names: A list of library names to filter out.
+        """
+        super().__init__()
+        self.library_names = library_names
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Determine if the specified record is to be logged.
+
+        Returns True if the record should be logged, or False otherwise. If deemed
+        appropriate, the record may be modified in-place.
+        """
+        # Allow the log record if its logger name is NOT in the specified libraries
+        return not any(
+            record.name.startswith(lib_name) for lib_name in self.library_names
+        )
+
+
+class OmitClientJobLoggingFilter(logging.Filter):
+    """
+    Filter to omit specific log records related to forwarding job logs to the Dioptra
+    API.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Determine if the specified record is to be logged.
+
+        Returns True if the record should be logged, or False otherwise. If deemed
+        appropriate, the record may be modified in-place.
+        """
+        # Allow the log record if its logger name is NOT associated with the client
+        # sessions module
+        if not record.name.startswith(CLIENT_SESSIONS_MODULE):
+            return True
+
+        # Allow the log record if it's not at the DEBUG level
+        if record.levelno != logging.DEBUG:
+            return True
+
+        # Allow the log record if it is not a general request or response log
+        message = record.getMessage()
+        if not message.startswith("Request made:") and not message.startswith(
+            "Response received:"
+        ):
+            return True
+
+        # Allow the log record if it doesn't have positional arguments (the args
+        # attribute is not a tuple)
+        args = record.args
+        if not isinstance(args, tuple):
+            return True
+
+        # Allow the log record if it has less than 2 positional arguments
+        if len(args) < 2:
+            return True
+
+        # Allow the log record if it is not a POST request
+        url, method = args[:2]
+        if str(method) != "POST":
+            return True
+
+        # Allow the log record if the target URL is not the job logging endpoint
+        endpoint_path = urllib.parse.urlparse(str(url)).path
+        if not JOB_LOG_PATH_RE.match(endpoint_path):
+            return True
+
+        # The log record is a request/response message emitted when the DioptraClient is
+        # forwarding a log to the /api/v1/jobs/{id}/log endpoint. We need to filter it
+        # out to prevent recursion.
+        return False

--- a/src/dioptra/sdk/utilities/logging/handlers.py
+++ b/src/dioptra/sdk/utilities/logging/handlers.py
@@ -85,12 +85,8 @@ class DioptraJobLoggingHandler(logging.handlers.BufferingHandler):
         """
         self.acquire()
         try:
-            try:
-                self.sender(job_id=self.job_id, logs=self._extract_logs_from_buffer())
-
-            except Exception:
-                for record in self.buffer:
-                    self.handleError(record)
+            if self.buffer:
+                self._send_buffered_logs()
 
             self.buffer.clear()
 
@@ -111,6 +107,14 @@ class DioptraJobLoggingHandler(logging.handlers.BufferingHandler):
 
             finally:
                 self.release()
+
+    def _send_buffered_logs(self) -> None:
+        try:
+            self.sender(job_id=self.job_id, logs=self._extract_logs_from_buffer())
+
+        except Exception:
+            for record in self.buffer:
+                self.handleError(record)
 
     def _extract_logs_from_buffer(self) -> list[dict[str, str]]:
         return [

--- a/src/dioptra/sdk/utilities/logging/handlers.py
+++ b/src/dioptra/sdk/utilities/logging/handlers.py
@@ -1,0 +1,123 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+
+import logging
+import logging.handlers
+from typing import Any, Protocol
+
+
+class JobLogSender(Protocol):
+    def __call__(self, job_id: str | int, logs: list[dict[str, str]]) -> Any:
+        """
+        Add log records for the given job. Job records are dicts of the form::
+
+            {
+                "severity": "WARNING",
+                "loggerName": "hello_world.tasks",
+                "message": "Log message",
+            }
+
+        Legal values for severity include DEBUG, INFO, WARNING, ERROR, CRITICAL. The
+        logger name captures the name of the logger that emitted the record.
+
+        Args:
+            job_id: The resource ID of a job.
+            logs: An iterable of log records.
+        """
+        ...
+
+
+class DioptraJobLoggingHandler(logging.handlers.BufferingHandler):
+    """
+    A handler class which buffers job log records in memory, periodically flushing them
+    using a sender to route the messages to the appropriate endpoint. Flushing occurs
+    whenever the buffer is full, or when an event of a certain severity or greater is
+    seen.
+    """
+
+    def __init__(
+        self,
+        sender: JobLogSender,
+        job_id: str | int,
+        capacity: int = 10,
+        flushLevel: int = logging.ERROR,
+    ) -> None:
+        """
+        Initialize this logging handler.
+
+        Args:
+            sender: A callable that sends log records to a Dioptra job.
+            job_id: The job ID to associate with the logs.
+            capacity: The maximum number of records to buffer before flushing.
+            flushLevel: The logging level at which to flush the buffer.
+        """
+        super().__init__(capacity)
+        self.sender = sender
+        self.job_id = job_id
+        self.flushLevel = flushLevel
+
+    def shouldFlush(self, record: logging.LogRecord) -> bool:
+        """
+        Check for buffer full or a record at the flushLevel or higher.
+        """
+        return (len(self.buffer) >= self.capacity) or (
+            record.levelno >= self.flushLevel
+        )
+
+    def flush(self) -> None:
+        """
+        For the DioptraJobLoggingHandler, flushing means just sending the buffered
+        records to the sender.
+        """
+        self.acquire()
+        try:
+            try:
+                self.sender(job_id=self.job_id, logs=self._extract_logs_from_buffer())
+
+            except Exception:
+                for record in self.buffer:
+                    self.handleError(record)
+
+            self.buffer.clear()
+
+        finally:
+            self.release()
+
+    def close(self) -> None:
+        """
+        Flush, if appropriately configured, and lose the buffer.
+        """
+        try:
+            self.flush()
+
+        finally:
+            self.acquire()
+            try:
+                super().close()
+
+            finally:
+                self.release()
+
+    def _extract_logs_from_buffer(self) -> list[dict[str, str]]:
+        return [
+            {
+                "severity": record.levelname,
+                "loggerName": record.name,
+                "message": self.format(record),
+            }
+            for record in self.buffer
+        ]

--- a/src/dioptra/worker/dioptra_worker_v1.py
+++ b/src/dioptra/worker/dioptra_worker_v1.py
@@ -26,6 +26,7 @@ import rq.cli
 
 from dioptra.sdk.utilities.logging import (
     attach_stdout_stream_handler,
+    configure_structlog_for_worker,
     set_logging_level,
 )
 
@@ -39,6 +40,7 @@ _REQUIRED_ENV = {
 
 
 def _setup_logging() -> None:
+    configure_structlog_for_worker()
     attach_stdout_stream_handler(
         True if os.getenv("DIOPTRA_RQ_WORKER_LOG_AS_JSON") else False,
     )


### PR DESCRIPTION
This update implements real-time log forwarding from the Dioptra workers to the API, enabling jobs to stream their logs for storage and retrieval. The implementation uses a context manager that attaches a custom logging handler during job execution, which buffers log records and periodically sends them to the API's job logging endpoint. The API client is authenticated using the worker credentials that are provided in environment variables and ensures logs are flushed even if jobs terminate unexpectedly.

The forwarding mechanism includes filters to prevent recursive logging loops when the client itself emits logs while sending data to the API, and to exclude noise from third-party libraries. The worker's logging configuration has been updated to use structured logging with proper formatting for both console output and API transmission.

A new unit test verifies that the messages emitted by multiple named loggers are forwarded to the API and recorded in the database while the context manager is active, and that out-of-context messages aren't captured.

Closes #925

---

Note: Logging Handlers in the Python stdlib use camelCase for naming methods instead of snake_case. The `DioptraJobLoggingHandler` class follows this convention since it is adapted from the source code for the `logging.handlers.MemoryHandler` class.