### PR TITLE
Fix: plugin deletion bug if resources have been deleted

### DIFF
--- a/src/dioptra/restapi/v1/plugins/service.py
+++ b/src/dioptra/restapi/v1/plugins/service.py
@@ -446,11 +446,12 @@ class PluginIdService(object):
             for plugin_file_resource in plugin_file_resources
         ]
         for plugin_file_resource in plugin_file_resources:
-            deleted_resource_lock = models.ResourceLock(
-                resource_lock_type=resource_lock_types.DELETE,
-                resource=plugin_file_resource,
-            )
-            db.session.add(deleted_resource_lock)
+            if not plugin_file_resource.is_deleted:
+                deleted_resource_lock = models.ResourceLock(
+                    resource_lock_type=resource_lock_types.DELETE,
+                    resource=plugin_file_resource,
+                )
+                db.session.add(deleted_resource_lock)
 
         db.session.commit()
 


### PR DESCRIPTION
Fixes #1005 

When deleting a plugin, the API now checks if a resource has already been deleted before trying to delete it. This fixes a bug that prevented the deletion of any plugin that had a deleted resource.