### PR TITLE
feat: replace plugin task form with dialogs

### DIFF
--- a/src/frontend/src/dialogs/ArtifactParamDialog.vue
+++ b/src/frontend/src/dialogs/ArtifactParamDialog.vue
@@ -1,8 +1,8 @@
 <template>
-  <q-dialog v-model="showDialog">
+  <q-dialog v-model="showDialog" :persistent="true">
     <q-card>
       <q-card-section class="bg-primary text-white text-h6">
-        <div class="text-h6">Add Artifact Parameter</div>
+        <div class="text-h6">Create Artifact Parameter</div>
       </q-card-section>
       <q-card-section>
         <q-form ref="artifactParamForm" greedy @submit.prevent="addArtifactParam" id="artifactForm">
@@ -17,7 +17,7 @@
               <label :class="`field-label`">Name:</label>
             </template>
           </q-input>
-          <div class="row items-end" style="height: 30px;">
+          <div class="row items-end" style="min-height: 30px;">
             <label>
               Output Parameters:
             </label>
@@ -121,7 +121,7 @@ function requiredRule(val) {
 
 watch(showDialog, (newVal) => {
   getPluginParameterTypes()
-  if(newVal) {
+  if(!newVal) {
     artifactParam.value = {
       name: '',
       outputParams: []
@@ -130,6 +130,7 @@ watch(showDialog, (newVal) => {
       name: '',
       parameterType: ''
     }
+    resetForm()
   }
 })
 
@@ -155,9 +156,6 @@ function addOutputParam() {
       outputParam.value = {}
       outputParamForm.value.reset()
     }
-    else {
-      // error
-    }
   })
 }
 
@@ -170,9 +168,6 @@ function addArtifactParam() {
       }
       emit('submit', submitArtifactParam)
       resetForm()
-    }
-    else {
-      // error
     }
   })
 }

--- a/src/frontend/src/dialogs/ImportPluginTasksDialog.vue
+++ b/src/frontend/src/dialogs/ImportPluginTasksDialog.vue
@@ -170,7 +170,7 @@ import TableComponent from '@/components/TableComponent.vue'
 import * as notify from '../notify'
 
 const props = defineProps(['pythonCode', 'pluginParameterTypes', 'existingTasks'])
-const emit = defineEmits(['addTasks'])
+const emit = defineEmits(['importTasks'])
 
 const showDialog = defineModel()
 
@@ -241,8 +241,8 @@ async function suggestPluginTasks() {
 const taskColumns = [
   { name: 'select', label: 'Select', align: 'center', },
   { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: false,  },
-  { name: 'inputParams', label: 'Input Params', field: 'inputParams', align: 'right', sortable: false, style: 'width: 150px', },
-  { name: 'outputParams', label: 'Output Params', field: 'outputParams', align: 'right', sortable: false, style: 'width: 150px' },
+  { name: 'inputParams', label: 'Input Parameters', field: 'inputParams', align: 'right', sortable: false, style: 'width: 150px', },
+  { name: 'outputParams', label: 'Output Parameters', field: 'outputParams', align: 'right', sortable: false, style: 'width: 150px' },
 ]
 
 async function submit() {
@@ -256,7 +256,7 @@ async function submit() {
       delete param.type
     })
   })
-  emit('addTasks', selectedTasks.value)
+  emit('importTasks', selectedTasks.value)
   showDialog.value = false
 }
 

--- a/src/frontend/src/dialogs/PluginTaskDialog.vue
+++ b/src/frontend/src/dialogs/PluginTaskDialog.vue
@@ -1,0 +1,259 @@
+<template>
+  <q-dialog v-model="showDialog" :persistent="true">
+    <q-card>
+      <q-card-section class="bg-primary text-white text-h6">
+        <div class="text-h6">Create {{ taskType === 'functions' ? 'Function' : 'Artifact' }} Task</div>
+      </q-card-section>
+      <q-card-section>
+        <q-form ref="taskForm" @submit.prevent="addTask" id="taskForm">
+          <q-input 
+            outlined 
+            dense 
+            v-model.trim="task.name"
+            :rules="[requiredRule]"
+            class="q-mt-sm"
+          >
+            <template v-slot:before>
+              <label :class="`field-label`">Task Name:</label>
+            </template>
+          </q-input>
+          <div class="row items-end" style="min-height: 30px;" v-if="taskType === 'functions'">
+            <label>
+              Input Parameters:
+            </label>
+            <q-chip
+              v-for="(param, i) in inputParams"
+              :key="i"
+              color="indigo"
+              text-color="white"
+              removable
+              dense
+              @remove="inputParams.splice(i, 1)"
+            >
+              {{ `${param.name}` }}
+              <span v-if="param.required" class="text-red">*</span>
+              {{ `: ${param.parameterType.name}` }}
+            </q-chip>
+          </div>
+          <q-form ref="inputParamForm" greedy @submit.prevent="addInputParam" v-if="taskType === 'functions'">
+            <div class="row">
+              <q-input
+                v-model.trim="inputParam.name"
+                label="Name"
+                :rules="[requiredRule]"
+                dense
+                outlined
+                class="col q-mr-sm"
+                style="width: 300px;"
+              />
+              <q-select 
+                v-model="inputParam.parameterType"
+                emit-value
+                option-value="id"
+                option-label="name"
+                map-options
+                label="Type"
+                :options="pluginParameterTypes"
+                class="col q-mr-xl"
+                outlined
+                dense
+                :rules="[requiredRule]"
+              />
+              <div class="col">
+                <q-checkbox
+                  label="Required"
+                  left-label
+                  v-model="inputParam.required"
+                />
+              </div>
+              <q-btn
+                round
+                icon="add"
+                color="indigo"
+                style="height: 10px"
+                class="q-mr-sm"
+                @click="addInputParam()"
+              >
+                <span class="sr-only">Add Input Parameter</span>
+                <q-tooltip>
+                  Add Input Parameter
+                </q-tooltip>
+              </q-btn>
+            </div>
+          </q-form>
+          
+          <div class="row items-end" style="min-height: 30px;">
+            <label>
+              Output Parameters:
+            </label>
+            <q-chip
+              v-for="(param, i) in outputParams"
+              :key="i"
+              color="purple"
+              text-color="white"
+              removable
+              dense
+              @remove="outputParams.splice(i, 1)"
+              :label="`${param.name}: ${param.parameterType.name}`"
+            />
+          </div>
+          <q-form ref="outputParamForm" greedy @submit.prevent="addOutputParam">
+            <div class="row">
+              <q-input
+                v-model.trim="outputParam.name"
+                label="Name"
+                :rules="[requiredRule]"
+                dense
+                outlined
+                class="col q-mr-sm"
+                style="width: 370px;"
+              />
+              <q-select 
+                v-model="outputParam.parameterType"
+                emit-value
+                option-value="id"
+                option-label="name"
+                map-options
+                label="Type"
+                :options="pluginParameterTypes"
+                class="col q-mr-xl"
+                outlined
+                dense
+                :rules="[requiredRule]"
+              />
+              <div class="col" v-if="taskType==='functions'"></div>
+              <q-btn
+                round
+                icon="add"
+                color="purple"
+                style="height: 10px"
+                class="q-mr-sm"
+                @click="addOutputParam()"
+              >
+                <span class="sr-only">Add Output Parameter</span>
+                <q-tooltip>
+                  Add Output Parameter
+                </q-tooltip>
+              </q-btn>
+            </div>
+          </q-form>
+        </q-form>
+      </q-card-section>
+
+      <q-separator />
+
+      <q-card-actions align="right">
+        <q-btn 
+          outline
+          color="primary cancel-btn" 
+          label="Cancel" 
+          v-close-popup 
+          class="q-mr-xs"
+        />
+        <q-btn
+          label="Confirm"
+          color="primary"
+          type="submit"
+          form="taskForm"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps(['taskType', 'pluginParameterTypes'])
+
+const emit = defineEmits(['submit'])
+
+const showDialog = defineModel()
+
+const inputParam = ref({
+  name: '',
+  parameterType: '',
+  required: true
+})
+const outputParam = ref({
+  name: '',
+  parameterType: ''
+})
+
+const inputParams = ref([])
+const outputParams = ref([])
+
+const task = ref({})
+
+const taskForm = ref(null)
+const inputParamForm = ref(null)
+const outputParamForm = ref(null)
+
+
+function requiredRule(val) {
+  return (!!val) || "This field is required"
+}
+
+function addTask() {
+  taskForm.value.validate().then(success => {
+    if(success) {
+      emit('submit', {
+        name: task.value.name,
+        inputParams: inputParams.value,
+        outputParams: outputParams.value
+      })
+      showDialog.value = false
+    }
+  })
+}
+
+function addInputParam() {
+  inputParamForm.value.validate().then(success => {
+    if (success) {
+      const type = props.pluginParameterTypes.find((paramType) => paramType.id === inputParam.value.parameterType)
+      inputParam.value.parameterType = {
+        name: type.name,
+        id: type.id
+      }
+      inputParams.value.push(inputParam.value)
+      inputParam.value = {}
+      inputParam.value.required = true
+      inputParamForm.value.reset()
+    }
+  })
+}
+
+function addOutputParam() {
+  outputParamForm.value.validate().then(success => {
+    if (success) {
+      const type = props.pluginParameterTypes.find((paramType) => paramType.id === outputParam.value.parameterType)
+      outputParam.value.parameterType = {
+        name: type.name,
+        id: type.id
+      }
+      outputParams.value.push(outputParam.value)
+      outputParam.value = {}
+      outputParamForm.value.reset()
+    }
+  })
+}
+
+function resetTaskForm() {
+  task.value ={}
+  taskForm.value.reset()
+  inputParam.value = { required: true }
+  outputParam.value = {}
+  inputParams.value = []
+  outputParams.value = []
+  inputParamForm.value?.reset()
+  outputParamForm.value?.reset()
+}
+
+
+watch(showDialog, (newVal) => {
+  if(!newVal) {
+    resetTaskForm()
+  }
+})
+
+</script>

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -62,7 +62,7 @@
           <q-btn
             label="Import Function Tasks"
             color="primary"
-            @click="showTasksDialog = true"
+            @click="showImportTasksDialog = true;"
           />
         </div>
 
@@ -82,12 +82,12 @@
         :columns="taskColumns"
         title="Plugin Function Tasks"
         :hideToggleDraft="true"
-        :hideCreateBtn="true"
         :hideSearch="true"
         :disableSelect="true"
         :hideOpenBtn="true"
         :hideDeleteBtn="true"
         rightCaption="*Click param to edit, or X to delete"
+        @create="showTaskDialog=true; taskType='functions'"
       >
         <template #body-cell-name="props">
         <div style="font-size: 18px;">
@@ -183,12 +183,12 @@
         :columns="taskColumns"
         title="Plugin Artifact Tasks"
         :hideToggleDraft="true"
-        :hideCreateBtn="true"
         :hideSearch="true"
         :disableSelect="true"
         :hideOpenBtn="true"
         :hideDeleteBtn="true"
         rightCaption="*Click param to edit, or X to delete"
+        @create="showTaskDialog=true; taskType='artifacts'"
       >
         <template #body-cell-name="props">
         <div style="font-size: 18px;">
@@ -235,162 +235,19 @@
           />
         </template>
       </TableComponent>
-      <q-card bordered class="q-ma-lg">
-        <q-card-section>
-          <div class="text-h6">Task Form</div>
-        </q-card-section>
-        <q-form ref="taskForm" greedy @submit.prevent="addTask" class="q-mx-lg">
-          Task Type:
-          <q-radio v-model="taskType" val="functions" label="Function" style="margin-left: 30px;" />
-          <q-radio v-model="taskType" val="artifacts" label="Artifact" />
-          <q-input 
-            outlined 
-            dense 
-            v-model.trim="task.name"
-            :rules="[requiredRule]"
-            class="q-mt-sm"
-          >
-            <template v-slot:before>
-              <label :class="`field-label`">Task Name:</label>
-            </template>
-          </q-input>
-          <label v-if="taskType === 'functions'">
-            Input Params:
-          </label>
-          <q-chip
-            v-for="(param, i) in inputParams"
-            v-if="taskType === 'functions'"
-            :key="i"
-            color="indigo"
-            text-color="white"
-            removable
-            @remove="inputParams.splice(i, 1)"
-          >
-            {{ `${param.name}` }}
-            <span v-if="param.required" class="text-red">*</span>
-            {{ `: ${param.parameterType.name}` }}
-          </q-chip>
-          <q-form ref="inputParamForm" greedy @submit.prevent="addInputParam" v-if="taskType === 'functions'">
-            <div class="row">
-              <q-input
-                v-model.trim="inputParam.name"
-                label="Input Param Name"
-                :rules="[requiredRule]"
-                dense
-                outlined
-                class="col q-mr-sm"
-              />
-              <q-select 
-                v-model="inputParam.parameterType"
-                emit-value
-                option-value="id"
-                option-label="name"
-                map-options
-                label="Param Type"
-                :options="pluginParameterTypes"
-                class="col q-mr-xl"
-                outlined
-                dense
-                :rules="[requiredRule]"
-              />
-              <div class="col">
-                <q-checkbox
-                  label="Required"
-                  left-label
-                  v-model="inputParam.required"
-                />
-              </div>
-              <q-btn
-                round
-                icon="add"
-                color="indigo"
-                style="height: 10px"
-                class="q-mr-sm"
-                @click="addInputParam()"
-              >
-                <span class="sr-only">Add Input Param</span>
-                <q-tooltip>
-                  Add Input Param
-                </q-tooltip>
-              </q-btn>
-            </div>
-          </q-form>
-
-          <label>
-            Output Params:
-          </label>
-          <q-chip
-            v-for="(param, i) in outputParams"
-            :key="i"
-            color="purple"
-            text-color="white"
-            removable
-            @remove="outputParams.splice(i, 1)"
-            :label="`${param.name}: ${param.parameterType.name}`"
-          />
-          <q-form ref="outputParamForm" greedy @submit.prevent="addOutputParam">
-            <div class="row">
-              <q-input
-                v-model.trim="outputParam.name"
-                label="Output Param Name"
-                :rules="[requiredRule]"
-                dense
-                outlined
-                class="col q-mr-sm"
-              />
-              <q-select 
-                v-model="outputParam.parameterType"
-                emit-value
-                option-value="id"
-                option-label="name"
-                map-options
-                label="Param Type"
-                :options="pluginParameterTypes"
-                class="col q-mr-xl"
-                outlined
-                dense
-                :rules="[requiredRule]"
-              />
-              <div class="col"></div>
-              <q-btn
-                round
-                icon="add"
-                color="purple"
-                style="height: 10px"
-                class="q-mr-sm"
-                @click="addOutputParam()"
-              >
-                <span class="sr-only">Add Output Param</span>
-                <q-tooltip>
-                  Add Output Param
-                </q-tooltip>
-              </q-btn>
-            </div>
-          </q-form>
-
-          <q-card-actions align="right">
-            <q-btn
-              label="Add Task"
-              color="secondary"
-              icon="add"
-              type="submit"
-            />
-          </q-card-actions>
-        </q-form>
-      </q-card>
 
       <q-expansion-item
-        :label="`${showParamTypes ? 'Hide' : 'Show'} Plugin Param Types`"
+        :label="`${showParamTypes ? 'Hide' : 'Show'} Plugin Parameter Types`"
         v-model="showParamTypes"
         header-class="text-bold shadow-2"
-        class="q-mb-md"
+        class="q-mb-md q-mt-lg"
         ref="expansionItem"
         @after-show="scroll"
       >
         <TableComponent
           :rows="pluginParameterTypes"
           :columns="columns"
-          title="Plugin Param Types"
+          title="Plugin Parameter Types"
           @request="getPluginParameterTypes"
           :hideToggleDraft="true"
           :hideCreateBtn="true"
@@ -471,13 +328,21 @@
     v-model="showReturnDialog"
     @cancel="clearForm"
   />
-  <PluginTasksDialog
-    v-model="showTasksDialog"
+  <ImportPluginTasksDialog
+    v-model="showImportTasksDialog"
     :pythonCode="pluginFile.contents"
     :pluginParameterTypes="pluginParameterTypes"
     :existingTasks="JSON.parse(JSON.stringify(pluginFile.tasks.functions))"
-    @addTasks="addInferedTasks"
+    @importTasks="addInferedTasks"
   />
+  <PluginTaskDialog
+    v-model="showTaskDialog"
+    :taskType="taskType"
+    :pluginParameterTypes="pluginParameterTypes"
+    @submit="(task) => pluginFile.tasks[taskType].push(task)"
+  />
+
+  <!-- pluginFile.value.tasks[taskType.value].push(task) -->
 </template>
 
 <script setup>
@@ -494,7 +359,8 @@
   import LeaveFormDialog from '@/dialogs/LeaveFormDialog.vue'
   import ReturnToFormDialog from '@/dialogs/ReturnToFormDialog.vue'
   import { useLoginStore } from '@/stores/LoginStore'
-  import PluginTasksDialog from '@/dialogs/PluginTasksDialog.vue'
+  import ImportPluginTasksDialog from '@/dialogs/ImportPluginTasksDialog.vue'
+  import PluginTaskDialog from '@/dialogs/PluginTaskDialog.vue'
 
   const store = useLoginStore()
   
@@ -678,31 +544,12 @@
     { name: 'view', label: 'Structure', align: 'left', sortable: false },
   ]
 
-  const inputParam = ref({
-    name: '',
-    parameterType: '',
-    required: true
-  })
-  const outputParam = ref({
-    name: '',
-    parameterType: ''
-  })
-
-  const inputParams = ref([])
-  const outputParams = ref([])
-
-  const task = ref({
-  })
-
   const basicInfoForm = ref(null)
-  const taskForm = ref(null)
-  const inputParamForm = ref(null)
-  const outputParamForm = ref(null)
 
   const taskColumns = [
     { name: 'name', label: 'Name', align: 'left', field: 'name', sortable: false, classes: 'vertical-top', },
-    { name: 'inputParams', label: 'Input Params', field: 'inputParams', align: 'right', sortable: false, classes: 'vertical-top', },
-    { name: 'outputParams', label: 'Output Params', field: 'outputParams', align: 'right', sortable: false, classes: 'vertical-top', },
+    { name: 'inputParams', label: 'Input Parameters', field: 'inputParams', align: 'right', sortable: false, classes: 'vertical-top', },
+    { name: 'outputParams', label: 'Output Parameters', field: 'outputParams', align: 'right', sortable: false, classes: 'vertical-top', },
     { name: 'actions', label: 'Actions', align: 'center', },
   ]
 
@@ -715,59 +562,6 @@
     } catch(err) {
       notify.error(err.response.data.message)
     } 
-  }
-
-  function addInputParam() {
-    inputParamForm.value.validate().then(success => {
-      if (success) {
-        const type = pluginParameterTypes.value.find((paramType) => paramType.id === inputParam.value.parameterType)
-        inputParam.value.parameterType = {
-          name: type.name,
-          id: type.id
-        }
-        inputParams.value.push(inputParam.value)
-        inputParam.value = {}
-        inputParam.value.required = true
-        inputParamForm.value.reset()
-      }
-      else {
-        // error
-      }
-    })
-  }
-
-  function addOutputParam() {
-    outputParamForm.value.validate().then(success => {
-      if (success) {
-        const type = pluginParameterTypes.value.find((paramType) => paramType.id === outputParam.value.parameterType)
-        outputParam.value.parameterType = {
-          name: type.name,
-          id: type.id
-        }
-        outputParams.value.push(outputParam.value)
-        outputParam.value = {}
-        outputParamForm.value.reset()
-      }
-      else {
-        // error
-      }
-    })
-  }
-
-  function addTask() {
-    taskForm.value.validate().then(success => {
-      if(success) {
-        pluginFile.value.tasks[taskType.value].push({
-          name: task.value.name,
-          inputParams: inputParams.value,
-          outputParams: outputParams.value
-        })
-        resetTaskForm()
-      }
-      else {
-        // error
-      }
-    })
   }
 
   function addInferedTasks(tasks) {
@@ -868,24 +662,8 @@
     }
   }
 
-  const showTasksDialog = ref(false)
+  const showImportTasksDialog = ref(false)
+  const showTaskDialog = ref(false)
   const taskType = ref('functions')
-
-  watch(() => taskType.value, () => {
-    resetTaskForm()
-  })
-
-  function resetTaskForm() {
-    task.value ={}
-    taskForm.value.reset()
-    inputParam.value = { required: true }
-    outputParam.value = {}
-    inputParams.value = []
-    outputParams.value = []
-    inputParamForm.value?.reset()
-    outputParamForm.value?.reset()
-  }
-
-
 
 </script>


### PR DESCRIPTION
Closes pluginfile form checkbox of #971 

- In pluginFile page, replace task form with dialogs
- rename params to parameters


Other fixes to the plugiFile tasks dialog and also the entrypoint artifact parameter dialog
- When the chips overflow, it should push the content down and not overlap
- Entrypoint artifact param dialog wasn't resetting when closing and opening
- When adding alot of chips, I sometimes click outside the dialog, accidentally clearing everything.  So for these dialogs I made it persistent so you have to hit the cancel or submit button to close.  I can also make it persistent only if the user fills something out, let me know what you think.
