### PR TITLE
feat: hide experiment and plugin metadata

### DIFF
--- a/src/frontend/src/components/KeyValueTable.vue
+++ b/src/frontend/src/components/KeyValueTable.vue
@@ -5,7 +5,7 @@
   >
     <tr v-for="(row, index) in rows" :key="index" :class="{ 'disabled': disabled }">
       <td>{{ row.label }}</td>
-      <td>
+      <td :style="secondColumnFullWidth ? { width: '100%' } : {}">
         <!-- Render as plain text OR use a custom slot -->
         <slot :name="row.slot" v-bind="row.props">
           {{ row.value }}
@@ -22,6 +22,10 @@ defineProps({
     required: true
   },
   disabled: {
+    type: Boolean,
+    default: false
+  },
+  secondColumnFullWidth: {
     type: Boolean,
     default: false
   }

--- a/src/frontend/src/views/CreateExperiment.vue
+++ b/src/frontend/src/views/CreateExperiment.vue
@@ -54,7 +54,6 @@
       <div class="q-ma-lg">
         <q-select
           outlined
-          dense
           v-model="experiment.entrypoints"
           use-input
           use-chips

--- a/src/frontend/src/views/EditExperiment.vue
+++ b/src/frontend/src/views/EditExperiment.vue
@@ -28,135 +28,157 @@
     />
   </div>
 
-  <fieldset 
-    class="q-mt-md q-pa-lg"
-    style="display: inline-block; width: auto; height: auto; max-width: 50%;"
-    :style="{ cursor: history ? 'not-allowed' : 'auto', }"
-    :disabled="history"
+  <q-expansion-item
+    v-model="showMetadata"
+    class="shadow-1 overflow-hidden q-mt-lg"
+    style="border-radius: 10px; width: 40%"
+    header-style="font-size: 22px"
+    header-class="bg-primary text-white"
+    expand-icon-class="text-white"
   >
-    <legend>Metadata</legend>
-    <KeyValueTable 
-      :rows="metadataRows"
-      :style="{ pointerEvents: history ? 'none' : 'auto', }"
+    <template #header>
+      <q-item-section avatar>
+        <q-icon name="sym_o_science" color="white" size="md" />
+      </q-item-section>
+      <q-item-section>
+        <q-item-label>
+          {{ showMetadata ? 'Hide' : 'Show' }} "{{ ORIGINAL_EXPERIMENT.name }}" Metadata
+        </q-item-label>
+        <q-item-label caption class="text-white" v-if="ORIGINAL_EXPERIMENT.description">
+          {{ truncateString(ORIGINAL_EXPERIMENT.description, 100) }}
+        </q-item-label>
+      </q-item-section>
+    </template>
+    <q-card 
+      class="q-pa-md"
+      :class="history ? 'disabled' : ''"
     >
-      <template #name="{ }">
-        {{ experiment?.name }}
-        <q-btn icon="edit" round size="sm" color="primary" flat />
-        <q-popup-edit
-          v-model="experiment.name" 
-          auto-save 
-          v-slot="scope"
-          :validate="requiredRule"
-        >
-          <q-input 
-            v-model.trim="scope.value"
-            dense
-            autofocus
-            counter
-            @keyup.enter="scope.set"
-            :error="invalidName"
-            :error-message="nameError"
-            @update:model-value="checkName"
-          />
-        </q-popup-edit>
-      </template>
-      <template #group="{ }">
-        <q-select
-          outlined 
-          v-model="experiment.group" 
-          :options="store.groups"
-          option-label="name"
-          option-value="id"
-          emit-value
-          map-options
-          dense
-          :rules="[requiredRule]"
-          aria-required="true"
-          :disable="history"
-          hide-bottom-space
-        />
-      </template>
-      <template #description="{ }">
-        <div class="row items-center no-wrap">
-          <div style="white-space: pre-line; overflow-wrap: break-word; ">
-            {{ experiment?.description }}
-          </div>
-          <q-btn icon="edit" round size="sm" color="primary" flat class="q-ml-xs" />
-        </div>
-        <q-popup-edit v-model.trim="experiment.description" auto-save v-slot="scope" buttons>
-          <q-input
-            v-model="scope.value"
-            dense
-            autofocus
-            counter
-            type="textarea"
-            @keyup.enter.stop
-          />
-        </q-popup-edit>
-      </template>
-      <template #entrypoints="{ }">
-        <q-select
-          v-if="!history"
-          outlined
-          dense
-          v-model="experiment.entrypoints"
-          use-input
-          use-chips
-          multiple
-          map-options
-          option-label="name"
-          option-value="id"
-          input-debounce="300"
-          :options="entrypoints"
-          @filter="getEntrypoints"
-          class="q-mb-md"
-          :disable="history"
-        >
-          <template v-slot:before>
-            <div class="field-label">Entrypoints:</div>
-          </template>
-          <template v-slot:selected>
-            <q-chip
-              v-for="(entrypoint, i) in experiment.entrypoints"
-              :key="entrypoint.id"
-              color="secondary"
-              :label="entrypoint.name"
-              class="text-white"
-              removable
-              @remove="experiment.entrypoints.splice(i, 1)"
+      <KeyValueTable 
+        :rows="metadataRows"
+        :style="{ pointerEvents: history ? 'none' : 'auto', }"
+        :secondColumnFullWidth="true"
+      >
+        <template #name="{ }">
+          {{ experiment?.name }}
+          <q-btn icon="edit" round size="sm" color="primary" flat />
+          <q-popup-edit
+            v-model="experiment.name" 
+            auto-save 
+            v-slot="scope"
+            :validate="requiredRule"
+          >
+            <q-input 
+              v-model.trim="scope.value"
+              dense
+              autofocus
+              counter
+              @keyup.enter="scope.set"
+              :error="invalidName"
+              :error-message="nameError"
+              @update:model-value="checkName"
             />
-          </template>  
-        </q-select>
-        <div class="row items-center" v-if="history">
-          <q-icon
-            name="sym_o_info"
-            size="2.5em"
-            color="grey"
-            class="q-mr-sm"
+          </q-popup-edit>
+        </template>
+        <template #group="{ }">
+          <q-select
+            outlined 
+            v-model="experiment.group" 
+            :options="store.groups"
+            option-label="name"
+            option-value="id"
+            emit-value
+            map-options
+            dense
+            :rules="[requiredRule]"
+            aria-required="true"
+            :disable="history"
+            hide-bottom-space
           />
-          <div style="flex: 1; white-space: normal; word-break: break-word;">
-            Entrypoints are not yet available in Experiment snapshots
+        </template>
+        <template #description="{ }">
+          <div class="row items-center no-wrap">
+            <div style="white-space: pre-line; overflow-wrap: break-word; ">
+              {{ experiment?.description }}
+            </div>
+            <q-btn icon="edit" round size="sm" color="primary" flat class="q-ml-xs" />
           </div>
-        </div>
-      </template>
-    </KeyValueTable>
-    <div class="float-right q-mt-md">
-      <q-btn
-        outline  
-        color="primary" 
-        label="Revert"
-        class="q-mr-lg cancel-btn"
-        @click="revertValues"
-        :disable="!valuesChanged"
-      />
-      <q-btn
-        label="Save"
-        color="primary"
-        @click="updateExperiment"
-        :disable="!valuesChanged"
-      />
-    </div>
-  </fieldset>
+          <q-popup-edit v-model.trim="experiment.description" auto-save v-slot="scope" buttons>
+            <q-input
+              v-model="scope.value"
+              dense
+              autofocus
+              counter
+              type="textarea"
+              @keyup.enter.stop
+            />
+          </q-popup-edit>
+        </template>
+        <template #entrypoints="{ }">
+          <q-select
+            v-if="!history"
+            outlined
+            v-model="experiment.entrypoints"
+            use-input
+            use-chips
+            multiple
+            map-options
+            option-label="name"
+            option-value="id"
+            input-debounce="300"
+            :options="entrypoints"
+            @filter="getEntrypoints"
+            :disable="history"
+              
+          >
+            <template v-slot:selected>
+              <q-chip
+                v-for="(entrypoint, i) in experiment.entrypoints"
+                :key="entrypoint.id"
+                color="secondary"
+                :label="entrypoint.name"
+                class="text-white"
+                removable
+                @remove="experiment.entrypoints.splice(i, 1)"
+              />
+            </template>  
+          </q-select>
+          <div class="row items-center" v-if="history">
+            <q-icon
+              name="sym_o_info"
+              size="2.5em"
+              color="grey"
+              class="q-mr-sm"
+            />
+            <div style="flex: 1; white-space: normal; word-break: break-word;">
+              Entrypoints are not yet available in Experiment snapshots
+            </div>
+          </div>
+        </template>
+      </KeyValueTable>
+      <div class="float-right q-my-sm" >
+        <q-btn
+          outline  
+          color="primary" 
+          label="Revert"
+          class="q-mr-lg cancel-btn"
+          @click="revertValues"
+          :disable="!valuesChanged"
+        />
+        <q-btn
+          label="Save"
+          color="primary"
+          @click="updateExperiment"
+          :disable="!valuesChanged"
+          style="min-width: 100px;"
+        >
+          <q-tooltip v-if="!valuesChanged">
+            No changes detected — nothing to save
+          </q-tooltip>
+        </q-btn>
+      </div>
+    </q-card>
+  </q-expansion-item>
+
   <JobsView /> 
 
   <DeleteDialog
@@ -193,7 +215,12 @@ const experiment = ref({
   description: '',
   entrypoints: [],
 })
-const ORIGINAL_EXPERIMENT = ref()
+const ORIGINAL_EXPERIMENT = ref({
+  name: '',
+  group: store.loggedInGroup.id,
+  description: '',
+  entrypoints: [],
+})
 
 const history = computed(() => {
   return store.showRightDrawer
@@ -295,6 +322,12 @@ async function updateExperiment() {
   }  
 }
 
+watch(() => history.value, (newVal) => {
+  if(newVal) {
+    showMetadata.value = true
+  }
+})
+
 watch(() => store.selectedSnapshot, (newVal) => {
   if(newVal) {
     experiment.value = newVal
@@ -313,6 +346,14 @@ async function deleteExperiment() {
   } catch(err) {
     notify.error(err.response.data.message);
   }
+}
+
+const showMetadata = ref(false)
+
+function truncateString(str, limit) { 
+  if(!str) return ''
+  if(str?.length < limit) return str 
+  return str?.slice(0, limit > 3 ? limit - 3 : limit) + '...'; 
 }
 
 </script>

--- a/src/frontend/src/views/EditPluginView.vue
+++ b/src/frontend/src/views/EditPluginView.vue
@@ -8,66 +8,93 @@
       @click="showDeletePluginDialog = true"
     />
   </div>
-  <fieldset class="q-mt-md q-pa-lg" style="display: inline-block; width: auto; height: auto; max-width: 50%;">
-    <legend>Metadata</legend>
-    <KeyValueTable :rows="pluginRows">
-      <template #name="{ }">
-        {{ name }}
-        <q-btn icon="edit" round size="sm" color="primary" flat />
-        <q-popup-edit
-          v-model="name" 
-          auto-save 
-          v-slot="scope"
-          :validate="requiredRule"
-        >
-          <q-input 
-            v-model.trim="scope.value"
-            dense
-            autofocus
-            counter
-            @keyup.enter="scope.set"
-            :error="invalidName"
-            :error-message="nameError"
-            @update:model-value="checkName"
-          />
-        </q-popup-edit>
-      </template>
-      <template #description="{ }">
-        <div class="row items-center no-wrap">
-          <div style="white-space: pre-line; overflow-wrap: break-word; ">
-            {{ description }}
+
+    <q-expansion-item
+    v-model="showMetadata"
+    class="shadow-1 overflow-hidden q-mt-lg"
+    style="border-radius: 10px; width: 40%"
+    header-style="font-size: 22px"
+    header-class="bg-primary text-white"
+    expand-icon-class="text-white"
+    :label="`${showMetadata ? 'Hide' : 'Edit'} Plugin Metadata`"
+  >
+    <template #header>
+      <q-item-section avatar>
+        <q-icon name="terminal" color="white" size="md" />
+      </q-item-section>
+      <q-item-section>
+        <q-item-label>
+          {{ showMetadata ? 'Hide' : 'Show' }} "{{ ORIGINAL_PLUGIN.name }}" Metadata
+        </q-item-label>
+        <q-item-label caption class="text-white" v-if="ORIGINAL_PLUGIN.description" >
+          {{ truncateString(ORIGINAL_PLUGIN.description, 100) }}
+        </q-item-label>
+      </q-item-section>
+    </template>
+    <q-card class="q-pa-md">
+      <KeyValueTable :rows="pluginRows" :secondColumnFullWidth="true">
+        <template #name="{ }">
+          {{ name }}
+          <q-btn icon="edit" round size="sm" color="primary" flat />
+          <q-popup-edit
+            v-model="name" 
+            auto-save 
+            v-slot="scope"
+            :validate="requiredRule"
+          >
+            <q-input 
+              v-model.trim="scope.value"
+              dense
+              autofocus
+              counter
+              @keyup.enter="scope.set"
+              :error="invalidName"
+              :error-message="nameError"
+              @update:model-value="checkName"
+            />
+          </q-popup-edit>
+        </template>
+        <template #description="{ }">
+          <div class="row items-center no-wrap">
+            <div style="white-space: pre-line; overflow-wrap: break-word; ">
+              {{ description }}
+            </div>
+            <q-btn icon="edit" round size="sm" color="primary" flat class="q-ml-xs" />
           </div>
-          <q-btn icon="edit" round size="sm" color="primary" flat class="q-ml-xs" />
-        </div>
-        <q-popup-edit v-model.trim="description" auto-save v-slot="scope" buttons>
-          <q-input
-            v-model="scope.value"
-            dense
-            autofocus
-            counter
-            type="textarea"
-            @keyup.enter.stop
-          />
-        </q-popup-edit>
-      </template>
-    </KeyValueTable>
-    <div class="float-right q-mt-md">
-      <q-btn
-        outline  
-        color="primary" 
-        label="Revert"
-        class="q-mr-lg cancel-btn"
-        @click="revertValues"
-        :disable="!valuesChanged"
-      />
-      <q-btn
-        label="Save"
-        color="primary"
-        @click="updatePlugin"
-        :disable="!valuesChanged"
-      />
-    </div>
-  </fieldset>
+          <q-popup-edit v-model.trim="description" auto-save v-slot="scope" buttons>
+            <q-input
+              v-model="scope.value"
+              dense
+              autofocus
+              counter
+              type="textarea"
+              @keyup.enter.stop
+            />
+          </q-popup-edit>
+        </template>
+      </KeyValueTable>
+      <div class="float-right q-my-sm">
+        <q-btn
+          outline  
+          color="primary" 
+          label="Revert"
+          class="q-mr-lg cancel-btn"
+          @click="revertValues"
+          :disable="!valuesChanged"
+        />
+        <q-btn
+          label="Save"
+          color="primary"
+          @click="updatePlugin"
+          :disable="!valuesChanged"
+        >
+          <q-tooltip v-if="!valuesChanged">
+            No changes detected — nothing to save
+          </q-tooltip>
+        </q-btn>
+      </div>
+    </q-card>
+  </q-expansion-item>
 
   <TableComponent 
     :rows="files"
@@ -133,7 +160,10 @@ onMounted(() => {
   getPlugin()
 })
 
-const ORIGINAL_PLUGIN = ref()
+const ORIGINAL_PLUGIN = ref({
+  name: '',
+  description: ''
+})
 
 async function getPlugin() {
   try {
@@ -255,5 +285,12 @@ async function deletePlugin() {
   }
 }
 
+const showMetadata = ref(false)
+
+function truncateString(str, limit) { 
+  if(!str) return ''
+  if(str?.length < limit) return str 
+  return str?.slice(0, limit > 3 ? limit - 3 : limit) + '...'; 
+}
 
 </script>


### PR DESCRIPTION
On the last call we discussed hiding the experiment and plugin metadata to save space.  This PR puts it in an expandable row.  Note when viewing history on the experiments page, the metadata row automatically expands.