### PR TITLE
Jk i920 worker env var

### DIFF
--- a/dev-kb/local-setup/MANUAL.md
+++ b/dev-kb/local-setup/MANUAL.md
@@ -4,10 +4,11 @@ The following are a set of manual instructions to set-up a local development env
 The instructions for the automated scripts can be found in [README.md](README.md).
 
 <!-- markdownlint-disable MD007 MD030 -->
-- [Note for Windows Users](#note-for-windows-users)
-- [Environment setup](#environment-setup)
-- [Limited frontend and REST API setup for Windows (no containers)](#limited-frontend-and-rest-api-setup-for-windows-no-containers)
-- [Full local development setup (no containers)](#full-local-development-setup-no-containers)
+- [Manual Instructions](#manual-instructions)
+  - [Note for Windows Users](#note-for-windows-users)
+  - [Environment setup](#environment-setup)
+  - [Limited frontend and REST API setup for Windows (no containers)](#limited-frontend-and-rest-api-setup-for-windows-no-containers)
+  - [Full local development setup (no containers)](#full-local-development-setup-no-containers)
 <!-- markdownlint-enable MD007 MD030 -->
 
 ## Note for Windows Users
@@ -151,6 +152,7 @@ It's also recommended that you install `tox` as a uv tool:
                 MLFLOW_TRACKING_URI="http://localhost:35000"     # If you're running a MLflow Tracking server, update this to point at it. Otherwise, this is a placeholder.
                 MLFLOW_S3_ENDPOINT_URL="http://localhost:35000"  # If you're running a MLflow Tracking server, update this to point at it. Otherwise, this is a placeholder.
                 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES   # Macs only, needed to make the RQ worker (i.e. the Dioptra Worker) work
+                DIOPTRA_WORKER_LIB=pytorch-cpu # Other options include: [pytorch-cpu | pytorch-gpu | tensorflow-cpu | tensorflow-cpu]
 
         -   Activate the python environment set-up in prior steps (e.g. `source .venv/bin/activate`)
         -   With the prior environment variables set then execute the following commands:

--- a/dev-kb/local-setup/README.md
+++ b/dev-kb/local-setup/README.md
@@ -80,6 +80,11 @@ DIOPTRA_DEPLOY_DIR=~/di/di-dep
 ### The source code location
 DIOPTRA_CODE_DIR=~/di/di-src
 
+### [NEW!!!] Mandatory entry Defaults to "tensorflow-cpu"
+### Worker-Type
+DIOPTRA_WORKER_LIB=tensorflow-cpu 
+### Other options include: [pytorch-cpu | pytorch-gpu | tensorflow-cpu | tensorflow-cpu]
+
 ### [OPTIONAL-ENTRY] Environment Info
 ### Auto-Generated from ENV, if not explicitly provided
 DIOPTRA_CONFIG_INFO=Dev-Dioptra for Tuning Unit-Tests
@@ -191,15 +196,16 @@ The `setup.sh` script will setup working and source directories using the config
 
 **Note:** The key names are **case-sensitive**.
 
-**Note:** The configuration file currently has the following four configuration parameter names:
+**Note:** The configuration file currently has the following configuration parameter names:
 
 -   DIOPTRA_GIT_BRANCH
 -   DIOPTRA_DEPLOY_DIR
 -   DIOPTRA_CODE_DIR
+-   DIOPTRA_WORKER_LIB
 -   DIOPTRA_CONFIG_INFO [OPTIONAL]
 -   DIOPTRA_ENV_NAME [OPTIONAL]
 
-See the [example]#a-configuration-file) above for usage. DIOPTRA_CONFIG_NAME is optional and will be composed (in case it is not provided) by the script using the mandatory keys.
+See the [example](#a-configuration-file) above for usage. DIOPTRA_CONFIG_NAME is optional and will be composed (in case it is not provided) by the script using the mandatory keys.
 
 **Note:** If you want to change the names of the config variables, then the script logic must be augmented to accommodate the changes. The names from within the config file are **mapped to the environment variables** and **do not directly become environment variables**. Case-insensitive configuration names are a nice-to-have feature.
 

--- a/dev-kb/local-setup/dev-set.sh
+++ b/dev-kb/local-setup/dev-set.sh
@@ -54,6 +54,7 @@ set_display_env_details(){
       \tbranch-id:\t$DIOPTRA_BRANCH
       \tcode-dir:\t$DIOPTRA_CODE
       \tdeploy-dir:\t$DIOPTRA_DEPLOY
+      \tworker-
       \n"
   fi
   printf "To recall "Environment Info:" below use command: printf \"\${DIOPTRA_CONFIG_DETAILS}\"\nEnvironment Info:$DIOPTRA_CONFIG_DETAILS\n"
@@ -95,6 +96,9 @@ read_properties_from_file()
         ;;
       "DIOPTRA_CONFIG_INFO")
         export DIOPTRA_CONFIG_INFO="$value"
+        ;;
+      "DIOPTRA_WORKER_LIB")
+        export DIOPTRA_WORKER_LIB="$value"
         ;;
       "DIOPTRA_ENV_NAME")
         export DIOPTRA_ENV_NAME="$value"
@@ -156,15 +160,19 @@ read_cli_parameters()
         export DIOPTRA_CODE="${2}"
         shift
         ;;
+      --lib|-l)
+        export DIOPTRA_WORKER_LIB="${2}"
+        shift
+        ;;      
       --environment|--env|-e)
         export DIOPTRA_ENV_FILE="${2}"
-        echo "Reading ${DIOPTRA_ENV_FILE@Q} file"
+        echo "Reading ${DIOPTRA_ENV_FILE} file"
         read_properties_from_file "${DIOPTRA_ENV_FILE}"
         shift
         break
         ;;
       *)
-        printf "Error: Incorrect Parameter [${1} ${2}]\n"
+        printf "Error: Incorrect CLI Parameter [${1} ${2}]\n"
         ### return 1
         shift
         ;;
@@ -172,6 +180,8 @@ read_cli_parameters()
     shift
   done
 }
+
+
 ##################################################################################
 ### Script Main-Body
 ##################################################################################
@@ -182,7 +192,10 @@ unset DIOPTRA_CODE
 unset DIOPTRA_DEPLOY
 unset DIOPTRA_CONFIG_INFO
 unset DIOPTRA_CONFIG_DETAILS
-
+# Add setting the default value of the env-variable
+# DIOPTRA_WORKER_LIB to tensorflow-cpu so the 
+# existing functionality keeps on working
+export DIOPTRA_WORKER_LIB=tensorflow-cpu
 
 # if [ -n "${BASH_VERSION}" ]; then
 #   printf "\nStarting script with BASH Version: ${BASH_VERSION}\n"

--- a/dev-kb/local-setup/run-worker.sh
+++ b/dev-kb/local-setup/run-worker.sh
@@ -16,4 +16,4 @@ uv sync --extra worker --extra "${_dioptra_worker_lib}"
 
 source ${DIOPTRA_CODE}/${DIOPTRA_VENV}/bin/activate
 cd ${DIOPTRA_DEPLOY}/workdir
-dioptra-worker-v1 'Tensorflow CPU'
+dioptra-worker-v1 "Configured-as: $_dioptra_worker_lib"


### PR DESCRIPTION
Added the env-variable as described to the `dev-set.sh` Now the variable defaults to the tensorflow-cpu, but will read the variable value if provided as an -l|--lib option from the CLI-style call or will read it from the environment config file. Tested and verified that the variable propagates to the TMux setup as well