### PR TITLE
feat: job dashboard updates

### DIFF
--- a/src/dioptra/restapi/v1/utils.py
+++ b/src/dioptra/restapi/v1/utils.py
@@ -785,6 +785,10 @@ def build_job(job_dict: JobDict) -> dict[str, Any]:
             param.parameter.name: param.value
             for param in job.entry_point_job.entry_point_parameter_values
         },
+        "artifact_values": {
+            av.artifact_parameter.name: build_artifact_value(av.artifact)
+            for av in job.entry_point_job.entry_point_artifact_parameter_values
+        },
         "timeout": job.timeout,
         "user": build_user_ref(job.creator),
         "group": build_group_ref(job.resource.owner),
@@ -889,6 +893,21 @@ def build_artifact_artifact_task(artifact: models.Artifact) -> dict[str, Any]:
         "plugin_file_resource_id": artifact.plugin_plugin_file.plugin_file.resource_id,
         "plugin_file_resource_snapshot_id": artifact.plugin_plugin_file.plugin_file.resource_snapshot_id,
         **_build_artifact_task(plugin_task=artifact.task),
+    }
+
+
+def build_artifact_value(artifact: models.Artifact) -> dict[str, Any]:
+    """Build a JobArtifactValue dictionary.
+
+    Args:
+        artifact: The Artifact object to convert into a JobArtifactValue dictionary.
+
+    Returns:
+        The JobArtifactValue dictionary.
+    """
+    return {
+        "id": artifact.resource_id,
+        "snapshot_id": artifact.resource_snapshot_id,
     }
 
 

--- a/src/frontend/src/components/JobArtifactsTable.vue
+++ b/src/frontend/src/components/JobArtifactsTable.vue
@@ -1,0 +1,73 @@
+<template>
+  <TableComponent
+    :rows="artifacts"
+    :columns="columns"
+    :title="`Artifacts Created by Job ${route.params.id}`"
+    v-model:selected="selected"
+    @edit="router.push(`/artifacts/${selected[0].id}`)"
+    :hideDeleteBtn="true"
+    :hideCreateBtn="true"
+  >
+    <template #body-cell-taskName="props">
+      {{ props.row.task.name }}
+    </template>
+    <template #body-cell-taskOutputParams="props">
+      <q-chip
+        v-for="param in props.row.task.outputParams"
+        color="purple"
+        text-color="white"
+        dense
+      >
+        {{ param.name }}: {{ param.parameterType.name }}
+      </q-chip>
+    </template>
+    <template #body-cell-download="props">
+      <q-btn
+        :href="props.row.fileUrl"
+        :download="`artifact-${props.row?.id}`"
+        color="primary"
+        round
+        icon="download"
+        size="sm"
+        @click.stop
+      />
+    </template>
+  </TableComponent>
+</template>
+
+<script setup>
+import TableComponent from '@/components/TableComponent.vue'
+import { ref, onMounted } from 'vue'
+import * as api from '@/services/dataApi'
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+const props = defineProps(['artifactIds'])
+const selected = ref([])
+
+onMounted(() => {
+  getArtifacts()
+})
+
+const artifacts = ref([])
+
+async function getArtifacts() {
+  try {
+    for (let id of props.artifactIds) {
+      const res = await api.getItem('artifacts', id)
+      artifacts.value.push(res.data)
+    }
+  } catch(err) {
+    console.warn(err)
+  }
+}
+
+const columns = [
+  { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: true },
+  { name: 'taskName', label: 'Task Name', align: 'left' },
+  { name: 'taskOutputParams', label: 'Task Output Params', align: 'left' },
+  { name: 'download', label: 'Download', align: 'center' },
+]
+</script>

--- a/src/frontend/src/views/EditArtifactView.vue
+++ b/src/frontend/src/views/EditArtifactView.vue
@@ -170,6 +170,9 @@ onMounted(async() => {
   await getArtifact()
   await getPluginSnapshot()
   await getFileSnapshot()
+  if(route.query.snapshotId && !store.showRightDrawer) {
+    store.showRightDrawer = true
+  }
 })
 
 const artifact = ref({

--- a/tests/unit/restapi/v1/test_job.py
+++ b/tests/unit/restapi/v1/test_job.py
@@ -114,6 +114,7 @@ def assert_job_response_contents_matches_expectations(
         "experiment",
         "entrypoint",
         "artifacts",
+        "artifactValues"
     }
     assert set(response.keys()) == expected_keys
 


### PR DESCRIPTION
Closes job dashboard part of #914 

Job Dashboard page updates
- artifacts produced goes on artifact outputs tab
- artifacts used goes on main job overview page
- move metrics table to metrics tab above plots
- rename Model metrics to Metrics
- remove System metrics tab