### PR TITLE
fix(devSetup): fix run-worker.sh to use correct worker name

### DIFF
--- a/dev-kb/local-setup/run-worker.sh
+++ b/dev-kb/local-setup/run-worker.sh
@@ -16,4 +16,4 @@ uv sync --extra worker --extra "${_dioptra_worker_lib}"
 
 source ${DIOPTRA_CODE}/${DIOPTRA_VENV}/bin/activate
 cd ${DIOPTRA_DEPLOY}/workdir
-dioptra-worker-v1 "Configured-as: $_dioptra_worker_lib"
+dioptra-worker-v1 $_dioptra_worker_lib


### PR DESCRIPTION
This PR fixes a bug where jobs wouldn't execute in a containerless setup (stayed queued forever). More specifically, the worker was never able to identify the job. 

The issue was discovered to be the `run-worker.sh` script incorrectly passed the worker name as an argument to the `dioptra-worker-v1` command. It looks like the worker was named 'tensorflow-cpu', but actually it was named 'Configured as: tensorflow-cpu'. This mismatch was stopping jobs from running if you started the worker using the `run-worker.sh` command

**The fix**: Remove the extra text which was concatenated to the worker name in `run-worker.sh`. 