### PR TITLE
Plugin dropdown component

### DIFF
--- a/src/frontend/src/components/AssignPluginsDropdown.vue
+++ b/src/frontend/src/components/AssignPluginsDropdown.vue
@@ -1,0 +1,116 @@
+<template>
+  <q-select
+    outlined
+    dense
+    v-model="selectedPlugins"
+    use-input
+    use-chips
+    multiple
+    option-label="name"
+    option-value="id"
+    input-debounce="100"
+    :options="pluginOptions"
+    @filter="getPlugins"
+    @add="(added) => addPlugin(added.value)"
+    @remove="(removed) => removePlugin(removed.value)"
+  >
+    <template v-slot:before>
+      <div class="field-label">Plugins:</div>
+    </template>
+    <template v-slot:selected>
+      <div>
+        <div
+          v-for="(plugin, i) in selectedPlugins"
+          :key="plugin.id"
+          :class="i > 0 ? 'q-mt-xs' : ''"
+          >
+            <q-chip
+              removable
+              color="secondary"
+              text-color="white"
+              class="q-ml-xs "
+              @remove="selectedPlugins.splice(i, 1); removePlugin(plugin)"
+            >
+              {{ plugin.name }}
+              <q-badge
+                v-if="!plugin.latestSnapshot" 
+                color="red" 
+                label="outdated" 
+                rounded
+                class="q-ml-xs"
+              />
+            </q-chip>
+            <q-btn
+              v-if="!plugin.latestSnapshot"
+              round 
+              color="red" 
+              icon="sync"
+              size="sm"
+              @click.stop="syncPlugin(plugin.id, i)"
+            >
+              <q-tooltip>
+                Sync to latest version of plugin
+              </q-tooltip>
+            </q-btn>
+        </div>
+      </div>
+    </template>
+  </q-select>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import * as api from '@/services/dataApi'
+
+const selectedPlugins = defineModel('selectedPlugins')
+const originalSelectedPluginIds = ref([])
+
+watch(selectedPlugins, (newVal) => {
+  originalSelectedPluginIds.value = newVal.map(p => p.id)
+  },
+  { once: true }
+)
+
+const pluginIDsToUpdate = defineModel('pluginIDsToUpdate')
+const pluginIDsToRemove = defineModel('pluginIDsToRemove')
+
+const pluginOptions = ref([])
+
+async function getPlugins(val = '', update) {
+  update(async () => {
+    try {
+      const res = await api.getData('plugins', {
+        search: val,
+        rowsPerPage: 0, // get all
+        index: 0
+      })
+      pluginOptions.value = res.data.data
+    } catch(err) {
+      notify.error(err.response.data.message)
+    } 
+  })
+}
+
+async function syncPlugin(pluginId, index) {
+  try {
+    const res = await api.getItem('plugins', pluginId)
+    selectedPlugins.value.splice(index, 1, res.data)
+    pluginIDsToUpdate.value.push(pluginId)
+  } catch(err) {
+    console.warn(err)
+  }
+}
+
+function addPlugin(plugin) {
+  pluginIDsToUpdate.value.push(plugin.id)
+  pluginIDsToRemove.value = pluginIDsToRemove.value.filter((id) => id !== plugin.id)
+}
+
+function removePlugin(plugin) {
+  if(originalSelectedPluginIds.value.includes(plugin.id)) {
+    pluginIDsToRemove.value.push(plugin.id)
+  }
+  pluginIDsToUpdate.value = pluginIDsToUpdate.value.filter((id) => id !== plugin.id)
+}
+
+</script>

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -397,8 +397,8 @@ export async function addPluginsToEntrypoint(id: string, plugins: number[], plug
   return await axios.post(`/api/entrypoints/${id}/${pluginType}`, {[pluginType]: plugins})
 }
 
-export async function removePluginFromEntrypoint(entrypointId: string, pluginId: number) {
-  return await axios.delete(`/api/entrypoints/${entrypointId}/plugins/${pluginId}`)
+export async function removePluginFromEntrypoint(entrypointId: string, pluginId: number, pluginType: string) {
+  return await axios.delete(`/api/entrypoints/${entrypointId}/${pluginType}/${pluginId}`)
 }
 
 export async function appendResource<T extends ItemType>(parentResourceType: T, parentResourceId: number, childResourceType: T, ids: number[]) {

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -37,7 +37,7 @@
           color="secondary" 
           text-color="white"
           clickable
-          @click.stop="editEntrypoint = props.row; showAssignPluginsDialog = true"
+          @click.stop="editEntrypoint = props.row; pluginType = 'plugins'; showAssignPluginsDialog = true"
         >
           {{ plugin.name }}
           <q-badge
@@ -54,8 +54,7 @@
           color="red" 
           icon="sync"
           size="sm"
-          @click.stop="syncPlugin(props.row.id, plugin.id, plugin.name)"
-          class="q-mr-md"
+          @click.stop="syncPlugin(props.row.id, plugin.id, plugin.name, 'plugins')"
         >
           <q-tooltip>
             Sync to latest version of plugin
@@ -66,7 +65,49 @@
         round
         size="sm"
         icon="add"
-        @click.stop="editEntrypoint = props.row; showAssignPluginsDialog = true"
+        @click.stop="editEntrypoint = props.row; pluginType = 'plugins'; showAssignPluginsDialog = true"
+        class="q-ml-sm"
+      />
+    </template>
+      <template #body-cell-artifactPlugins="props">
+      <span
+        v-for="(plugin, i) in props.row.artifactPlugins"
+        :key="i"
+      >
+        <q-chip
+          color="secondary" 
+          text-color="white"
+          clickable
+          @click.stop="editEntrypoint = props.row; pluginType = 'artifactPlugins'; showAssignPluginsDialog = true"
+        >
+          {{ plugin.name }}
+          <q-badge
+            v-if="!plugin.latestSnapshot" 
+            color="red" 
+            label="outdated" 
+            rounded
+            class="q-ml-xs"
+          />
+        </q-chip>
+        <q-btn
+          v-if="!plugin.latestSnapshot"
+          round 
+          color="red" 
+          icon="sync"
+          size="sm"
+          @click.stop="syncPlugin(props.row.id, plugin.id, plugin.name, 'artifactPlugins')"
+        >
+          <q-tooltip>
+            Sync to latest version of plugin
+          </q-tooltip>
+        </q-btn>
+      </span>
+      <q-btn
+        round
+        size="sm"
+        icon="add"
+        @click.stop="editEntrypoint = props.row; pluginType = 'artifactPlugins'; showAssignPluginsDialog = true"
+        class="q-ml-sm"
       />
     </template>
   </TableComponent>
@@ -95,6 +136,7 @@
   />
   <AssignPluginsDialog 
     v-model="showAssignPluginsDialog"
+    :pluginType="pluginType"
     :editObj="editEntrypoint"
     @refreshTable="tableRef.refreshTable()"
   />
@@ -122,6 +164,7 @@
     { name: 'taskGraph', label: 'Task Graph', align: 'left', field: 'taskGraph',sortable: false, },
     { name: 'tags', label: 'Tags', align: 'left', field: 'tags', sortable: false },
     { name: 'plugins', label: 'Plugins', align: 'left', field: 'plugins', sortable: false },
+    { name: 'artifactPlugins', label: 'Artifact Plugins', align: 'left', field: 'artifactPlugins', sortable: false },
   ]
 
   const selected = ref([])
@@ -136,6 +179,7 @@
   const showDeleteDialog = ref(false)
   const showAssignPluginsDialog = ref(false)
   const editEntrypoint = ref('')
+  const pluginType = ref('')
 
   async function getEntrypoints(pagination, showDrafts) {
     try {
@@ -163,9 +207,9 @@
   const editObjTags = ref({})
   const showTagsDialog = ref(false)
 
-  async function syncPlugin(entrypointId, pluginId, pluginName) {
+  async function syncPlugin(entrypointId, pluginId, pluginName, pluginType) {
     try {
-      await api.addPluginsToEntrypoint(entrypointId, [pluginId], 'plugins')
+      await api.addPluginsToEntrypoint(entrypointId, [pluginId], pluginType)
       tableRef.value.refreshTable()
       notify.success(`Successfully updated plugin '${pluginName}' to latest version`)
     } catch(err) {


### PR DESCRIPTION
closes #989 

- Adding/removing/syncing plugins to entrypoints should be possible in both the entrypoint table page and the entrypoint edit page.
- The plugin dropdown is now a re-usable component.  Adding/removing/syncing should work like before.