### PR TITLE
Remember pagination

### DIFF
--- a/src/frontend/src/components/ResourceBadge.vue
+++ b/src/frontend/src/components/ResourceBadge.vue
@@ -146,7 +146,12 @@ function openResource(event) {
     return
   }
 
-  router.push({ path: formattedUrl.value, state: { viaBadgeLink: true } })
+  const r = router.resolve(formattedUrl.value)
+  router.push({
+    path: r.path,
+    query: { ...r.query },
+    state: { viaBadgeLink: true }
+  })
 }
 </script>
 

--- a/src/frontend/src/components/ResourceBadge.vue
+++ b/src/frontend/src/components/ResourceBadge.vue
@@ -146,7 +146,7 @@ function openResource(event) {
     return
   }
 
-  router.push(formattedUrl.value)
+  router.push({ path: formattedUrl.value, state: { viaBadgeLink: true } })
 }
 </script>
 

--- a/src/frontend/src/components/SnapshotList.vue
+++ b/src/frontend/src/components/SnapshotList.vue
@@ -3,20 +3,20 @@
     :rows="snapshots"
     :columns="columns"
     v-model:selected="selected"
-    :title="props.maxHeight ? '' : 'Snapshots'"
+    title="Snapshots"
     :hideCreateBtn="true"
     :hideSearch="true"
     rowKey="snapshot"
     :showAll="true"
     :style="{ 
       marginTop: '0', 
-      maxHeight: props.maxHeight ? props.maxHeight + 'px' : '',
-      height: props.maxHeight ? '' : 'calc(100vh - 50px)'
+      height: 'calc(100vh - 50px)'
     }"
     :hideOpenBtn="true"
     :hideDeleteBtn="true"
     :highlightSelection="true"
     :defaultSort="{sortBy: 'snapshotCreatedOn', descending: true}"
+    :preserveSort="false"
   >
     <template #body-cell-snapshotCreatedOn="props">
       <div :data-snapshot-id="props.row.snapshot">
@@ -50,7 +50,7 @@ import TableComponent from '@/components/TableComponent.vue'
 import { ref, watch, nextTick } from 'vue'
 import * as api from '@/services/dataApi'
 
-const props = defineProps(['showDialogHistory', 'type', 'id', 'maxHeight'])
+const props = defineProps(['showDialogHistory', 'type', 'id'])
 
 const store = useLoginStore()
 const route = useRoute()

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -211,6 +211,8 @@
 
 <script setup>
   import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+  import { useRoute } from 'vue-router'
+  import { useLoginStore } from '@/stores/LoginStore'
   import { useQuasar } from 'quasar'
   import * as notify from '../notify'
 
@@ -287,6 +289,8 @@
   })
 
   const $q = useQuasar()
+  const route = useRoute()
+  const loginStore = useLoginStore()
 
   const darkMode = computed(() => {
     if($q.dark.mode === 'auto') {
@@ -359,7 +363,17 @@
 
   const tableRef = ref()
   onMounted(() => {
-    // get initial data from server (1st page)
+    // Restore cached pagination when arriving via back; otherwise use defaults
+    const key = route.path
+    const cached = loginStore.tablePaginationCache[key]
+    if (route.meta.backButton && cached) {
+      pagination.value = { ...pagination.value, ...cached }
+      // consume one-shot flag
+      route.meta.backButton = false
+    } else if(cached) {
+      delete loginStore.tablePaginationCache[key]
+    }
+    // get initial data from server with current pagination
     tableRef.value.requestServerInteraction()
   })
 
@@ -379,6 +393,15 @@
       return
     }
     pagination.value = requestProps.pagination
+    // cache current pagination keyed by route path
+    if(route.path !== '/') {
+      loginStore.tablePaginationCache[route.path] = {
+        page: pagination.value.page,
+        rowsPerPage: pagination.value.rowsPerPage,
+        sortBy: pagination.value.sortBy,
+        descending: pagination.value.descending,
+      }
+    }
     const paginationOptions = requestProps.pagination
     const { page, rowsPerPage } = requestProps.pagination
     const index = (page - 1) * rowsPerPage

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -36,7 +36,7 @@
           </span>
           <q-icon 
             v-if="col.sortable"
-            :name="getSortIcon(col.field)"
+            :name="getSortIcon(col.name)"
             class="sort-icon"
           />
         </q-th>

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -252,6 +252,10 @@
   defaultSort: {
     type: Object,
     default: { sortBy: 'lastModifiedOn', descending: true }
+  },
+  preserveSort: {
+    type: Boolean,
+    default: true
   }
 })
   const emit = defineEmits([
@@ -465,7 +469,7 @@
     invalidSearchNotification()
 
     // cache current pagination keyed by route path
-    if(route.path !== '/') {
+    if(props.preserveSort) {
       loginStore.tablePaginationCache[path] = {
         page: pagination.value.page,
         rowsPerPage: pagination.value.rowsPerPage,

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -368,6 +368,7 @@
     const cached = loginStore.tablePaginationCache[key]
     if (route.meta.backButton && cached) {
       pagination.value = { ...pagination.value, ...cached }
+      showDeleted.value = cached.showDeleted
       // consume one-shot flag
       route.meta.backButton = false
     } else if(cached) {
@@ -400,6 +401,7 @@
         rowsPerPage: pagination.value.rowsPerPage,
         sortBy: pagination.value.sortBy,
         descending: pagination.value.descending,
+        showDeleted: props.showDeleted
       }
     }
     const paginationOptions = requestProps.pagination

--- a/src/frontend/src/components/TableComponent.vue
+++ b/src/frontend/src/components/TableComponent.vue
@@ -210,7 +210,7 @@
 </template>
 
 <script setup>
-  import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+  import { ref, watch, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
   import { useRoute } from 'vue-router'
   import { useLoginStore } from '@/stores/LoginStore'
   import { useQuasar } from 'quasar'
@@ -232,6 +232,7 @@
   showAll: Boolean,
   highlightRow: Boolean,
   selection: String,
+  loading: Boolean,
   disabledRowKeys: {
     type: Array,
     default: []
@@ -348,6 +349,18 @@
     if(newVal !== oldVal) selected.value = []
   })
 
+  watch(() => props.loading, async (newVal) => {
+    if(!newVal) {
+      await nextTick()
+      // after loading, scroll to saved position
+      if(route.meta.backButton && loginStore.tablePaginationCache[route.path]) {
+        window.scrollTo({
+          top: loginStore.tablePaginationCache[route.path].lastScrollPosition,
+        })
+      }
+    }
+  })
+
   function getSelectedColor(selected) {
     if (!props.highlightSelection) return
     if(darkMode.value && selected) return 'bg-deep-purple-10'
@@ -369,8 +382,7 @@
     if (route.meta.backButton && cached) {
       pagination.value = { ...pagination.value, ...cached }
       showDeleted.value = cached.showDeleted
-      // consume one-shot flag
-      route.meta.backButton = false
+      filter.value = cached.search
     } else if(cached) {
       delete loginStore.tablePaginationCache[key]
     }
@@ -394,16 +406,6 @@
       return
     }
     pagination.value = requestProps.pagination
-    // cache current pagination keyed by route path
-    if(route.path !== '/') {
-      loginStore.tablePaginationCache[route.path] = {
-        page: pagination.value.page,
-        rowsPerPage: pagination.value.rowsPerPage,
-        sortBy: pagination.value.sortBy,
-        descending: pagination.value.descending,
-        showDeleted: props.showDeleted
-      }
-    }
     const paginationOptions = requestProps.pagination
     const { page, rowsPerPage } = requestProps.pagination
     const index = (page - 1) * rowsPerPage
@@ -457,8 +459,23 @@
     return ''
   }
 
+  const path = route.path
+
   onBeforeUnmount(() => {
     invalidSearchNotification()
+
+    // cache current pagination keyed by route path
+    if(route.path !== '/') {
+      loginStore.tablePaginationCache[path] = {
+        page: pagination.value.page,
+        rowsPerPage: pagination.value.rowsPerPage,
+        sortBy: pagination.value.sortBy,
+        descending: pagination.value.descending,
+        showDeleted: props.showDeleted,
+        search: filter.value,
+        lastScrollPosition: window.scrollY
+      }
+    }
   })
 
   function updateTotalRows(totalRows) {

--- a/src/frontend/src/dialogs/AssignPluginsDialog.vue
+++ b/src/frontend/src/dialogs/AssignPluginsDialog.vue
@@ -1,25 +1,38 @@
 <template>
-  <DialogComponent 
-    v-model="showDialog"
-    @emitSubmit="submitPlugins"
-    :hideDraftBtn="true"
-  >
-    <template #title>
-      <label id="modalTitle">
-        Assign {{ pluginType === 'plugins' ? 'Plugins' : 'Artifact Plugins' }} for '{{ editObj.name }}'
-      </label>
-    </template>
-    <AssignPluginsDropdown
-      v-model:selectedPlugins="selectedPlugins"
-      v-model:pluginIDsToUpdate="pluginIDsToUpdate"
-      v-model:pluginIDsToRemove="pluginIDsToRemove"
-    />
-  </DialogComponent>
+  <q-dialog v-model="showDialog">
+    <q-card style="min-width: 35%;">
+      <q-card-section class="bg-primary text-white text-h6">
+        <div class="text-h6">Assign {{ pluginType === 'plugins' ? 'Plugins' : 'Artifact Plugins' }} for '{{ editObj.name }}'</div>
+      </q-card-section>
+      <q-card-section>
+        <AssignPluginsDropdown
+          v-model:selectedPlugins="selectedPlugins"
+          v-model:pluginIDsToUpdate="pluginIDsToUpdate"
+          v-model:pluginIDsToRemove="pluginIDsToRemove"
+        />
+      </q-card-section>
+      <q-separator />
+      <q-card-actions align="right">
+        <q-btn 
+          outline
+          color="primary cancel-btn" 
+          label="Cancel" 
+          v-close-popup 
+          class="q-mr-xs"
+        />
+        <q-btn
+          label="Confirm"
+          color="primary"
+          type="submit"
+          @click="submitPlugins()"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
 </template>
 
 <script setup>
   import { ref, onUpdated } from 'vue'
-  import DialogComponent from './DialogComponent.vue'
   import * as api from '@/services/dataApi'
   import * as notify from '../notify'
   import AssignPluginsDropdown from '@/components/AssignPluginsDropdown.vue'
@@ -52,7 +65,7 @@
         await api.removePluginFromEntrypoint(props.editObj.id, pluginId, props.pluginType)
       }
       notify.success(`Successfully updated plugins for '${props.editObj.name}'`)
-      emit('refreshTable')
+      emit('refreshTable', props.editObj.id)
       showDialog.value = false
     } catch (err) {
       notify.error(err.response.data.message);

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -179,13 +179,6 @@ const router = createRouter({
 router.beforeEach(async (to, from) => {
   const store = useLoginStore()
 
-  const backButton = window.event?.type === 'popstate'
-  const backToSameType = to.meta?.type === from.meta?.type
-  const jobBackToExperiment = to.name === 'experimentJobs' && from.name === 'jobDashboard'
-  if(backButton && (backToSameType || jobBackToExperiment)) {
-    to.meta.backButton = true
-  }
-
   // on every route change, close snapshot drawer if open
   if(store.showRightDrawer) {
     store.showRightDrawer = false
@@ -222,6 +215,20 @@ async function callGetLoginStatus() {
     store.loggedInUser = ''
   }
 }
+
+router.afterEach((to, from) => {
+  // remember pagination when clicking into a resource then going back to the table
+  const backButton = window.event?.type === 'popstate'
+  const backToSameType = to.meta?.type === from.meta?.type
+  const jobBackToExperiment = to.name === 'experimentJobs' && from.name === 'jobDashboard'
+  const viaBadgeLink = window.history.state?.viaBadgeLink === true
+  if (viaBadgeLink) {
+    to.meta.viaBadgeLink = true
+  }
+  if(backButton && (backToSameType || jobBackToExperiment || from.meta?.viaBadgeLink)) {
+    to.meta.backButton = true
+  }
+})
 
 
 export default router

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -232,6 +232,15 @@ router.afterEach((to, from) => {
   if(backButton && (backToSameType || jobBackToExperiment || from.meta?.viaBadgeLink)) {
     to.meta.backButton = true
   }
+
+  // ensure only to and from pagination settings are stored
+  const store = useLoginStore()
+  const keep = new Set<string>([to.path, from.path])
+  Object.keys(store.tablePaginationCache).forEach((k) => {
+    if (!keep.has(k)) {
+      delete (store.tablePaginationCache as any)[k]
+    }
+  })
 })
 
 

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -2,11 +2,13 @@ import { createRouter, createWebHistory, START_LOCATION } from 'vue-router'
 import { useLoginStore } from '@/stores/LoginStore'
 import HomeView from '../views/HomeView.vue'
 import * as api from '@/services/dataApi'
-import { scroll } from 'quasar'
-const { getScrollTarget, setVerticalScrollPosition } = scroll
 
 const router = createRouter({
   history: createWebHistory(),
+  scrollBehavior(to, from, savedPosition) {
+    // always scroll to top
+    return { top: 0 }
+  },
   routes: [
     {
       path: '/',
@@ -230,13 +232,6 @@ router.afterEach((to, from) => {
   if(backButton && (backToSameType || jobBackToExperiment || from.meta?.viaBadgeLink)) {
     to.meta.backButton = true
   }
-
-  // Reset scroll on forward navigations
-  // if (!backButton) {
-  //   const el = document.querySelector('.q-page-container') as HTMLElement | null
-  //   const target = el ? getScrollTarget(el) : window
-  //   setVerticalScrollPosition(target, 0)
-  // }
 })
 
 

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -13,22 +13,20 @@ const router = createRouter({
     },
     {
       path: '/experiments',
+      meta: { type: 'experiments' },
       children: [
         {
           path: '',
           component: () => import('../views/ExperimentsView.vue'),
-          meta: { type: 'experiments' },
           name: 'experiments',
         },
         {
           path: '/experiments/new',
           component: () => import('../views/CreateExperiment.vue'),
-          meta: { type: 'experiments' }
         },
         {
           path: '/experiments/:id',
           component: () => import('../views/EditExperiment.vue'),
-          meta: { type: 'experiments' },
           name: 'experimentJobs'
         },
         {
@@ -40,6 +38,7 @@ const router = createRouter({
     },
     {
       path: '/entrypoints',
+      meta: { type: 'entrypoints' },
       children: [
         {
           path: '',
@@ -49,12 +48,12 @@ const router = createRouter({
         {
           path: '/entrypoints/:id',
           component: () => import('../views/CreateEntryPoint.vue'),
-          meta: { type: 'entrypoints' }
         },
       ]
     },
     {
       path: '/plugins',
+      meta: { type: 'plugins' },
       children: [
         {
           path: '',
@@ -64,7 +63,6 @@ const router = createRouter({
         {
           path: '/plugins/new',
           component: () => import('../views/CreatePluginView.vue'),
-          meta: { type: 'plugins' }
         },
         {
           path: '/plugins/:id',
@@ -80,6 +78,7 @@ const router = createRouter({
     },
     {
       path: '/queues',
+      meta: { type: 'queues' },
       children: [
         {
           path: '',
@@ -89,17 +88,16 @@ const router = createRouter({
         {
           path: '/queues/:id/:draftType/:newResourceDraft?',
           component: () => import('../views/QueuesFormDraftView.vue'),
-          meta: { type: 'queues' }
         },
         {
           path: '/queues/:id',
           component: () => import('../views/QueuesFormView.vue'),
-          meta: { type: 'queues' }
         },
       ]
     },
     {
       path: '/jobs',
+      meta: { type: 'jobs' },
       children: [
         {
           path: '',
@@ -131,6 +129,7 @@ const router = createRouter({
     },
     {
       path: '/pluginParams',
+      meta: { type: 'pluginParams' },
       children: [
         {
           path: '',
@@ -151,17 +150,16 @@ const router = createRouter({
     },
     {
       path: '/artifacts',
+      meta: { type: 'artifacts' },
       children: [
         {
           path: '/artifacts',
           component: () => import('../views/ArtifactsView.vue'),
           name: 'artifacts',
-          meta: { type: 'artifacts' }
         },
         {
           path: '/artifacts/:id',
           component: () => import('../views/EditArtifactView.vue'),
-          meta: { type: 'artifacts' }
         },
       ]
     },
@@ -179,6 +177,12 @@ const router = createRouter({
 
 router.beforeEach(async (to, from) => {
   const store = useLoginStore()
+
+  const backButton = window.event?.type === 'popstate'
+  const backToSameType = to.meta?.type === from.meta?.type
+  if(backButton && backToSameType) {
+    to.meta.backButton = true
+  }
 
   // on every route change, close snapshot drawer if open
   if(store.showRightDrawer) {

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -110,7 +110,8 @@ const router = createRouter({
         },
         {
           path: '/jobs/:id',
-          component: () => import('../views/JobDashboardView.vue')
+          component: () => import('../views/JobDashboardView.vue'),
+          name: 'jobDashboard'
         },
       ]
     },
@@ -180,7 +181,8 @@ router.beforeEach(async (to, from) => {
 
   const backButton = window.event?.type === 'popstate'
   const backToSameType = to.meta?.type === from.meta?.type
-  if(backButton && backToSameType) {
+  const jobBackToExperiment = to.name === 'experimentJobs' && from.name === 'jobDashboard'
+  if(backButton && (backToSameType || jobBackToExperiment)) {
     to.meta.backButton = true
   }
 

--- a/src/frontend/src/router/index.ts
+++ b/src/frontend/src/router/index.ts
@@ -2,6 +2,8 @@ import { createRouter, createWebHistory, START_LOCATION } from 'vue-router'
 import { useLoginStore } from '@/stores/LoginStore'
 import HomeView from '../views/HomeView.vue'
 import * as api from '@/services/dataApi'
+import { scroll } from 'quasar'
+const { getScrollTarget, setVerticalScrollPosition } = scroll
 
 const router = createRouter({
   history: createWebHistory(),
@@ -228,6 +230,13 @@ router.afterEach((to, from) => {
   if(backButton && (backToSameType || jobBackToExperiment || from.meta?.viaBadgeLink)) {
     to.meta.backButton = true
   }
+
+  // Reset scroll on forward navigations
+  // if (!backButton) {
+  //   const el = document.querySelector('.q-page-container') as HTMLElement | null
+  //   const target = el ? getScrollTarget(el) : window
+  //   setVerticalScrollPosition(target, 0)
+  // }
 })
 
 

--- a/src/frontend/src/stores/LoginStore.ts
+++ b/src/frontend/src/stores/LoginStore.ts
@@ -51,10 +51,18 @@ export const useLoginStore = defineStore('login', () => {
 
   const initialPage = ref(false)
 
+  // cache table pagination by route path (in-memory; resets on refresh)
+  const tablePaginationCache = ref<Record<string, {
+    page: number
+    rowsPerPage: number
+    sortBy?: string
+    descending?: boolean
+  }>>({})
+
   // computed()'s are getters
 
   // function()'s are actions
   
 
-  return { loggedInUser, loggedInGroup, groups, users, savedForms, showRightDrawer, selectedSnapshot, triggerPopup, initialPage };
+  return { loggedInUser, loggedInGroup, groups, users, savedForms, showRightDrawer, selectedSnapshot, triggerPopup, initialPage, tablePaginationCache };
 })

--- a/src/frontend/src/stores/LoginStore.ts
+++ b/src/frontend/src/stores/LoginStore.ts
@@ -57,6 +57,8 @@ export const useLoginStore = defineStore('login', () => {
     rowsPerPage: number
     sortBy?: string
     descending?: boolean
+    lastScrollPosition?: number,
+    search?: string
   }>>({})
 
   // computed()'s are getters

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -924,10 +924,10 @@
   const confirmLeave = ref(false)
   const toPath = ref()
 
-  onBeforeRouteLeave((to, from, next) => {
+  onBeforeRouteLeave((to, from) => {
     toPath.value = to.path
     if(confirmLeave.value || !valuesChangedFromEditStart.value || history.value) {
-      next(true)
+      return true
     } else if(route.params.id === 'new') {
       leaveForm()
     } else {

--- a/src/frontend/src/views/CreateExperiment.vue
+++ b/src/frontend/src/views/CreateExperiment.vue
@@ -246,16 +246,16 @@
     })
   }
 
-  onBeforeRouteLeave((to, from, next) => {
+  onBeforeRouteLeave((to, from) => {
     toPath.value = to.path
     if(confirmLeave.value) {
-      next(true)
+      return true
     } else if(valuesChangedFromOriginal.value) {
       store.savedForms.experiment = experiment.value
-      next(true)
+      return true
     } else {
       store.savedForms.experiment = null
-      next(true)
+      return true
     }
   })
 

--- a/src/frontend/src/views/CreateJob.vue
+++ b/src/frontend/src/views/CreateJob.vue
@@ -930,16 +930,16 @@
     }
   })
 
-  onBeforeRouteLeave((to, from, next) => {
+  onBeforeRouteLeave((to, from) => {
     toPath.value = to.path
     if(!valuesChanged.value) {
       store.savedForms.jobs[expJobOrAllJobs.value] = null
-      next(true)
+      return true
     } else if(confirmLeave.value) {
-      next(true)
+      return true
     } else {
       store.savedForms.jobs[expJobOrAllJobs.value] = job.value
-      next(true)
+      return true
     }
   })
 

--- a/src/frontend/src/views/CreatePluginFile.vue
+++ b/src/frontend/src/views/CreatePluginFile.vue
@@ -634,10 +634,10 @@
     pluginFile.value.tasks[selectedTaskProps.value.functionsOrArtifacts][selectedTaskProps.value.rowIndex][selectedTaskProps.value.inputOrOutputParams].push(newParam)
   }
 
-  onBeforeRouteLeave((to, from, next) => {
+  onBeforeRouteLeave((to, from) => {
     toPath.value = to.path
     if(confirmLeave.value || !valuesChangedFromEditStart.value) {
-      next(true)
+      return true
     } else if(route.params.fileId === 'new') {
       leaveForm()
     } else {

--- a/src/frontend/src/views/CreatePluginView.vue
+++ b/src/frontend/src/views/CreatePluginView.vue
@@ -163,16 +163,16 @@ const showReturnDialog = ref(false)
 const confirmLeave = ref(false)
 const toPath = ref()
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave((to, from) => {
   toPath.value = to.path
   if(confirmLeave.value) {
-    next(true)
+    return true
   } else if(valuesChangedFromOriginal.value) {
     store.savedForms.plugin = plugin.value
-    next(true)
+    return true
   } else {
     store.savedForms.plugin = null
-    next(true)
+    return true
   }
 })
 

--- a/src/frontend/src/views/EntryPointsView.vue
+++ b/src/frontend/src/views/EntryPointsView.vue
@@ -94,7 +94,7 @@
     v-model="showAssignPluginsDialog"
     :pluginType="pluginType"
     :editObj="editEntrypoint"
-    @refreshTable="tableRef.refreshTable()"
+    @refreshTable="(id) => updateSingleEntrypoint(id)"
   />
 </template>
 
@@ -181,10 +181,22 @@
   async function syncPlugin(entrypointId, pluginId, pluginName, pluginType) {
     try {
       await api.addPluginsToEntrypoint(entrypointId, [pluginId], pluginType)
-      tableRef.value.refreshTable()
+      await updateSingleEntrypoint(entrypointId)
       notify.success(`Successfully updated plugin '${pluginName}' to latest version`)
     } catch(err) {
       console.warn(err)
+      notify.error(err.response.data.message);
+    }
+  }
+
+  async function updateSingleEntrypoint(entrypointId) {
+    try {
+      const res = await api.getItem('entrypoints', entrypointId)
+      const idx = entrypoints.value.findIndex((e) => e.id === entrypointId)
+      entrypoints.value[idx] = res.data
+    } catch(err) {
+      console.warn(err)
+      notify.error(err.response.data.message);
     }
   }
 

--- a/src/frontend/src/views/PluginParamForm.vue
+++ b/src/frontend/src/views/PluginParamForm.vue
@@ -269,16 +269,16 @@ const showReturnDialog = ref(false)
 const confirmLeave = ref(false)
 const toPath = ref()
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave((to, from) => {
   toPath.value = to.path
   if(confirmLeave.value) {
-    next(true)
+    return true
   } else if(valuesChangedFromOriginal.value && route.params.id === 'new') {
     store.savedForms.pluginParamType = pluginParamType.value
-    next(true)
+    return true
   } else {
     store.savedForms.pluginParamType = null
-    next(true)
+    return true
   }
 })
 

--- a/src/frontend/src/views/QueuesFormDraftView.vue
+++ b/src/frontend/src/views/QueuesFormDraftView.vue
@@ -263,16 +263,16 @@ const showReturnDialog = ref(false)
 const confirmLeave = ref(false)
 const toPath = ref()
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave((to, from) => {
   toPath.value = to.path
   if(confirmLeave.value) {
-    next(true)
+    return true
   } else if(valuesChangedFromEditStart.value && route.params.id === 'new') {
     store.savedForms.queue = queue.value
-    next(true)
+    return true
   } else {
     store.savedForms.queue = null
-    next(true)
+    return true
   }
 })
 

--- a/src/frontend/src/views/QueuesFormView.vue
+++ b/src/frontend/src/views/QueuesFormView.vue
@@ -282,16 +282,16 @@ const showReturnDialog = ref(false)
 const confirmLeave = ref(false)
 const toPath = ref()
 
-onBeforeRouteLeave((to, from, next) => {
+onBeforeRouteLeave((to, from) => {
   toPath.value = to.path
   if(confirmLeave.value) {
-    next(true)
+    return true
   } else if(valuesChangedFromEditStart.value && route.params.id === 'new') {
     store.savedForms.queue = queue.value
-    next(true)
+    return true
   } else {
     store.savedForms.queue = null
-    next(true)
+    return true
   }
 })
 


### PR DESCRIPTION
Closes #1252 

- When hitting back or cancel to return to a table page, the table should remember your previous pagination and sort settings. However in all other cases such as refresh or navigating to the page or saving/deleting a resource and being redirected back to the table page, it should use the default sort and start on page 1.
- Should also work when clicking on a resource badge in a table then hitting back
- Search terms and show deleted toggle should also be restored when going back to table
- Scroll position should also be restored when going back to table.  In all other cases pages should load at top.

- Also includes a minor fix for the entrypoint page: when add/remove/sync'ing plugins directly on the entrypoint table, only that row will be refreshed and not the whole table.  This prevents the row from jumping to the top due to the default sort by last modified.  This seems to be the best expected behavior since you're updating a row, not refreshing the whole table.