### PR TITLE
feat: filter artifact snapshots by output params

### DIFF
--- a/src/dioptra/restapi/v1/artifacts/service.py
+++ b/src/dioptra/restapi/v1/artifacts/service.py
@@ -62,6 +62,49 @@ SORTABLE_FIELDS: Final[dict[str, Any]] = {
 }
 
 
+def apply_output_params_filter(stmt: Select, output_params: list[int]) -> Select:
+    # creates a comparison for each outuput parameter and makes
+    # sure the type is correct for that parameter_number
+    for index, p in enumerate(output_params):
+        task_alias = aliased(models.ArtifactTask)
+        parameter_alias = aliased(models.PluginTaskOutputParameter)
+        type_alias = aliased(models.PluginTaskParameterType)
+        stmt = (
+            stmt.join(models.Artifact.task.of_type(task_alias))
+            .join(models.ArtifactTask.output_parameters.of_type(parameter_alias))
+            .join(
+                type_alias,
+                type_alias.resource_snapshot_id
+                == parameter_alias.plugin_task_parameter_type_resource_snapshot_id,
+            )
+            .where(
+                type_alias.resource_id == p,
+                parameter_alias.parameter_number == index,
+            )
+        )
+
+    # verifies that the number of parameters is what we are looking for
+    # prevents picking up artifacts which match the ones we are looking
+    # for, but have more parameters
+    count_subquery = (
+        select(
+            models.PluginTaskOutputParameter.task_id,
+            func.count().label("param_count"),
+        )
+        .group_by(models.PluginTaskOutputParameter.task_id)
+        .subquery()
+    )
+    task_alias = aliased(models.ArtifactTask)
+    stmt = (
+        stmt.join(models.Artifact.task.of_type(task_alias))
+        .join(count_subquery, task_alias.task_id == count_subquery.c.task_id)
+        .where(
+            count_subquery.c.param_count == len(output_params),
+        )
+    )
+    return stmt
+
+
 class ArtifactTaskHelper(object):
     @inject
     def __init__(
@@ -280,7 +323,7 @@ class ArtifactService(object):
         )
 
         if output_params:
-            stmt = self._apply_ouput_params_filter(stmt, output_params)
+            stmt = apply_output_params_filter(stmt, output_params)
 
         total_num_artifacts = db.session.scalars(stmt).first()
 
@@ -310,7 +353,7 @@ class ArtifactService(object):
         )
 
         if output_params:
-            latest_artifacts_stmt = self._apply_ouput_params_filter(
+            latest_artifacts_stmt = apply_output_params_filter(
                 latest_artifacts_stmt, output_params
             )
 
@@ -343,50 +386,6 @@ class ArtifactService(object):
             artifacts_dict[resource_id]["has_draft"] = True
 
         return list(artifacts_dict.values()), total_num_artifacts
-
-    def _apply_ouput_params_filter(
-        self, stmt: Select, output_params: list[int]
-    ) -> Select:
-        # creates a comparison for each outuput parameter and makes
-        # sure the type is correct for that parameter_number
-        for index, p in enumerate(output_params):
-            task_alias = aliased(models.ArtifactTask)
-            parameter_alias = aliased(models.PluginTaskOutputParameter)
-            type_alias = aliased(models.PluginTaskParameterType)
-            stmt = (
-                stmt.join(models.Artifact.task.of_type(task_alias))
-                .join(models.ArtifactTask.output_parameters.of_type(parameter_alias))
-                .join(
-                    type_alias,
-                    type_alias.resource_snapshot_id
-                    == parameter_alias.plugin_task_parameter_type_resource_snapshot_id,
-                )
-                .where(
-                    type_alias.resource_id == p,
-                    parameter_alias.parameter_number == index,
-                )
-            )
-
-        # verifies that the number of parameters is what we are looking for
-        # prevents picking up artifacts which match the ones we are looking
-        # for, but have more parameters
-        count_subquery = (
-            select(
-                models.PluginTaskOutputParameter.task_id,
-                func.count().label("param_count"),
-            )
-            .group_by(models.PluginTaskOutputParameter.task_id)
-            .subquery()
-        )
-        task_alias = aliased(models.ArtifactTask)
-        stmt = (
-            stmt.join(models.Artifact.task.of_type(task_alias))
-            .join(count_subquery, task_alias.task_id == count_subquery.c.task_id)
-            .where(
-                count_subquery.c.param_count == len(output_params),
-            )
-        )
-        return stmt
 
 
 class ArtifactIdService(object):

--- a/src/dioptra/restapi/v1/shared/snapshots/controller.py
+++ b/src/dioptra/restapi/v1/shared/snapshots/controller.py
@@ -32,6 +32,7 @@ from structlog.stdlib import BoundLogger
 from dioptra.restapi.db import models
 from dioptra.restapi.v1 import utils
 from dioptra.restapi.v1.schemas import ResourceGetQueryParameters
+from dioptra.restapi.v1.artifacts.schema import ArtifactGetQueryParameters
 
 from .service import ResourceSnapshotsIdService, ResourceSnapshotsService
 
@@ -90,7 +91,12 @@ def generate_resource_snapshots_endpoint(
             super().__init__(*args, **kwargs)
 
         @login_required
-        @accepts(query_params_schema=ResourceGetQueryParameters, api=api)
+        @accepts(
+            query_params_schema=ArtifactGetQueryParameters
+            if resource_name == "artifact"
+            else ResourceGetQueryParameters,
+            api=api,
+        )
         @responds(schema=page_schema, model_name=model_name, api=api)
         def get(self, id: int):
             """Gets the Snapshots for the resource."""
@@ -102,6 +108,7 @@ def generate_resource_snapshots_endpoint(
             search_string = unquote(parsed_query_params["search"])
             page_index = parsed_query_params["index"]
             page_length = parsed_query_params["page_length"]
+            output_params = parsed_query_params.get("output_params")
 
             snapshots, total_num_snapshots = cast(
                 tuple[list[dict[str, Any]], int],
@@ -110,6 +117,7 @@ def generate_resource_snapshots_endpoint(
                     search_string=search_string,
                     page_index=page_index,
                     page_length=page_length,
+                    output_params=output_params,
                     error_if_not_found=True,
                     log=log,
                 ),
@@ -256,7 +264,12 @@ def generate_nested_resource_snapshots_endpoint(
             super().__init__(*args, **kwargs)
 
         @login_required
-        @accepts(query_params_schema=ResourceGetQueryParameters, api=api)
+        @accepts(
+            query_params_schema=ArtifactGetQueryParameters
+            if resource_name == "artifact"
+            else ResourceGetQueryParameters,
+            api=api,
+        )
         @responds(schema=page_schema, model_name=model_name, api=api)
         def get(self, id: int, **kwargs):
             """Gets the Snapshots for the resource."""
@@ -277,6 +290,7 @@ def generate_nested_resource_snapshots_endpoint(
             search_string = unquote(parsed_query_params["search"])
             page_index = parsed_query_params["index"]
             page_length = parsed_query_params["page_length"]
+            output_params = parsed_query_params.get("output_params")
 
             snapshots, total_num_snapshots = cast(
                 tuple[list[models.ResourceSnapshot], int],
@@ -285,6 +299,7 @@ def generate_nested_resource_snapshots_endpoint(
                     search_string=search_string,
                     page_index=page_index,
                     page_length=page_length,
+                    output_params=output_params,
                     error_if_not_found=True,
                     log=log,
                 ),

--- a/src/dioptra/restapi/v1/shared/snapshots/service.py
+++ b/src/dioptra/restapi/v1/shared/snapshots/service.py
@@ -108,6 +108,14 @@ class ResourceSnapshotsService(object):
                 models.Resource.is_deleted == False,  # noqa: E712
             )
         )
+
+        output_params = kwargs.get("output_params")
+
+        if self._resource_type == "artifact" and output_params:
+            from dioptra.restapi.v1.artifacts.service import apply_output_params_filter
+
+            stmt = apply_output_params_filter(stmt, output_params)
+
         total_num_snapshots = db.session.scalars(stmt).unique().first()
 
         if total_num_snapshots is None:
@@ -133,6 +141,12 @@ class ResourceSnapshotsService(object):
             .offset(page_index)
             .limit(page_length)
         )
+
+        if self._resource_type == "artifact" and output_params:
+            from dioptra.restapi.v1.artifacts.service import apply_output_params_filter
+
+            stmt = apply_output_params_filter(stmt, output_params)
+
         snapshots = [
             {self._resource_type: snapshot, "has_draft": None}
             for snapshot in db.session.scalars(stmt).unique()


### PR DESCRIPTION
This is a continuation of #976, which added the ability to get artifacts filtered by output_param types.  This PR reuses the same code to filter artifact snapshots by output_param types as well.  This is needed for the optional artifact snapshot dropdown on the job creation page.