### PR TITLE
fix: docker frontend errors

### DIFF
--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/cookiecutter.json
@@ -96,7 +96,7 @@
         "nodejs": {
             "image": "node",
             "namespace": "",
-            "tag": "18",
+            "tag": "22-bullseye",
             "registry": ""
         },
         "redis": {

--- a/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/scripts/init-frontend.sh
+++ b/cookiecutter-templates/cookiecutter-dioptra-deployment/{{cookiecutter.__project_slug}}/scripts/init-frontend.sh
@@ -294,6 +294,7 @@ prepare_build_dir() {
     "tsconfig.app.json"
     "tsconfig.node.json"
     "vite.config.ts"
+    "env.d.ts"
   )
 
   log_info "Creating the build directory ${BUILD_DIR}"

--- a/src/frontend/env.d.ts
+++ b/src/frontend/env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+declare module '*.css'
+declare module '*.scss'
+declare module '*.sass'


### PR DESCRIPTION
Resolves 2 issues below when running the containers.  See slack thread for details.

- When installing the frontend, we get `You are using Node.js 18.20.8.  Vite requires Node.js version 20.19+ or 22.12+.  Please upgrade your Node.js version.`   In cookiecutter.json I updated the version to `22-bullseye`
- After the node error, we get errors that typescript cant import css files.  I added css module declarations in `env.d.ts` so that typescript treats them as files.  Also I added this file in `init-frontend.sh` so that it's copied over into the build.