### PR TITLE
Job logs UI

### DIFF
--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -115,6 +115,7 @@
     </template>
 
     <template #top-right>
+      <slot name="jobLogSlot" />
       <q-btn
         v-if="!hideCreateBtn" 
         color="primary" 
@@ -278,6 +279,10 @@
   }
 
   let invalidSearchNotification = notify.wait()
+
+  // watch(() => props.rows, (newVal) => {
+  //   loading.value = false
+  // })
 
   function onRequest(props) {
     const searchError = checkSearch(props.filter)

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -241,7 +241,28 @@ export async function getJobs(id: number, pagination: Pagination) {
 
 export async function getJobMetrics(id: number) {
   return await axios.get(`/api/jobs/${id}/metrics`)
+}
 
+export async function getJobLogs(id: number, pagination: Pagination) {
+  const res = await axios.get(`/api/jobs/${id}/log`, {
+    params: {
+      index: pagination.index,
+      pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
+      search: pagination.search,
+    },
+  })
+
+  // if GET ALL (rowsPerPage = 0), then keep on getting next page until there is no next
+  if(pagination.rowsPerPage === 0 && res.data.next) {
+    let nextUrl = res.data.next.replace("/v1", "")
+    while (nextUrl) {
+      const response = await axios.get(nextUrl)
+      res.data.data.push(...response.data.data)
+      nextUrl = response.data.next ? response.data.next.replace("/v1", "") : null
+    }
+  }
+
+  return res
 }
 
 export async function getItem<T extends ItemType>(type: T, id: number, isDraft: boolean = false) {

--- a/src/frontend/src/views/JobsView.vue
+++ b/src/frontend/src/views/JobsView.vue
@@ -99,8 +99,7 @@
   }
 
   const artifactColumns = [
-    { name: 'description', label: 'Description', align: 'left', field: 'description', sortable: true, },
-    { name: 'uri', label: 'uri', align: 'left', field: 'uri', sortable: true, },
+    { name: 'id', label: 'id', align: 'left', field: 'id', sortable: true, },
   ]
 
   const selected = ref([])


### PR DESCRIPTION
closes #927 

- Display job logs in job dashboard page, in a table
- show expand/collapse button if log is over 10 lines long
- all code editors will now follow the same light/dark mode as the overall page
- added filter severity dropdown