### PR TITLE
Ensure both example notebooks offer the same import options

### DIFF
--- a/examples/hello_world.ipynb
+++ b/examples/hello_world.ipynb
@@ -72,7 +72,7 @@
     "# import from git\n",
     "response = client.workflows.import_resources(\n",
     "    group_id=1,\n",
-    "    source=\"https://github.com/usnistgov/dioptra.git;extra#dev\",\n",
+    "    source=\"https://github.com/usnistgov/dioptra.git#main\",\n",
     "    config_path=\"extra/dioptra.toml\",\n",
     "    resolve_name_conflicts_strategy=\"update\",\n",
     ")\n",
@@ -250,7 +250,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dioptra",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -264,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/examples/mnist_demo.ipynb
+++ b/examples/mnist_demo.ipynb
@@ -203,11 +203,43 @@
    "metadata": {},
    "source": [
     "In this step, we do several things:\n",
-    "  1. Upload all the plugins and entrypoints in the `extra/` folder.\n",
+    "  1. Import the resources (plugins, entrypoints, and plugin parameter types) used in this example. It is possible to import from a git repository (Option A) or from files on the local filesystem (Option B), choose one of the two options below.\n",
     "  2. Register these plugins and entrypoints with the Dioptra RESTAPI for use in our experiment.\n",
     "  3. Create a queue which represents the `tensorflow-cpu` container created as part of the Dioptra default installation.\n",
     "  4. Register an experiment named `mnist_fgm`.\n",
     "  5. Associate all of the entrypoints we created with the `mnist_fgm` experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import from git (Option A)\n",
+    "response = client.workflows.import_resources(\n",
+    "    group_id=1,\n",
+    "    source=\"https://github.com/usnistgov/dioptra.git#main\",\n",
+    "    config_path=\"dioptra_optic.toml\",\n",
+    "    resolve_name_conflicts_strategy=\"update\",\n",
+    ")\n",
+    "resources = response[\"resources\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import from local filesystem (Option B)\n",
+    "response = client.workflows.import_resources(\n",
+    "    group_id=1,\n",
+    "    source=select_files_in_directory(\"../extra/\", recursive=True),\n",
+    "    config_path=\"dioptra_optic.toml\",\n",
+    "    resolve_name_conflicts_strategy=\"update\",\n",
+    ")\n",
+    "resources = response[\"resources\"]"
    ]
   },
   {
@@ -221,15 +253,6 @@
     "QUEUE_NAME = \"tensorflow-cpu\"\n",
     "QUEUE_DESC = \"Tensorflow CPU Queue\"\n",
     "JOB_TIME_LIMIT = \"1h\"\n",
-    "\n",
-    "# import from local filesystem\n",
-    "\n",
-    "response = client.workflows.import_resources(group_id=1,\n",
-    "                                             source=select_files_in_directory(\"../extra/\", recursive=True),\n",
-    "                                             config_path=\"dioptra_optic.toml\",\n",
-    "                                             resolve_name_conflicts_strategy=\"update\",\n",
-    "                                            )\n",
-    "resources = response[\"resources\"]\n",
     "\n",
     "train_ep = resources[\"entrypoints\"][\"Train Keras Image Classifier\"]\n",
     "fgm_ep = resources[\"entrypoints\"][\"Evasion Attack: Fast Gradient Method\"]\n",
@@ -655,7 +678,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The hello_world.ipynb and mnist_demo.ipynb tutorial notebooks differed in how the import_resources() method was provided to users. The former offered both git-based and filesystem-based import options, while the latter only offered filesystem-based imports. Furthermore, the hello_world.ipynb notebook retained the old ";extra" parameter in the git URL and pointed at the dev branch.

The hello_world.ipynb notebook was fixed by dropping the ";extra" parameter and pointing at the main branch instead of the dev branch in the git source URL option. The mnist_demo.ipynb notebook was fixed by updating the notebook to provide the same two options for importing resources as the hello_world.ipynb notebook.