### PR TITLE
Duplicate artifact param error

### DIFF
--- a/src/dioptra/restapi/v1/entrypoints/service.py
+++ b/src/dioptra/restapi/v1/entrypoints/service.py
@@ -465,6 +465,11 @@ class EntrypointIdService(object):
         duplicates = find_non_unique("name", parameters)
         if len(duplicates) > 0:
             raise QueryParameterNotUniqueError(RESOURCE_TYPE, name=duplicates)
+        artifact_parameter_duplicates = find_non_unique("name", artifact_parameters)
+        if len(artifact_parameter_duplicates) > 0:
+            raise QueryParameterNotUniqueError(
+                RESOURCE_TYPE, name=artifact_parameter_duplicates
+            )
 
         entrypoint_dict = self.get(entrypoint_id, log=log)
 

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -247,7 +247,7 @@
             outlined 
             dense 
             v-model.trim="task.name"
-            :rules="[requiredRule, taskType === 'functions' ? uniqueFunctionName : uniqueArtifactName]"
+            :rules="[requiredRule]"
             class="q-mt-sm"
           >
             <template v-slot:before>
@@ -575,14 +575,6 @@
 
   function requiredRule(val) {
     return (!!val) || "This field is required"
-  }
-
-  function uniqueFunctionName(val) {
-    return (!pluginFile.value.tasks.functions.map(task => task.name).includes(val)) || "Duplicate task name"
-  }
-
-  function uniqueArtifactName(val) {
-    return (!pluginFile.value.tasks.artifacts.map(task => task.name).includes(val)) || "Duplicate task name"
   }
 
   function pythonFilenameRule(val) {


### PR DESCRIPTION
closes #921 

- Saving entrypoint with duplicate artifact param names causes 500.  It should raise the same error as when you have duplicate entrypoint param names.
-  In the plugin file form, remove frontend logic that checks for duplicate task names.  From our discussion on the call, the backend should handle most validation errors by itself.