### PR TITLE
fix: fix sort by last_modified_on for repository pattern resources

### DIFF
--- a/src/dioptra/restapi/db/repository/experiments.py
+++ b/src/dioptra/restapi/db/repository/experiments.py
@@ -26,6 +26,7 @@ from dioptra.restapi.db.models import (
     EntryPoint,
     Experiment,
     Group,
+    Resource,
     Tag,
 )
 
@@ -37,12 +38,12 @@ class ExperimentRepository:
         "tag": lambda x: Experiment.tags.any(Tag.name.like(x, escape="/")),
     }
 
-    # Maps a general sort criterion name to an Experiment attribute name
-    SORTABLE_FIELDS: Final[dict[str, str]] = {
-        "name": "name",
-        "createdOn": "created_on",
-        "lastModifiedOn": "last_modified_on",
-        "description": "description",
+    # Maps a general sort criterion name to an Experiment attribute
+    SORTABLE_FIELDS: Final[dict[str, Any]] = {
+        "name": Experiment.name,
+        "createdOn": Experiment.created_on,
+        "lastModifiedOn": Resource.last_modified_on,
+        "description": Experiment.description,
     }
 
     def __init__(self, session: utils.CompatibleSession[utils.S]):

--- a/src/dioptra/restapi/db/repository/queues.py
+++ b/src/dioptra/restapi/db/repository/queues.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any, Final, overload
 
 import dioptra.restapi.db.repository.utils as utils
-from dioptra.restapi.db.models import Group, Queue, Tag
+from dioptra.restapi.db.models import Group, Queue, Resource, Tag
 
 
 class QueueRepository:
@@ -32,12 +32,12 @@ class QueueRepository:
         "tag": lambda x: Queue.tags.any(Tag.name.like(x, escape="/")),
     }
 
-    # Maps a general sort criterion name to a Queue attribute name
-    SORTABLE_FIELDS: Final[dict[str, str]] = {
-        "name": "name",
-        "createdOn": "created_on",
-        "lastModifiedOn": "last_modified_on",
-        "description": "description",
+    # Maps a general sort criterion name to a Queue attribute
+    SORTABLE_FIELDS: Final[dict[str, Any]] = {
+        "name": Queue.name,
+        "createdOn": Queue.created_on,
+        "lastModifiedOn": Resource.last_modified_on,
+        "description": Queue.description,
     }
 
     def __init__(self, session: utils.CompatibleSession[utils.S]):

--- a/src/dioptra/restapi/db/repository/types.py
+++ b/src/dioptra/restapi/db/repository/types.py
@@ -25,6 +25,7 @@ import dioptra.restapi.db.repository.utils as utils
 from dioptra.restapi.db.models import (
     Group,
     PluginTaskParameterType,
+    Resource,
     Tag,
 )
 
@@ -38,11 +39,12 @@ class TypeRepository:
         "tag": lambda x: PluginTaskParameterType.tags.any(Tag.name.like(x, escape="/")),
     }
 
+    # Maps a general sort criterion name to an PluginTaskParameterType attribute
     SORTABLE_FIELDS: Final[dict[str, Any]] = {
-        "name": "name",
-        "createdOn": "created_on",
-        "lastModifiedOn": "last_modified_on",
-        "description": "description",
+        "name": PluginTaskParameterType.name,
+        "createdOn": PluginTaskParameterType.created_on,
+        "lastModifiedOn": Resource.last_modified_on,
+        "description": PluginTaskParameterType.description,
     }
 
     def __init__(self, session: utils.CompatibleSession[utils.S]):

--- a/src/dioptra/restapi/db/repository/utils/resources.py
+++ b/src/dioptra/restapi/db/repository/utils/resources.py
@@ -714,7 +714,7 @@ def add_resource_lock_types(
 def get_by_filters_paged(
     session: CompatibleSession[S],
     snap_class: typing.Type[ResourceT],
-    sortable_fields: dict[str, str],
+    sortable_fields: dict[str, typing.Any],
     searchable_fields: dict[str, typing.Any],
     group: m.Group | int | None,
     filters: list[dict],
@@ -733,8 +733,7 @@ def get_by_filters_paged(
             of resource to get
         sortable_fields: Determines the legal values for the "sort_by"
             argument.  This is a dict which maps a legal sort_by value to
-            the name of an attribute of the "snap_class" argument.  The
-            attribute value corresponds to a table column to sort by.
+            an attribute corresponding to a table column to sort by.
         searchable_fields: Determines the legal filters in the "filters"
             argument.  This is a dict which maps from a search field name to a
             function of one argument which transforms a query string to an
@@ -765,11 +764,8 @@ def get_by_filters_paged(
         EntityDeletedError: if the given group is deleted
     """
     sql_filter = construct_sql_query_filters(filters, searchable_fields)
-    if sort_by:
-        if sort_by in sortable_fields:
-            sort_by = sortable_fields[sort_by]
-        else:
-            raise e.SortParameterValidationError("resource", sort_by)
+    if sort_by and sort_by not in sortable_fields:
+        raise e.SortParameterValidationError("resource", sort_by)
     group_id = None if group is None else get_group_id(group)
 
     if group_id is not None:
@@ -813,7 +809,7 @@ def get_by_filters_paged(
         page_stmt = apply_resource_deletion_policy(page_stmt, deletion_policy)
 
         if sort_by:
-            sort_criteria = getattr(snap_class, sort_by)
+            sort_criteria = sortable_fields[sort_by]
             if descending:
                 sort_criteria = sort_criteria.desc()
         else:


### PR DESCRIPTION
The repository pattern implementation for sorting resources broke sorting by last_modified_on. The implementation used a mapping from field name to attribute name a corresponding sortable column, which was then used with `getattr` to get the sortable column object. This doesn't work when the attribute name isn't a attribute of the Resource type as is the case with `last_modified_on`.

This commit changes the implementation to map the field name to the sortable column object directly. This matches the implementation currently in place for Resources that aren't using the repository pattern.


To test: in the UI create multiple Queues and Param-Types. Attempt to sort by last_modified_on by clicking on the table header. You should receive a 500 error. Switch to this branch and sort should work as expected.

closes #895 