### PR TITLE
fix(restapi): capture 500 error

### DIFF
--- a/src/dioptra/restapi/v1/workflows/service.py
+++ b/src/dioptra/restapi/v1/workflows/service.py
@@ -725,7 +725,7 @@ class ResourceImportService(object):
                     log=log,
                 )
 
-    def _register_entrypoints(
+    def _register_entrypoints(  # noqa: C901
         self,
         group_id: int,
         entrypoints_config: list[dict[str, Any]],


### PR DESCRIPTION
Address #1000.

In the future, it may be desirable as a feature to have it be possible to use artifacts that are not directly registered (or are declared, but not defined) in the TOML - for example, if an external GitHub repository wants to somehow use some of the artifact plugins in dioptra's extra folder.