### PR TITLE
fix(frontend): fix issue syncing or adding plugins to an entrypoint

### DIFF
--- a/src/frontend/src/dialogs/AssignPluginsDialog.vue
+++ b/src/frontend/src/dialogs/AssignPluginsDialog.vue
@@ -112,7 +112,7 @@
 
     try {
       if(pluginsToAdd.length > 0) {
-        await api.addPluginsToEntrypoint(props.editObj.id, pluginsToAdd) 
+        await api.addPluginsToEntrypoint(props.editObj.id, pluginsToAdd, 'plugins')
       }
       for(const plugin of pluginsToRemove) {
         await api.removePluginFromEntrypoint(props.editObj.id, plugin)

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -164,7 +164,7 @@
 
   async function syncPlugin(entrypointId, pluginId, pluginName) {
     try {
-      await api.addPluginsToEntrypoint(entrypointId, [pluginId]) 
+      await api.addPluginsToEntrypoint(entrypointId, [pluginId], 'plugins')
       tableRef.value.refreshTable()
       notify.success(`Successfully updated plugin '${pluginName}' to latest version`)
     } catch(err) {


### PR DESCRIPTION
This commit fixes an issue in the frontend where the following resulted in a 404 error:
- sync an entrypoint to the latest snapshot of a plugin
- assign a plugin to an entrypoint

The frontend was updated to request the correct endpoint for both operations.


closes #990 and #992