### PR TITLE
feat: add sort/filter/search to job logs

### DIFF
--- a/src/dioptra/client/jobs.py
+++ b/src/dioptra/client/jobs.py
@@ -302,6 +302,9 @@ class JobsCollectionClient(CollectionClient[T]):
         job_id: str | int,
         index: int = 0,
         page_length: int = 10,
+        sort_by: str | None = None,
+        descending: bool | None = None,
+        severity: list[str] | None = None,
     ) -> T:
         """
         Get log records for the given job resource. Records are returned in the order
@@ -311,6 +314,11 @@ class JobsCollectionClient(CollectionClient[T]):
             job_id: The resource ID of a job.
             index: Index of the first log record to return.
             page_length: Number of log records to return.
+            sort_by: The field to use to sort the returned list. Optional, defaults to
+                None.
+            descending: Sort the returned list in descending order. Optional, defaults
+                to None.
+            severity: list of severities to filter on
 
         Returns:
             The response from the Dioptra API.
@@ -320,6 +328,15 @@ class JobsCollectionClient(CollectionClient[T]):
             "index": index,
             "pageLength": page_length,
         }
+
+        if sort_by is not None:
+            params["sortBy"] = sort_by
+
+        if descending is not None:
+            params["descending"] = descending
+
+        if severity:
+            params["severity"] = severity
 
         return self._session.get(self.url, str(job_id), LOG, params=params)
 

--- a/src/dioptra/restapi/v1/jobs/controller.py
+++ b/src/dioptra/restapi/v1/jobs/controller.py
@@ -429,8 +429,20 @@ class JobIdLogEndpoint(Resource):
     def get(self, id: int):
         index = request.parsed_query_params["index"]  # type: ignore
         page_length = request.parsed_query_params["page_length"]  # type: ignore
+        search_string = unquote(request.parsed_query_params["search"])  # type: ignore
+        severity = request.parsed_query_params.get("severity")  # type: ignore
+        sort_by_string = request.parsed_query_params["sort_by"]  # type: ignore
+        descending = request.parsed_query_params["descending"]  # type: ignore
 
-        records, total = self._job_log_service.get_logs(id, index, page_length)
+        records, total = self._job_log_service.get_logs(
+            job_resource_id=id,
+            index=index,
+            page_length=page_length,
+            search_string=search_string,
+            sort_by_string=sort_by_string,
+            descending=descending,
+            severity=severity,
+        )
 
         page = utils.build_paging_envelope(
             f"{V1_JOBS_ROUTE}/{id}/log",
@@ -442,6 +454,8 @@ class JobIdLogEndpoint(Resource):
             index=index,
             length=page_length,
             total_num_elements=total,
+            sort_by=sort_by_string,
+            descending=descending,
         )
 
         return page

--- a/src/dioptra/restapi/v1/jobs/schema.py
+++ b/src/dioptra/restapi/v1/jobs/schema.py
@@ -387,7 +387,18 @@ class JobLogRecordsPageSchema(BasePageSchema):
     )
 
 
-class JobLogGetQueryParameters(PagingQueryParametersSchema):
+class JobLogGetQueryParameters(
+    PagingQueryParametersSchema,
+    SortByGetQueryParametersSchema,
+    SearchQueryParametersSchema,
+):
     """
     The query parameters for the GET method of the /jobs/{id}/log endpoint.
     """
+
+    severity = fields.List(
+        fields.String(validate=validate.OneOf([e.name for e in JobLogSeverity])),
+        required=False,
+        allow_none=True,
+        metadata={"description": "List of severities to filter by"},
+    )

--- a/src/dioptra/restapi/v1/jobs/service.py
+++ b/src/dioptra/restapi/v1/jobs/service.py
@@ -85,6 +85,16 @@ SORTABLE_FIELDS: Final[dict[str, Any]] = {
     "entrypoint": models.EntryPoint.name,
     "queue": models.Queue.name,
 }
+SEARCHABLE_LOG_FIELDS: Final[dict[str, Any]] = {
+    "severity": lambda x: models.JobLog.severity.like(x),
+    "message": lambda x: models.JobLog.message.like(x),
+    "logger_name": lambda x: models.JobLog.logger_name.like(x),
+}
+SORTABLE_LOG_FIELDS: Final[dict[str, Any]] = {
+    "severity": models.JobLog.severity,
+    "logger_name": models.JobLog.logger_name,
+    "created_on": models.JobLog.created_on,
+}
 JOB_STATUS_TRANSITIONS: Final[dict[str, Any]] = {
     "queued": {"started", "deferred", "reset"},
     "started": {"finished", "failed", "reset"},
@@ -1396,6 +1406,10 @@ class JobLogService(object):
         job_resource_id: int,
         index: int,
         page_length: int,
+        search_string: str,
+        sort_by_string: str,
+        descending: bool,
+        severity: list[str] | None = None,
         **kwargs,
     ) -> tuple[list[dict[str, Any]], int]:
         """
@@ -1405,6 +1419,10 @@ class JobLogService(object):
             job_resource_id: The resource ID of a job
             index: Zero-based index of the first log record to return
             page_length: The number of records to return
+            search_string: A search string used to filter results.
+            sort_by_string: The name of the column to sort.
+            descending: Boolean indicating whether to sort by descending or not.
+            severity: list of severities to filter by
 
         Returns:
             A 2-tuple including (1) The list of records comprising this page,
@@ -1414,22 +1432,45 @@ class JobLogService(object):
 
         log: BoundLogger = kwargs.get("log", LOGGER.new())
         log.debug("Get job logs", job_id=job_resource_id)
+
+        filters = []
+
+        if search_string:
+            filters.append(
+                construct_sql_query_filters(search_string, SEARCHABLE_LOG_FIELDS)
+            )
+
         count_stmt = (
             select(func.count())
             .select_from(models.JobLog)
-            .where(models.JobLog.job_resource_id == job_resource_id)
+            .where(*filters, models.JobLog.job_resource_id == job_resource_id)
         )
+        if severity:
+            count_stmt = count_stmt.where(models.JobLog.severity.in_(severity))
         total_count = db.session.scalar(count_stmt)
         # "select count(*) ..." can't produce None
         assert total_count is not None
 
         page_stmt = (
             select(models.JobLog)
-            .where(models.JobLog.job_resource_id == job_resource_id)
-            .order_by(models.JobLog.id)
+            .where(*filters, models.JobLog.job_resource_id == job_resource_id)
             .offset(index)
             .limit(page_length)
         )
+
+        if severity:
+            page_stmt = page_stmt.where(models.JobLog.severity.in_(severity))
+
+        if sort_by_string and sort_by_string in SORTABLE_LOG_FIELDS:
+            sort_column = SORTABLE_LOG_FIELDS[sort_by_string]
+            sort_column = sort_column.desc() if descending else sort_column.asc()
+            # primary: user sort, secondary: id
+            page_stmt = page_stmt.order_by(sort_column, models.JobLog.id)
+        elif sort_by_string:
+            raise SortParameterValidationError(RESOURCE_TYPE, sort_by_string)
+        else:
+            # default: just by id
+            page_stmt = page_stmt.order_by(models.JobLog.id)
 
         log_objs = db.session.scalars(page_stmt)
 

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -81,7 +81,7 @@
                 class="q-ml-xs"
               />
             </div>
-            <div v-else-if="col.name === 'createdOn' || col.name === 'lastModifiedOn'">
+            <div v-else-if="col.name === 'createdOn' || col.name === 'created_on' || col.name === 'lastModifiedOn'">
               {{ formatDate(col.value) }}
             </div>
             <div v-else-if="!Array.isArray(col.value)">

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -243,12 +243,20 @@ export async function getJobMetrics(id: number) {
   return await axios.get(`/api/jobs/${id}/metrics`)
 }
 
-export async function getJobLogs(id: number, pagination: Pagination) {
+export async function getJobLogs(id: number, pagination: Pagination, severity?: string[]) {
   const res = await axios.get(`/api/jobs/${id}/log`, {
     params: {
       index: pagination.index,
       pageLength: pagination.rowsPerPage === 0 ? 100 : pagination.rowsPerPage,  // 0 means GET ALL
       search: pagination.search,
+      sortBy: pagination.sortBy,
+      descending: pagination.descending,
+      severity: severity ?? null,
+    },
+    paramsSerializer: {
+      // This makes arrays become: severity=INFO&severity=WARNING
+      // instead of severity[]=INFO&severity[]=WARNING
+      indexes: null,
     },
   })
 

--- a/src/frontend/src/views/JobDashboardView.vue
+++ b/src/frontend/src/views/JobDashboardView.vue
@@ -121,7 +121,6 @@
         :hideDeleteBtn="true"
         :disableSelect="true"
         :hideCreateBtn="true"
-        :hideSearch="true"
         style="margin-top: 0;"
         class="q-mb-lg"
         ref="tableRef"
@@ -146,19 +145,20 @@
             emit-value
             map-options
             dense
-            filled
+            outlined
             style="width: 175px"
             class="q-mr-lg"
           />
-          <!-- <q-select
+          <q-select
             label="Filter Severity"
             v-model="selectedSeverity"
-            :options="['INFO', 'WARNING', 'ERROR']"
+            :options="['DEBUG', 'INFO','WARNING', 'ERROR', 'CRITICAL']"
             multiple
-            style="width: 225px;"
-            filled
-            dense 
-            class="q-mr-lg" 
+            outlined
+            dense
+            use-chips 
+            class="q-mr-lg"
+            style="width: 485px;" 
           >
             <template v-slot:option="{ itemProps, opt, selected, toggleOption }">
               <q-item v-bind="itemProps">
@@ -175,7 +175,7 @@
                 </q-item-section>
               </q-item>
             </template>
-          </q-select> -->
+          </q-select>
         </template>
       </TableComponent>
     </div>
@@ -340,11 +340,11 @@ async function loadAllMetricHistories() {
 }
 
 const jobLogs = ref([])
-const filteredJobLogs = computed(() => {
-  return jobLogs.value.filter((log) => selectedSeverity.value.includes(log.severity))
-})
-const selectedSeverity = ref(['INFO', 'WARNING', 'ERROR'])
+const selectedSeverity = ref(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
 watch(selectedSeverity, () => {
+  if(selectedSeverity.value.length === 0) {
+    selectedSeverity.value = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+  }
   tableRef.value.refreshTable()
 })
 
@@ -352,11 +352,9 @@ const tableRef = ref(null)
 
 async function getLogs(pagination) {
   try {
-    const res = await api.getJobLogs(job.value.id, pagination)
+    const res = await api.getJobLogs(job.value.id, pagination, selectedSeverity.value)
     console.log('logs = ', res.data)
-    jobLogs.value = res.data.data.filter(log =>
-      selectedSeverity.value.includes(log.severity)
-    )
+    jobLogs.value = res.data.data
     logTotalNumber.value = res.data.totalNumResults
     tableRef.value.updateTotalRows(res.data.totalNumResults)
   } catch(err) {
@@ -402,7 +400,7 @@ async function setupLogsPolling() {
 
   if (tab.value !== 'logs') return
 
-  await getJob()
+  await getJob() // get job status
   if(job.value.status === 'finished' || job.value.status === 'failed') return
 
   // Ensure the table is rendered so tableRef is non-null
@@ -413,7 +411,7 @@ async function setupLogsPolling() {
 
   // Then start interval
   logsIntervalId = setInterval(async() => {
-    await getJob()
+    await getJob() // get job status
     if(job.value.status === 'finished' || job.value.status === 'failed') {
       clearLogsInterval()
       return
@@ -505,9 +503,9 @@ const metricColumns = [
 ]
 
 const logColumns = [
-  { name: 'severity', label: 'Severity', align: 'left', field: 'severity', sortable: false, classes: 'vertical-top' },
-  { name: 'loggerName', label: 'Logger Name', align: 'left', field: 'loggerName', sortable: false, classes: 'vertical-top', },
-  { name: 'createdOn', label: 'Received On', align: 'left', field: 'createdOn', sortable: false, classes: 'vertical-top', },
+  { name: 'severity', label: 'Severity', align: 'left', field: 'severity', sortable: true, classes: 'vertical-top' },
+  { name: 'logger_name', label: 'Logger Name', align: 'left', field: 'loggerName', sortable: true, classes: 'vertical-top', },
+  { name: 'created_on', label: 'Received On', align: 'left', field: 'createdOn', sortable: true, classes: 'vertical-top', },
   { name: 'message', label: 'Message', align: 'left', field: 'message', sortable: false, },
 ]
 

--- a/tests/unit/restapi/v1/test_job.py
+++ b/tests/unit/restapi/v1/test_job.py
@@ -1353,3 +1353,62 @@ def test_forward_job_logs_using_loggers(
         "first": f"/api/v1/jobs/{job_resource_id}/log?index=0&pageLength=10",
         "data": expected_log_records,
     }
+
+
+def test_get_logs_filtered_by_severity(
+    dioptra_client,
+    registered_jobs,
+    registered_job_logs,
+):
+    # Test that jobs logs can be filtered by severity
+
+    job = registered_jobs["job1"]
+    job_resource_id = job["id"]
+
+    resp = dioptra_client.jobs.get_logs_by_id(
+        job_resource_id,
+        severity=["CRITICAL"],
+    )
+    returned = resp.json()
+
+    # Validate that createdOn timestamps are present in the logs, then remove them for a
+    # predictable comparison.
+    for log in returned["data"]:
+        assert "createdOn" in log
+        del log["createdOn"]
+
+    expected = [log for log in registered_job_logs if log["severity"] == "CRITICAL"]
+
+    assert returned["data"] == expected
+
+
+@pytest.mark.parametrize(
+    "sortBy, descending , expected",
+    [
+        ("severity", True, ["WARNING", "INFO", "ERROR", "DEBUG", "CRITICAL"]),
+        ("severity", False, ["CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING"]),
+    ],
+)
+def test_job_log_sort(
+    dioptra_client: DioptraClient[DioptraResponseProtocol],
+    auth_account: dict[str, Any],
+    registered_jobs: dict[str, Any],
+    registered_job_logs,
+    sortBy: str,
+    descending: bool,
+    expected: list[str],
+) -> None:
+    # Test that jobs logs can be sorted by column, specifically severity.
+
+    job = registered_jobs["job1"]
+    job_resource_id = job["id"]
+
+    resp = dioptra_client.jobs.get_logs_by_id(
+        job_resource_id,
+        sort_by=sortBy,
+        descending=descending
+    )
+    returned = resp.json()
+    returned_severities = [log["severity"] for log in returned["data"]]
+
+    assert returned_severities == expected


### PR DESCRIPTION
closes #958 

- job logs can be sorted by column (severity, logger name, received on)
- job logs can be filtered by severity (info, debug, warning, error, critical)
- job logs can be searched by keywords (search is done on the severity and message columns)