### PR TITLE
fix: unlink queues from parent entrypoints on deletion

### DIFF
--- a/src/dioptra/restapi/db/repository/queues.py
+++ b/src/dioptra/restapi/db/repository/queues.py
@@ -127,6 +127,21 @@ class QueueRepository:
 
         utils.delete_resource(self.session, queue)
 
+    def unlink_entrypoints(self, queue: Queue | int) -> None:
+        """
+        "Unlink" the all parent entry points from the given queue.  This
+        only severs the relationship; it does not delete either resource.  If
+        there is no parent/child relationship, this is a no-op.
+
+        Args:
+            queue: An queue or resource_id integer primary key value
+
+        Raises:
+            EntityDoesNotExistError: if parent or child do not exist
+        """
+
+        utils.unlink_parents(self.session, queue)
+
     @overload
     def get(
         self,

--- a/src/dioptra/restapi/db/repository/utils/resources.py
+++ b/src/dioptra/restapi/db/repository/utils/resources.py
@@ -563,6 +563,83 @@ def unlink_child(
             break
 
 
+def unlink_parents(
+    session: CompatibleSession[S],
+    child: m.Resource | m.ResourceSnapshot | int,
+):
+    """
+    "Unlink" the all parents from the given child.  This only severs the
+    relationship; it does not delete either resource.  If there is no
+    parent/child relationship, this is a no-op.
+
+    Args:
+        session: An SQLAlchemy session
+        child: A resource, snapshot, or resource_id integer primary key
+            value
+
+    Raises:
+        EntityDoesNotExistError: if the child do not exist
+    """
+
+    child = get_one_resource(session, child, DeletionPolicy.ANY)
+    child.parents.clear()
+
+
+def get_one_resource(
+    session: CompatibleSession[S],
+    resource: m.Resource | m.ResourceSnapshot | int,
+    deletion_policy: DeletionPolicy,
+) -> m.Resource:
+    """
+    Get the a resource given the resource, resource snapshot, or resource ID; require
+    that exactly one is found, or raise an exception.
+
+    Args:
+        session: An SQLAlchemy session
+        resource: A resource or resource snapshot or integer resource ID
+        deletion_policy: Whether to look at deleted resources, non-deleted
+            resources, or all resources
+
+    Returns:
+        A resource
+
+    Raises:
+        EntityDoesNotExistError: if the resource does not exist in the database
+            (deleted or not)
+        EntityExistsError: if the resource exists and is not deleted, but
+            policy was to find a deleted resource
+        EntityDeletedError: if the resource is deleted, but policy was to find
+            a non-deleted resource
+    """
+    resource_id = get_resource_id(resource)
+
+    stmt = sa.select(m.Resource).where(m.Resource.resource_id == resource_id)
+    resource_obj = session.scalar(stmt)
+
+    if resource_obj is None:
+        existence_result = ExistenceResult.DOES_NOT_EXIST
+    elif resource_obj.is_deleted:
+        existence_result = ExistenceResult.DELETED
+    else:
+        existence_result = ExistenceResult.EXISTS
+
+    resource_type = resource_obj.resource_type if resource_obj is not None else None
+
+    # Here, we combine the passed-in deletion policy with existence, to
+    # determine the exception.
+    assert_exists(
+        deletion_policy,
+        existence_result,
+        resource_type,
+        resource_id,
+    )
+
+    # The above assert_exists() function would have raised an exception, so
+    # latest can't be None here.
+    assert resource_obj is not None
+    return resource_obj
+
+
 def delete_resource(
     session: CompatibleSession[S], resource: m.Resource | m.ResourceSnapshot | int
 ) -> None:
@@ -836,8 +913,10 @@ __all__ = [
     "get_latest_child_snapshots",
     "get_latest_snapshots",
     "get_one_latest_snapshot",
+    "get_one_resource",
     "get_resource_lock_types",
     "get_snapshot_by_name",
     "set_resource_children",
+    "unlink_parents",
     "unlink_child",
 ]

--- a/src/dioptra/restapi/db/repository/utils/resources.py
+++ b/src/dioptra/restapi/db/repository/utils/resources.py
@@ -543,24 +543,11 @@ def unlink_child(
     Raises:
         EntityDoesNotExistError: if parent or child do not exist
     """
-    assert_resource_exists(session, parent, DeletionPolicy.ANY)
-    assert_resource_exists(session, child, DeletionPolicy.ANY)
 
-    # We need a parent object...
-    if isinstance(parent, int):
-        temp = session.get(m.Resource, parent)
-        # I just checked parent exists above, so the above .get() should not
-        # return None.
-        assert temp is not None
-        parent = temp
+    parent_obj = get_one_resource(session, parent, DeletionPolicy.ANY)
+    child_obj = get_one_resource(session, child, DeletionPolicy.ANY)
 
-    # ... but a child ID
-    child_id = get_resource_id(child)
-
-    for idx, child in enumerate(parent.children):
-        if child.resource_id == child_id:
-            del parent.children[idx]
-            break
+    parent_obj.children.remove(child_obj)
 
 
 def unlink_parents(
@@ -612,6 +599,7 @@ def get_one_resource(
             a non-deleted resource
     """
     resource_id = get_resource_id(resource)
+    resource_type = get_resource_type(resource)
 
     stmt = sa.select(m.Resource).where(m.Resource.resource_id == resource_id)
     resource_obj = session.scalar(stmt)
@@ -622,8 +610,6 @@ def get_one_resource(
         existence_result = ExistenceResult.DELETED
     else:
         existence_result = ExistenceResult.EXISTS
-
-    resource_type = resource_obj.resource_type if resource_obj is not None else None
 
     # Here, we combine the passed-in deletion policy with existence, to
     # determine the exception.

--- a/src/dioptra/restapi/v1/queues/service.py
+++ b/src/dioptra/restapi/v1/queues/service.py
@@ -298,6 +298,7 @@ class QueueIdService(object):
 
         with self._uow:
             # No-op if already deleted
+            self._uow.queue_repo.unlink_entrypoints(queue_id)
             self._uow.queue_repo.delete(queue_id)
 
         log.debug("Queue deleted", queue_id=queue_id)

--- a/tests/unit/restapi/test_queue_repository.py
+++ b/tests/unit/restapi/test_queue_repository.py
@@ -308,6 +308,7 @@ def test_queue_delete(queue_repo, db_session: DBSession, queue_snap_setup):
     queue_repo.delete(queues[0])
     db_session.commit()
     assert queues[0].resource.is_deleted
+    assert queues[0].resource.parents == []
 
     # Second time should be a no-op
     queue_repo.delete(queues[0])

--- a/tests/unit/restapi/test_repo_utils.py
+++ b/tests/unit/restapi/test_repo_utils.py
@@ -1334,6 +1334,21 @@ def test_get_one_latest_snapshot_bad_id_uses_resource_entity_type(db_session):
     assert exc_info.value.entity_type is EntityType.RESOURCE
 
 
+def test_get_one_resource(db_session, resource_status, deletion_policy):
+
+    snap, status = resource_status
+
+    exc = helpers.expected_exception_for_combined_status((status,), deletion_policy)
+
+    if exc:
+        with pytest.raises(exc):
+            utils.get_one_resource(db_session, snap, deletion_policy)
+    else:
+        resource = utils.get_one_resource(db_session, snap.resource_id, deletion_policy)
+
+        assert resource == snap.resource
+
+
 def test_get_latest_child_snapshots(db_session, resource_parent_combo, deletion_policy):
 
     parent, child_snaps, _ = resource_parent_combo
@@ -1851,6 +1866,38 @@ def test_unlink_child_child_not_exist(db_session, fake_data, account):
 
     with pytest.raises(EntityDoesNotExistError):
         utils.unlink_child(db_session, exp, 999999)
+
+
+def test_unlink_parents(db_session, fake_data, account):
+    qres = models.Resource("queue", account.group)
+    q = models.Queue("", qres, account.user, "queue1")
+
+    epres1 = models.Resource("entry_point", account.group)
+    ep1 = models.EntryPoint(
+        "", epres1, account.user, "ep1", "graph:", "artifacts_input:", [], []
+    )
+
+    epres2 = models.Resource("entry_point", account.group)
+    ep2 = models.EntryPoint(
+        "", epres2, account.user, "ep2", "graph:", "artifacts_input:", [], []
+    )
+
+    qres.parents.extend((ep1.resource, ep2.resource))
+    db_session.add(q)
+    db_session.commit()
+
+    assert len(q.parents) == 2
+    utils.unlink_parents(db_session, q)
+    db_session.commit()
+
+    assert q.parents == []
+    assert ep1.children == []
+    assert ep2.children == []
+
+
+def test_unlink_parents_parent_not_exist(db_session):
+    with pytest.raises(EntityDoesNotExistError):
+        utils.unlink_parents(db_session, -1)
 
 
 def test_filter_all_unsorted(db_session, queue_filter_setup):

--- a/tests/unit/restapi/v1/workflows/test_resource_import.py
+++ b/tests/unit/restapi/v1/workflows/test_resource_import.py
@@ -222,6 +222,39 @@ def test_resource_import_update(
     )
 
 
+def test_resource_import_update_deleted_queue(
+    dioptra_client: DioptraClient[DioptraResponseProtocol],
+    auth_account: dict[str, Any],
+    resources_tar_file: NamedTemporaryFile,
+):
+    group_id = auth_account["groups"][0]["id"]
+    description_to_replace = "original description"
+
+    entrypoint_response = dioptra_client.entrypoints.create(
+        group_id=group_id,
+        name="Hello World",
+        task_graph="",
+        description=description_to_replace,
+    )
+    dioptra_client.plugins.create(
+        group_id=group_id, name="hello_world", description=description_to_replace
+    )
+    dioptra_client.plugin_parameter_types.create(
+        group_id=group_id, name="message", description=description_to_replace
+    )
+    queue_response = dioptra_client.queues.create(group_id=group_id, name="queue")
+    dioptra_client.entrypoints.queues.create(
+        entrypoint_response.json()["id"], [queue_response.json()["id"]]
+    )
+    dioptra_client.queues.delete_by_id(queue_response.json()["id"])
+    assert_resource_import_update_works(
+        dioptra_client,
+        group_id=group_id,
+        archive_file=resources_tar_file,
+        description=description_to_replace,
+    )
+
+
 def test_resource_import_overwrite(
     dioptra_client: DioptraClient[DioptraResponseProtocol],
     auth_account: dict[str, Any],


### PR DESCRIPTION
This commit fixes a bug in which the REST API could raise a 500 error when a queue attached to an entrypoint was deleted and then the entrypoint was modified.

The fix is to unlink all entrypoints from a queue when it is deleted.

This commit includes a new test.