### PR TITLE
feat: open new tab

### DIFF
--- a/src/frontend/src/components/JobArtifactsTable.vue
+++ b/src/frontend/src/components/JobArtifactsTable.vue
@@ -4,7 +4,10 @@
     :columns="columns"
     :title="`Artifacts Created by Job ${route.params.id}`"
     v-model:selected="selected"
-    @edit="router.push(`/artifacts/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/artifacts/${selected[0].id}`, '_blank')
+      : router.push(`/artifacts/${selected[0].id}`)
+    )"
     :hideDeleteBtn="true"
     :hideCreateBtn="true"
     :loading="isLoading"
@@ -43,6 +46,7 @@ import * as api from '@/services/dataApi'
 import { useRouter, useRoute } from 'vue-router'
 import * as notify from '../notify'
 
+const openWindow = window
 const router = useRouter()
 const route = useRoute()
 
@@ -82,6 +86,7 @@ async function getArtifacts() {
 
 
 const columns = [
+  { name: 'id', label: 'ID', field: 'id', align: 'left', sortable: true },
   { name: 'description', label: 'Description', field: 'description', align: 'left', sortable: true },
   { name: 'taskName', label: 'Task Name', align: 'left' },
   { name: 'taskOutputParams', label: 'Task Output Params', align: 'left' },

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -31,15 +31,40 @@
       <q-tr 
         :class="`${getSelectedColor(props.selected)} cursor-pointer ${highlightRow(props)} ${disableRow(props)}` " 
         :props="props"
-        @click="openResource(props); selectResource(props)"
+        @click="openResource(props, $event); selectResource(props)"
+        @auxclick="onAuxClick(props, $event)"
       >
         <q-td v-for="col in props.cols" :key="col.name" :props="props" :style="props.expand ? {'border-bottom': 'none'} : {}">
+          <q-menu
+            v-if="selection !== 'multiple'"
+            context-menu
+            @show="props.selected = true"
+          >
+            <q-list dense>
+              <q-item clickable v-close-popup @click="openResource(props)">
+                <q-item-section>Open</q-item-section>
+              </q-item>
+              <q-item clickable v-close-popup @click="openResource(props, null, true)">
+                <q-item-section>Open In New Tab</q-item-section>
+              </q-item>
+            </q-list>
+          </q-menu>
           <slot v-bind="props" :name="`body-cell-${col.name}`">
             <div v-if="typeof(col.value) === 'boolean'" class="text-body1">
               {{ col.value ? '✅' : 	'❌'}}
             </div>
             <div v-else-if="col.name === 'id'">
               <span class="link">{{ props.row.id }}</span>
+              <q-icon
+                name="open_in_new"
+                size="sm"
+                class="q-ml-sm"
+                @click.stop="openResource(props, $event, true)"
+              >
+                <q-tooltip>
+                  Open In New Tab
+                </q-tooltip>
+              </q-icon>
             </div>
             <div v-else-if="col.name === 'name'">
               {{ truncateString(props.row.name, 20) }}
@@ -85,14 +110,6 @@
               <!-- if value is an array, then render it with a custom slot -->
               {{ col.value }}
             </div>
-            <!-- <q-btn
-              v-if="col.name === 'open'"
-              round
-              color="primary"
-              icon="edit"
-              size="sm"
-              @click.stop="openResource(props)"
-            /> -->
             <q-btn
               v-if="col.name === 'delete'"
               round
@@ -191,7 +208,7 @@
   },
 })
   const emit = defineEmits([
-    'edit', 
+    'open', 
     'delete', 
     'request', 
     'expand', 
@@ -244,10 +261,21 @@
     else tableProps.selected = !tableProps.selected
   }
 
-  function openResource(tableProps) {
+  function openResource(tableProps, event = null, openTab = false) {
     if(props.disableSelect || props.selection === 'multiple') return
     tableProps.selected = true
-    emit('edit')
+    // ⌘ on macOS or Ctrl on windows should open new tab
+    if(event?.metaKey || event?.ctrlKey) {
+      emit('open', true)
+    } else {
+      emit('open', openTab)
+    }
+  }
+
+  function onAuxClick(tableProps, event) {
+    if (event.button === 1) {   // mouse wheel click only
+      openResource(tableProps, event , true)
+    }
   }
 
   function deleteResource(tableProps) {
@@ -384,7 +412,7 @@
       selected.value = [nextRow]
     }
   } else if(event.key === 'Enter') {
-    emit('edit')
+    emit('open')
   }
 }
 

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -188,7 +188,10 @@ router.beforeEach(async (to, from) => {
 
   // check login status on mounted and reloads
   if(from === START_LOCATION) {
+    store.initialPage = true
     await callGetLoginStatus()
+  } else {
+    store.initialPage = false
   }
 
   const isAuthRoute = to.path === '/login' || to.path === '/register'

--- a/src/frontend/src/stores/LoginStore.ts
+++ b/src/frontend/src/stores/LoginStore.ts
@@ -49,10 +49,12 @@ export const useLoginStore = defineStore('login', () => {
   const showRightDrawer = ref(false)
   const selectedSnapshot = ref()
 
+  const initialPage = ref(false)
+
   // computed()'s are getters
 
   // function()'s are actions
   
 
-  return { loggedInUser, loggedInGroup, groups, users, savedForms, showRightDrawer, selectedSnapshot, triggerPopup };
+  return { loggedInUser, loggedInGroup, groups, users, savedForms, showRightDrawer, selectedSnapshot, triggerPopup, initialPage };
 })

--- a/src/frontend/src/views/ArtifactsView.vue
+++ b/src/frontend/src/views/ArtifactsView.vue
@@ -5,7 +5,10 @@
     :columns="columns"
     title="Artifacts"
     v-model:selected="selected"
-    @edit="router.push(`/artifacts/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/artifacts/${selected[0].id}`, '_blank')
+      : router.push(`/artifacts/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getArtifacts"
     ref="tableRef"
@@ -76,6 +79,7 @@ import PageTitle from '@/components/PageTitle.vue'
 import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
 import { useRouter } from 'vue-router'
 
+const openWindow = window
 const router = useRouter()
 
 const selected = ref([])

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -397,7 +397,7 @@
       color="primary" 
       label="Cancel"
       class="q-mr-lg cancel-btn"
-      @click="confirmLeave = true; router.back()"
+      @click="confirmLeave = true; store.initialPage ? router.push('/entrypoints') : router.back()"
     />
     <q-btn  
       @click="submit()" 

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -275,7 +275,7 @@
       color="primary" 
       label="Cancel"
       class="q-mr-lg cancel-btn"
-      @click="confirmLeave = true; router.back()"
+      @click="confirmLeave = true; store.initialPage ? router.push(`/plugins/${route.params.id}`) : router.back()"
     />
     <q-btn  
       @click="submit()" 

--- a/src/frontend/src/views/EditArtifactView.vue
+++ b/src/frontend/src/views/EditArtifactView.vue
@@ -167,7 +167,7 @@
       color="primary" 
       label="Cancel"
       class="q-mr-lg cancel-btn"
-      @click="router.back()"
+      @click="store.initialPage ? router.push('/artifacts') : router.back()"
     />
     <q-btn  
       @click="submit()" 

--- a/src/frontend/src/views/EditPluginView.vue
+++ b/src/frontend/src/views/EditPluginView.vue
@@ -101,7 +101,10 @@
     :columns="fileColumns"
     title="Plugin Files"
     v-model:selected="selected"
-    @edit="router.push(`/plugins/${route.params.id}/files/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/plugins/${route.params.id}/files/${selected[0].id}`, '_blank')
+      : router.push(`/plugins/${route.params.id}/files/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getFiles"
     ref="tableRef"
@@ -148,6 +151,7 @@ import TableComponent from '@/components/TableComponent.vue'
 import DeleteDialog from '@/dialogs/DeleteDialog.vue'
 import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
 
+const openWindow = window
 const route = useRoute()
 const router = useRouter()
 

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -7,7 +7,10 @@
     :columns="columns"
     title="Entrypoints"
     v-model:selected="selected"
-    @edit="router.push(`/entrypoints/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/entrypoints/${selected[0].id}`, '_blank')
+      : router.push(`/entrypoints/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getEntrypoints"
     ref="tableRef"
@@ -156,6 +159,7 @@
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
   import AssignPluginsDialog from '@/dialogs/AssignPluginsDialog.vue'
 
+  const openWindow = window
   const router = useRouter()
 
   const columns = [

--- a/src/frontend/src/views/ExperimentsView.vue
+++ b/src/frontend/src/views/ExperimentsView.vue
@@ -5,7 +5,10 @@
     :columns="columns"
     title="Experiments"
     v-model:selected="selected"
-    @edit="router.push(`/experiments/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/experiments/${selected[0].id}`, '_blank')
+      : router.push(`/experiments/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getExperiments"
     ref="tableRef"
@@ -40,7 +43,6 @@
 </template>
 
 <script setup>
-
   import TableComponent from '@/components/TableComponent.vue'
   import { ref } from 'vue'
   import { useRouter } from 'vue-router'
@@ -51,6 +53,7 @@
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
   
   const router = useRouter()
+  const openWindow = window
 
   const showDeleteDialog = ref(false)
   const showTagsDialog = ref(false)

--- a/src/frontend/src/views/JobDashboardView.vue
+++ b/src/frontend/src/views/JobDashboardView.vue
@@ -254,7 +254,7 @@
       <q-btn
         outline  
         label="Return to Jobs"
-        @click="router.back()"
+        @click="store.initialPage ? router.push('/jobs') : router.back()"
         class="cancel-btn q-mt-lg"
         color="primary"
       />
@@ -289,6 +289,9 @@ import * as notify from '../notify'
 import PlotlyGraph from '@/components/PlotlyGraph.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import JobArtifactsTable from '@/components/JobArtifactsTable.vue'
+import { useLoginStore } from '@/stores/LoginStore.ts'
+
+const store = useLoginStore()
 
 const route = useRoute()
 const router = useRouter()

--- a/src/frontend/src/views/JobsView.vue
+++ b/src/frontend/src/views/JobsView.vue
@@ -14,7 +14,10 @@
     @editTags="(row) => { editObjTags = row; showTagsDialog = true }"
     @create="pushToJobRoute"
     :hideOpenBtn="true"
-    @edit="router.push(`/jobs/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/jobs/${selected[0].id}`, '_blank')
+      : router.push(`/jobs/${selected[0].id}`)
+    )"
     :loading="isLoading"
   >
     <template #body-cell-experiment="props">
@@ -66,6 +69,7 @@
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
   import JobStatus from '@/components/JobStatus.vue'
 
+  const openWindow = window
   const route = useRoute()
   const router = useRouter()
 

--- a/src/frontend/src/views/PluginParamForm.vue
+++ b/src/frontend/src/views/PluginParamForm.vue
@@ -91,7 +91,7 @@
       color="primary" 
       label="Cancel"
       class="q-mr-lg cancel-btn"
-      @click="confirmLeave = true; router.back()"
+      @click="confirmLeave = true; store.initialPage ? router.push(`/pluginParams`) : router.back()"
     />
     <q-btn  
       @click="submit()" 

--- a/src/frontend/src/views/PluginParamsView.vue
+++ b/src/frontend/src/views/PluginParamsView.vue
@@ -5,7 +5,10 @@
     :columns="columns"
     title="Plugin Parameter Types"
     v-model:selected="selected"
-    @edit="router.push(`/pluginParams/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/pluginParams/${selected[0].id}`, '_blank')
+      : router.push(`/pluginParams/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getPluginParameterTypes"
     ref="tableRef"
@@ -41,10 +44,9 @@
   import * as notify from '../notify'
   import PageTitle from '@/components/PageTitle.vue'
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
-  import { useLoginStore } from '@/stores/LoginStore'
   import { useRouter } from 'vue-router'
 
-  const store = useLoginStore()
+  const openWindow = window
   const router = useRouter()
 
   const selected = ref([])

--- a/src/frontend/src/views/PluginsView.vue
+++ b/src/frontend/src/views/PluginsView.vue
@@ -6,7 +6,10 @@
     :columns="columns"
     title="Plugins"
     v-model:selected="selected"  
-    @edit="router.push(`/plugins/${selected[0].id}`)"
+    @open="openTab => (openTab
+      ? openWindow.open(`/plugins/${selected[0].id}`, '_blank')
+      : router.push(`/plugins/${selected[0].id}`)
+    )"
     @delete="showDeleteDialog = true"
     @request="getPlugins"
     ref="tableRef"
@@ -46,9 +49,8 @@
   import * as notify from '../notify'
   import PageTitle from '@/components/PageTitle.vue'
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
-  import { useLoginStore } from '@/stores/LoginStore.ts'
 
-  const store = useLoginStore()
+  const openWindow = window
 
   const router = useRouter()
 

--- a/src/frontend/src/views/QueuesFormDraftView.vue
+++ b/src/frontend/src/views/QueuesFormDraftView.vue
@@ -76,7 +76,7 @@
           color="primary" 
           label="Cancel"
           class="q-mr-lg cancel-btn"
-          @click="confirmLeave = true; router.back()"
+          @click="confirmLeave = true; store.initialPage ? router.push('/queues') : router.back()"
         />
         <q-btn  
           @click="submit()" 

--- a/src/frontend/src/views/QueuesFormView.vue
+++ b/src/frontend/src/views/QueuesFormView.vue
@@ -90,7 +90,7 @@
           color="primary" 
           label="Cancel"
           class="q-mr-lg cancel-btn"
-          @click="confirmLeave = true; router.back()"
+          @click="confirmLeave = true; store.initialPage ? router.push('/queues') : router.back()"
           :disable="history"
         />
         <q-btn  

--- a/src/frontend/src/views/QueuesView.vue
+++ b/src/frontend/src/views/QueuesView.vue
@@ -5,7 +5,7 @@
     :columns="showDrafts ? draftColumns : columns"
     title="Queues"
     @delete="showDeleteDialog = true"
-    @edit="openQueue()"
+    @open="openQueue($event)"
     v-model:selected="selected"
     v-model:showDrafts="showDrafts"
     @request="getQueues"
@@ -46,12 +46,10 @@
   import * as notify from '../notify'
   import TableComponent from '@/components/TableComponent.vue'
   import DeleteDialog from '@/dialogs/DeleteDialog.vue'
-  import { useLoginStore } from '@/stores/LoginStore'
   import AssignTagsDialog from '@/dialogs/AssignTagsDialog.vue'
   import PageTitle from '@/components/PageTitle.vue'
   import { useRouter } from 'vue-router'
 
-  const store = useLoginStore()
   const router = useRouter()
 
   const showDeleteDialog = ref(false)
@@ -122,12 +120,13 @@
 
   const editObjTags = ref({})
 
-  function openQueue() {
-    if(selected.value[0].payload) {
-      router.push(`/queues/${selected.value[0].id}/draft`)
-    } else {
-      router.push(`/queues/${selected.value[0].id}`)
-    }
+  function openQueue(openTab) {
+    const url = selected.value[0].payload
+      ? `/queues/${selected.value[0].id}/draft`
+      : `/queues/${selected.value[0].id}`
+
+    if(openTab) window.open(url, '_blank', 'noopener,noreferrer')
+    else router.push(url)
   }
 
 </script>


### PR DESCRIPTION
Closes remaining checkboxes in #971 

- Add ability to open table row in new tab
  - Middle click (mouse wheel)
  - Cmd + click (macOS)
  - Ctrl + click (Windows / Linux)
  - Right click -> open new tab
  - "open new tab" icon button next to id

- When opening in new tab or going directly to a URL, then hitting `Cancel`, it should go to the logical parent page.  Otherwise Cancel should act as a back button.