### PR TITLE
fix: remove baseUrl to fix typescript error

### DIFF
--- a/src/frontend/tsconfig.app.json
+++ b/src/frontend/tsconfig.app.json
@@ -5,7 +5,6 @@
   "compilerOptions": {
     "composite": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
To resolve error below when building frontend:

Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.