### PR TITLE
ci: add uv.lock refresh workflow

### DIFF
--- a/.github/actions/monitor-refresh-validation/action.yml
+++ b/.github/actions/monitor-refresh-validation/action.yml
@@ -1,0 +1,46 @@
+name: Monitor refresh validation
+description: Monitor validation workflows dispatched by the uv.lock refresh workflow.
+inputs:
+  repository:
+    description: GitHub repository in OWNER/REPO form.
+    required: true
+  pr-number:
+    description: Pull request number to update.
+    required: true
+  head-branch:
+    description: Automation branch that validation workflows run against.
+    required: true
+  source-branch:
+    description: Source branch that the automation branch was rebuilt from.
+    required: true
+  head-sha:
+    description: Commit SHA on the automation branch.
+    required: true
+  dispatch-started-at:
+    description: UTC timestamp captured before dispatching validation workflows.
+    required: true
+  timeout-seconds:
+    description: Maximum seconds to wait for validation workflows.
+    required: false
+    default: "3600"
+  poll-interval-seconds:
+    description: Seconds to wait between polling attempts.
+    required: false
+    default: "30"
+runs:
+  using: composite
+  steps:
+    - name: Monitor validation workflows
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        uv run --no-project python "$ACTION_PATH/monitor.py" \
+          --repository "${{ inputs.repository }}" \
+          --pr-number "${{ inputs.pr-number }}" \
+          --head-branch "${{ inputs.head-branch }}" \
+          --source-branch "${{ inputs.source-branch }}" \
+          --head-sha "${{ inputs.head-sha }}" \
+          --dispatch-started-at "${{ inputs.dispatch-started-at }}" \
+          --timeout-seconds "${{ inputs.timeout-seconds }}" \
+          --poll-interval-seconds "${{ inputs.poll-interval-seconds }}"

--- a/.github/actions/monitor-refresh-validation/monitor.py
+++ b/.github/actions/monitor-refresh-validation/monitor.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+"""Monitor validation workflows dispatched by the uv.lock refresh workflow."""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALIDATION_START = "<!-- refresh-validation:start -->"
+VALIDATION_END = "<!-- refresh-validation:end -->"
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    file_name: str
+    display_name: str
+
+
+@dataclass
+class RunResult:
+    spec: WorkflowSpec
+    database_id: int | None = None
+    url: str | None = None
+    status: str = "not found"
+    conclusion: str | None = None
+    jobs: list[dict[str, Any]] = field(default_factory=list)
+    timed_out: bool = False
+
+
+WORKFLOWS = (
+    WorkflowSpec(file_name="tox-tests.yml", display_name="Tox tests"),
+    WorkflowSpec(file_name="sphinx-docs.yml", display_name="Sphinx documentation"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr-number", required=True)
+    parser.add_argument("--head-branch", required=True)
+    parser.add_argument("--source-branch", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--dispatch-started-at", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--poll-interval-seconds", type=int, default=30)
+    return parser.parse_args()
+
+
+def parse_github_timestamp(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+
+    return datetime.fromisoformat(value).astimezone(timezone.utc)
+
+
+def run_gh_json(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    if not result.stdout.strip():
+        return None
+
+    return json.loads(result.stdout)
+
+
+def run_gh(args: list[str]) -> None:
+    subprocess.run(["gh", *args], check=True)
+
+
+def discover_run(
+    *,
+    repo: str,
+    spec: WorkflowSpec,
+    head_branch: str,
+    head_sha: str,
+    dispatch_started_at: datetime,
+) -> RunResult | None:
+    runs = run_gh_json(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            spec.file_name,
+            "--branch",
+            head_branch,
+            "--event",
+            "workflow_dispatch",
+            "--commit",
+            head_sha,
+            "--limit",
+            "20",
+            "--json",
+            "databaseId,status,conclusion,event,headBranch,headSha,createdAt,url",
+        ]
+    )
+
+    matches = [
+        run
+        for run in runs
+        if run.get("event") == "workflow_dispatch"
+        and run.get("headBranch") == head_branch
+        and run.get("headSha") == head_sha
+        and parse_github_timestamp(run["createdAt"]) >= dispatch_started_at
+    ]
+    if not matches:
+        return None
+
+    matches.sort(key=lambda run: parse_github_timestamp(run["createdAt"]), reverse=True)
+    match = matches[0]
+    return RunResult(
+        spec=spec,
+        database_id=match["databaseId"],
+        url=match["url"],
+        status=match["status"],
+        conclusion=match.get("conclusion"),
+    )
+
+
+def refresh_run(repo: str, result: RunResult) -> RunResult:
+    if result.database_id is None:
+        return result
+
+    run = run_gh_json(
+        [
+            "run",
+            "view",
+            str(result.database_id),
+            "--repo",
+            repo,
+            "--json",
+            "databaseId,status,conclusion,url,jobs",
+        ]
+    )
+    result.status = run["status"]
+    result.conclusion = run.get("conclusion")
+    result.url = run["url"]
+    result.jobs = run.get("jobs", [])
+    return result
+
+
+def poll_runs(
+    *,
+    repo: str,
+    head_branch: str,
+    head_sha: str,
+    dispatch_started_at: datetime,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+) -> list[RunResult]:
+    results = {spec.file_name: RunResult(spec=spec) for spec in WORKFLOWS}
+    deadline = time.monotonic() + timeout_seconds
+
+    while time.monotonic() < deadline:
+        for spec in WORKFLOWS:
+            result = results[spec.file_name]
+            if result.database_id is None:
+                discovered = discover_run(
+                    repo=repo,
+                    spec=spec,
+                    head_branch=head_branch,
+                    head_sha=head_sha,
+                    dispatch_started_at=dispatch_started_at,
+                )
+                if discovered is not None:
+                    result = discovered
+
+            if result.database_id is not None:
+                result = refresh_run(repo, result)
+
+            results[spec.file_name] = result
+
+        if all(result.status == "completed" for result in results.values()):
+            return list(results.values())
+
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds > 0:
+            time.sleep(min(poll_interval_seconds, remaining_seconds))
+
+    for result in results.values():
+        if result.status != "completed":
+            result.timed_out = True
+
+    return list(results.values())
+
+
+def failed_job_names(jobs: list[dict[str, Any]]) -> list[str]:
+    return [
+        job["name"]
+        for job in jobs
+        if job.get("status") == "completed"
+        and job.get("conclusion") not in {"success", "skipped", None}
+    ]
+
+
+def markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def markdown_code(value: str) -> str:
+    escaped = value.replace("`", "\\`")
+    return f"`{escaped}`"
+
+
+def result_succeeded(result: RunResult) -> bool:
+    return result.status == "completed" and result.conclusion == "success"
+
+
+def validation_succeeded(results: list[RunResult]) -> bool:
+    return all(result_succeeded(result) for result in results)
+
+
+def summarize_result(result: RunResult) -> str:
+    if result.database_id is None:
+        if result.timed_out:
+            return "not found before timeout"
+
+        return "not found"
+
+    if result.status != "completed":
+        if result.timed_out:
+            return f"timed out while {result.status}"
+
+        return result.status
+
+    conclusion = result.conclusion or "completed"
+    if conclusion == "success":
+        return "success"
+
+    jobs = failed_job_names(result.jobs)
+    if not jobs:
+        return conclusion
+
+    formatted_jobs = ", ".join(markdown_code(job) for job in jobs)
+    return f"{conclusion}, failed jobs: {formatted_jobs}"
+
+
+def render_validation_section(
+    *,
+    results: list[RunResult],
+    head_branch: str,
+    source_branch: str,
+) -> str:
+    lines = [
+        VALIDATION_START,
+        "## Validation",
+        "",
+        "| Workflow | Status | Run |",
+        "| --- | --- | --- |",
+    ]
+
+    for result in results:
+        run_link = ""
+        if result.database_id is not None and result.url is not None:
+            run_link = f"[Run {result.database_id}]({result.url})"
+
+        lines.append(
+            "| "
+            f"{markdown_cell(result.spec.display_name)} | "
+            f"{markdown_cell(summarize_result(result))} | "
+            f"{run_link} |"
+        )
+
+    lines.append("")
+    if validation_succeeded(results):
+        lines.append(
+            "Validation completed successfully. This pull request only refreshes "
+            "`uv.lock`."
+        )
+    else:
+        lines.append(
+            f"Validation failed. Do not fix this on `{head_branch}`; the refresh "
+            f"workflow recreates that branch from `{source_branch}` on each run. "
+            f"Make compatibility fixes or dependency constraint changes on "
+            f"`{source_branch}`, then rerun the lockfile refresh workflow."
+        )
+
+    lines.append(VALIDATION_END)
+    return "\n".join(lines)
+
+
+def replace_validation_section(body: str, validation_section: str) -> str:
+    start_index = body.find(VALIDATION_START)
+    end_index = body.find(VALIDATION_END)
+
+    if start_index != -1 and end_index != -1 and start_index < end_index:
+        end_index += len(VALIDATION_END)
+        return f"{body[:start_index]}{validation_section}{body[end_index:]}"
+
+    body = body.rstrip()
+    if body:
+        return f"{body}\n\n{validation_section}\n"
+
+    return f"{validation_section}\n"
+
+
+def get_pr_body(repo: str, pr_number: str) -> str:
+    pr = run_gh_json(
+        [
+            "pr",
+            "view",
+            pr_number,
+            "--repo",
+            repo,
+            "--json",
+            "body",
+        ]
+    )
+    return pr.get("body") or ""
+
+
+def update_pr_body(repo: str, pr_number: str, body: str) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
+        f.write(body)
+        body_path = Path(f.name)
+
+    try:
+        run_gh(
+            [
+                "pr",
+                "edit",
+                pr_number,
+                "--repo",
+                repo,
+                "--body-file",
+                str(body_path),
+            ]
+        )
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    args = parse_args()
+    dispatch_started_at = parse_github_timestamp(args.dispatch_started_at)
+
+    results = poll_runs(
+        repo=args.repository,
+        head_branch=args.head_branch,
+        head_sha=args.head_sha,
+        dispatch_started_at=dispatch_started_at,
+        timeout_seconds=args.timeout_seconds,
+        poll_interval_seconds=args.poll_interval_seconds,
+    )
+    validation_section = render_validation_section(
+        results=results,
+        head_branch=args.head_branch,
+        source_branch=args.source_branch,
+    )
+    pr_body = get_pr_body(args.repository, args.pr_number)
+    update_pr_body(
+        args.repository,
+        args.pr_number,
+        replace_validation_section(pr_body, validation_section),
+    )
+
+    print(validation_section)
+    if not validation_succeeded(results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/monitor-refresh-validation/tests/test_monitor.py
+++ b/.github/actions/monitor-refresh-validation/tests/test_monitor.py
@@ -1,11 +1,28 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
 import importlib.util
 import unittest
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).parents[1] / "monitor.py"
 SPEC = importlib.util.spec_from_file_location("monitor", MODULE_PATH)
-monitor = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None
 assert SPEC.loader is not None
+monitor = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(monitor)
 
 

--- a/.github/actions/monitor-refresh-validation/tests/test_monitor.py
+++ b/.github/actions/monitor-refresh-validation/tests/test_monitor.py
@@ -1,0 +1,123 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[1] / "monitor.py"
+SPEC = importlib.util.spec_from_file_location("monitor", MODULE_PATH)
+monitor = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(monitor)
+
+
+class MonitorRefreshValidationTests(unittest.TestCase):
+    def test_replace_validation_section_replaces_existing_section(self) -> None:
+        body = "\n".join(
+            [
+                "Intro",
+                "",
+                monitor.VALIDATION_START,
+                "old",
+                monitor.VALIDATION_END,
+                "",
+                "Tail",
+            ]
+        )
+
+        result = monitor.replace_validation_section(body, "new")
+
+        self.assertEqual(result, "Intro\n\nnew\n\nTail")
+
+    def test_replace_validation_section_appends_new_section(self) -> None:
+        result = monitor.replace_validation_section("Intro\n", "new")
+
+        self.assertEqual(result, "Intro\n\nnew\n")
+
+    def test_render_validation_section_reports_failed_jobs(self) -> None:
+        results = [
+            monitor.RunResult(
+                spec=monitor.WorkflowSpec("tox-tests.yml", "Tox tests"),
+                database_id=1,
+                url="https://github.com/usnistgov/dioptra/actions/runs/1",
+                status="completed",
+                conclusion="failure",
+                jobs=[
+                    {
+                        "name": "linting-and-style-checks (3.11, mypy)",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    }
+                ],
+            ),
+            monitor.RunResult(
+                spec=monitor.WorkflowSpec(
+                    "sphinx-docs.yml",
+                    "Sphinx documentation",
+                ),
+                database_id=2,
+                url="https://github.com/usnistgov/dioptra/actions/runs/2",
+                status="completed",
+                conclusion="success",
+            ),
+        ]
+
+        section = monitor.render_validation_section(
+            results=results,
+            head_branch="automation/refresh-uv-lock-dev",
+            source_branch="dev",
+        )
+
+        self.assertIn(
+            "failure, failed jobs: `linting-and-style-checks (3.11, mypy)`",
+            section,
+        )
+        self.assertIn(
+            "[Run 1](https://github.com/usnistgov/dioptra/actions/runs/1)", section
+        )
+        self.assertIn("Validation failed.", section)
+        self.assertFalse(monitor.validation_succeeded(results))
+
+    def test_render_validation_section_reports_success(self) -> None:
+        results = [
+            monitor.RunResult(
+                spec=monitor.WorkflowSpec("tox-tests.yml", "Tox tests"),
+                database_id=1,
+                url="https://github.com/usnistgov/dioptra/actions/runs/1",
+                status="completed",
+                conclusion="success",
+            )
+        ]
+
+        section = monitor.render_validation_section(
+            results=results,
+            head_branch="automation/refresh-uv-lock-dev",
+            source_branch="dev",
+        )
+
+        self.assertIn("Validation completed successfully.", section)
+        self.assertTrue(monitor.validation_succeeded(results))
+
+    def test_timed_out_run_is_a_failure(self) -> None:
+        result = monitor.RunResult(
+            spec=monitor.WorkflowSpec("tox-tests.yml", "Tox tests"),
+            database_id=1,
+            status="in_progress",
+            timed_out=True,
+        )
+
+        self.assertEqual(
+            monitor.summarize_result(result), "timed out while in_progress"
+        )
+        self.assertFalse(monitor.validation_succeeded([result]))
+
+    def test_missing_run_timeout_is_reported(self) -> None:
+        result = monitor.RunResult(
+            spec=monitor.WorkflowSpec("tox-tests.yml", "Tox tests"),
+            timed_out=True,
+        )
+
+        self.assertEqual(monitor.summarize_result(result), "not found before timeout")
+        self.assertFalse(monitor.validation_succeeded([result]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -105,6 +105,7 @@ jobs:
           echo "Would dispatch tox-tests.yml and sphinx-docs.yml against ${AUTOMATION_BRANCH}."
 
       - name: Commit and push refresh
+        id: refresh-branch
         if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
         run: |
           git config user.name "github-actions[bot]"
@@ -121,7 +122,10 @@ jobs:
             git push origin "HEAD:refs/heads/${AUTOMATION_BRANCH}"
           fi
 
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Open or update pull request
+        id: pull-request
         if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
         run: |
           pr_body="${RUNNER_TEMP}/refresh-uv-lock-pr-body.md"
@@ -130,7 +134,7 @@ jobs:
 
           The refresh workflow ran \`uv lock --upgrade\`, which updates locked packages within the constraints in \`pyproject.toml\`.
 
-          After opening or updating this pull request, the workflow dispatches tox tests and the Sphinx documentation build against \`${AUTOMATION_BRANCH}\`.
+          After opening or updating this pull request, the workflow dispatches tox tests and the Sphinx documentation build against \`${AUTOMATION_BRANCH}\` and reports their results here.
           EOF
 
           pr_number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${AUTOMATION_BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // ""')"
@@ -138,11 +142,28 @@ jobs:
             gh pr edit "$pr_number" --repo "${GITHUB_REPOSITORY}" --title "${PR_TITLE}" --body-file "$pr_body" --base "${TARGET_BRANCH}"
             echo "Updated pull request #${pr_number}."
           else
-            gh pr create --repo "${GITHUB_REPOSITORY}" --base "${TARGET_BRANCH}" --head "${AUTOMATION_BRANCH}" --title "${PR_TITLE}" --body-file "$pr_body"
+            pr_url="$(gh pr create --repo "${GITHUB_REPOSITORY}" --base "${TARGET_BRANCH}" --head "${AUTOMATION_BRANCH}" --title "${PR_TITLE}" --body-file "$pr_body")"
+            pr_number="$(gh pr view "$pr_url" --repo "${GITHUB_REPOSITORY}" --json number --jq '.number')"
           fi
 
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch validation workflows
+        id: dispatch-validation
         if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
         run: |
+          dispatch_started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "dispatch_started_at=${dispatch_started_at}" >> "$GITHUB_OUTPUT"
           gh workflow run tox-tests.yml --repo "${GITHUB_REPOSITORY}" --ref "${AUTOMATION_BRANCH}"
           gh workflow run sphinx-docs.yml --repo "${GITHUB_REPOSITORY}" --ref "${AUTOMATION_BRANCH}"
+
+      - name: Monitor validation workflows
+        if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
+        uses: ./.github/actions/monitor-refresh-validation
+        with:
+          repository: ${{ github.repository }}
+          pr-number: ${{ steps.pull-request.outputs.pr_number }}
+          head-branch: ${{ env.AUTOMATION_BRANCH }}
+          source-branch: ${{ env.TARGET_BRANCH }}
+          head-sha: ${{ steps.refresh-branch.outputs.head_sha }}
+          dispatch-started-at: ${{ steps.dispatch-validation.outputs.dispatch_started_at }}

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -1,0 +1,148 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+name: Refresh uv.lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to refresh from.
+        required: true
+        default: dev
+        type: string
+      dry_run:
+        description: Preview the refresh without pushing or opening a pull request.
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "37 8 * * 1"
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-uv-lock-dev
+  cancel-in-progress: false
+
+env:
+  AUTOMATION_BRANCH: automation/refresh-uv-lock-dev
+  COMMIT_MESSAGE: "build: refresh uv.lock"
+  DRY_RUN: ${{ inputs.dry_run || false }}
+  PR_TITLE: "build: refresh uv.lock"
+  TARGET_BRANCH: ${{ inputs.target_branch || 'dev' }}
+
+jobs:
+  refresh:
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target_branch || 'dev' }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: "3.11"
+
+      - name: Refresh uv.lock
+        run: uv lock --upgrade
+
+      - name: Guard changed files
+        id: guard
+        run: |
+          changed_files="$(git status --porcelain=v1 --untracked-files=all | sed -E 's/^...//')"
+
+          if [ -z "$changed_files" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "uv.lock is already current for ${TARGET_BRANCH}."
+            exit 0
+          fi
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          invalid_files="$(printf '%s\n' "$changed_files" | grep -vx 'uv.lock' || true)"
+          if [ -n "$invalid_files" ]; then
+            echo "uv lock --upgrade modified files other than uv.lock:" >&2
+            printf '%s\n' "$invalid_files" >&2
+            exit 1
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Report dry run
+        if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN == 'true' }}
+        run: |
+          echo "Dry run requested. No branch, commit, pull request, or workflow dispatch will be created."
+          echo "uv.lock changed for ${TARGET_BRANCH}."
+          git diff --stat -- uv.lock
+          echo "Would recreate ${AUTOMATION_BRANCH} from ${TARGET_BRANCH}."
+          echo "Would commit uv.lock with subject: ${COMMIT_MESSAGE}"
+          echo "Would open or update a pull request into ${TARGET_BRANCH}."
+          echo "Would dispatch tox-tests.yml and sphinx-docs.yml against ${AUTOMATION_BRANCH}."
+
+      - name: Commit and push refresh
+        if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "${AUTOMATION_BRANCH}"
+          git add uv.lock
+          git commit -m "${COMMIT_MESSAGE}"
+
+          remote_sha="$(git ls-remote --heads origin "${AUTOMATION_BRANCH}" | cut -f1)"
+          if [ -n "$remote_sha" ]; then
+            git push --force-with-lease="refs/heads/${AUTOMATION_BRANCH}:${remote_sha}" origin "HEAD:refs/heads/${AUTOMATION_BRANCH}"
+          else
+            git push origin "HEAD:refs/heads/${AUTOMATION_BRANCH}"
+          fi
+
+      - name: Open or update pull request
+        if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
+        run: |
+          pr_body="${RUNNER_TEMP}/refresh-uv-lock-pr-body.md"
+          cat > "$pr_body" <<EOF
+          This pull request refreshes \`uv.lock\` for \`${TARGET_BRANCH}\`.
+
+          The refresh workflow ran \`uv lock --upgrade\`, which updates locked packages within the constraints in \`pyproject.toml\`.
+
+          After opening or updating this pull request, the workflow dispatches tox tests and the Sphinx documentation build against \`${AUTOMATION_BRANCH}\`.
+          EOF
+
+          pr_number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${AUTOMATION_BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --repo "${GITHUB_REPOSITORY}" --title "${PR_TITLE}" --body-file "$pr_body" --base "${TARGET_BRANCH}"
+            echo "Updated pull request #${pr_number}."
+          else
+            gh pr create --repo "${GITHUB_REPOSITORY}" --base "${TARGET_BRANCH}" --head "${AUTOMATION_BRANCH}" --title "${PR_TITLE}" --body-file "$pr_body"
+          fi
+
+      - name: Dispatch validation workflows
+        if: ${{ steps.guard.outputs.changed == 'true' && env.DRY_RUN != 'true' }}
+        run: |
+          gh workflow run tox-tests.yml --repo "${GITHUB_REPOSITORY}" --ref "${AUTOMATION_BRANCH}"
+          gh workflow run sphinx-docs.yml --repo "${GITHUB_REPOSITORY}" --ref "${AUTOMATION_BRANCH}"

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -22,6 +22,7 @@ on:
       - "**"
     tags:
       - "*.*.*"
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -22,6 +22,7 @@ on:
       - "**"
     tags:
       - "*.*.*"
+  workflow_dispatch:
 
 jobs:
   linting-and-style-checks:


### PR DESCRIPTION
Closes #1289

## Summary

This adds a workflow that refreshes `uv.lock` from `dev`, recreates a fixed automation branch, and opens or updates one lockfile refresh pull request when the lockfile changes.

The refresh workflow dispatches tox tests and the Sphinx documentation build against the generated automation branch. It then watches those validation workflows and updates the generated pull request body with a validation table, run links, and guidance for handling validation failures.

Because this pull request targets `dev`, the scheduled trigger is defined here but will not run on cron until the workflow also exists on the repository default branch. The implementation notes and final action-location decision are recorded in Issue #1289.

## Testing

- Ran local checks for the new action helper and workflow wiring, including Python syntax, action-local tests, Ruff, mypy, YAML parsing, actionlint, and gitlint.
- Verified a dry-run workflow test completed without creating or updating a pull request.
- Verified a full workflow test created the automation branch, updated scratch PR #1290, dispatched validation workflows, reported the tox mypy failure and Sphinx success in the pull request body, and failed the refresh workflow after reporting the validation failure.

## Test Runs

- Dry-run workflow test: https://github.com/usnistgov/dioptra/actions/runs/26192492918
- Full workflow test: https://github.com/usnistgov/dioptra/actions/runs/26192552031
- Dispatched tox validation: https://github.com/usnistgov/dioptra/actions/runs/26192578877
- Dispatched Sphinx validation: https://github.com/usnistgov/dioptra/actions/runs/26192579821
- Scratch refresh PR: https://github.com/usnistgov/dioptra/pull/1290