### PR TITLE
Update the postgres_container_tag reference default to 17

### DIFF
--- a/docs/source/how-to/setup-dioptra/reference/deployment-template-reference.rst
+++ b/docs/source/how-to/setup-dioptra/reference/deployment-template-reference.rst
@@ -123,7 +123,7 @@ If ``False``, the NGINX ports will be exposed on all available network interface
 postgres_container_tag
 ~~~~~~~~~~~~~~~~~~~~~~
 
-**Default:** ``18``
+**Default:** ``17``
 
 Sets the version of PostgreSQL to be used in the deployment.
 For a full list of available versions, visit the *Tags* tab on the `postgres image page on Docker Hub <https://hub.docker.com/_/postgres>`__.


### PR DESCRIPTION
Missed this value in the docs in the recent fix e3b7bec8f94715a3c48a84ed24fc15f565b0ba9a pushed to main.