### PR TITLE
fix: update "add to task graph" button for tasks with no params

### DIFF
--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -906,7 +906,7 @@
   }
 
   function addToArtifactGraph(task) {
-    let string = `<output-name>:\n  contents: <contents>\n  task:\n    args:\n    name: ${task.name}`
+    let string = `<output-name>:\n  contents: <contents>\n  task:\n    name: ${task.name}`
     if(entryPoint.value.artifactGraph.trim().length === 0) {
       entryPoint.value.artifactGraph = string
     } else {


### PR DESCRIPTION
Closes #1002 

In the entrypoint form, for function tasks, the "add to task graph" button will now use [Mixed Style Invocation](https://pages.nist.gov/dioptra/reference/task-engine-reference.html#mixed-style-invocation) to accomidate tasks with and without parameters.

```
<step-name>:
  task: hello_world
  kwargs:
    greeting: <input-value>
    name: <input-value>
<step-name>:
  task: taskWithNoParams
```