### PR TITLE
Remove uv caches from Dockerfile builds in Github Actions

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -114,25 +114,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup cache
-        if: matrix.dioptra-app != 'nginx'
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: cache-mount
-          key: cache-mount-${{ matrix.dioptra-app }}-${{ steps.platform.outputs.pair }}-${{ hashFiles('uv.lock') }}
-
-      - name: Inject cache into Buildkit
-        if: matrix.dioptra-app != 'nginx'
-        uses: reproducible-containers/buildkit-cache-dance@v3
-        with:
-          builder: ${{ steps.setup-buildx.outputs.name }}
-          cache-map: |
-            {
-              "cache-mount": "/root/.cache/uv"
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The uv cache sizes produced by building the project Dockerfiles is quite large and regularly exceeds the 10GB allocation, causing them to be frequently removed. In addition, the pulling and uploading of the cache adds significant overhead to the Dockerfile build times. This commit removes this functionality since it is not serving the intended purpose of speeding up builds and preventing the redownloading of packages.