### PR TITLE
Frontend playwright tests

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -1,0 +1,94 @@
+name: Frontend Playwright e2e
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "dev"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      UV_PROJECT_ENVIRONMENT: .di-venv-e2e
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: src/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: src/frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: src/frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Create Dioptra e2e env file
+        run: |
+          cat > "${RUNNER_TEMP}/dioptra-e2e.env" <<EOF
+          DIOPTRA_GIT_BRANCH=dev
+          DIOPTRA_CODE_DIR=${GITHUB_WORKSPACE}
+          DIOPTRA_DEPLOY_DIR=${RUNNER_TEMP}/dioptra-e2e
+          DIOPTRA_WORKER_LIB=tensorflow-cpu
+          DIOPTRA_ENV_NAME=.di-venv-e2e
+          EOF
+
+      - name: Run Playwright e2e tests
+        working-directory: src/frontend
+        env:
+          DIOPTRA_E2E_ENV_FILE: ${{ runner.temp }}/dioptra-e2e.env
+        run: |
+          set -eo pipefail
+
+          npm run dev -- --host 127.0.0.1 > vite.log 2>&1 &
+          VITE_PID=$!
+
+          cleanup() {
+            kill "${VITE_PID}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          echo "Waiting for frontend at http://localhost:5173 ..."
+          for _ in {1..90}; do
+            if curl --silent --fail http://localhost:5173 >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+
+          if ! curl --silent --fail http://localhost:5173 >/dev/null 2>&1; then
+            echo "Frontend did not become ready."
+            cat vite.log
+            exit 1
+          fi
+
+          npm run test:e2e:with-backend
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-playwright-artifacts
+          path: |
+            src/frontend/playwright-report
+            src/frontend/test-results
+            src/frontend/vite.log
+          if-no-files-found: ignore

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -107,9 +107,10 @@ To run the unit tests:
 
 ### Running frontend end-to-end tests with Playwright
 
-This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please do the following:
+This project stores Playwright tests in the `src/frontend/tests` folder.  To run them, please do the following:
 
 1. Ensure your [frontend dev server](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#6-start-front-end) is running.
+If you haven't installed the frontend packages, in `src/frontend` run `npm install` to make sure Playwright is installed.
 
 2. Ensure your dev mode Flask server is stopped.  The test script starts its own backend using a test database.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -109,10 +109,9 @@ To run the unit tests:
 
 This project stores Playwright tests in the `src/frontend/tests` folder.  To run them, please do the following:
 
-1. Ensure your [frontend dev server](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#6-start-front-end) is running.
-If you haven't installed the frontend packages, in `src/frontend` run `npm install` to make sure Playwright is installed.
+1. If you haven't installed the frontend packages, in `src/frontend` run `npm install` to make sure Playwright is installed. You do not need to repeat this step.
 
-2. Ensure your dev mode Flask server is stopped.  The test script starts its own backend using a test database.
+2. Ensure your backend Flask server is stopped.  The test script starts it's own backend using a test database.  The test script will also start the frontend for you if it's not already running.
 
 3. If your [env-dev.cfg](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#a-configuration-file-) is not in your project root or the directory above it, please specify it's location location using this command
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -63,7 +63,7 @@ At a minimum, you should run this before opening a merge request on your branch:
     uvx tox run -e lint -- --select I --fix src/dioptra
     uvx tox run -e format -- src/dioptra
 
-If commiting any frontend changes, run the following from the src/frontend directory to lint and format frontend code:
+If commiting any frontend changes, run the following from the `src/frontend` directory to lint and format frontend code:
 
     npm run lint
     npm run format
@@ -97,6 +97,12 @@ This project stores its pytest-based unit tests in the `tests/` folder and uses 
 If you haven't done so yet, install `tox` as a uv tool:
 
     uv tool install --python 3.11 tox --with tox-uv
+
+### Running frontend end-to-end tests with Playwright
+
+This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please ensure your frontend is running and your dev mode Flask server is stopped, then run the following from `src/frontend`
+
+    test:e2e:with-backend
 
 Developers are expected to create new unit tests to validate any new features or behavior that they contribute and to verify that all unit tests pass before opening a Pull Request.
 To run the unit tests:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -102,7 +102,7 @@ If you haven't done so yet, install `tox` as a uv tool:
 
 This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please ensure your frontend is running and your dev mode Flask server is stopped, then run the following from `src/frontend`
 
-    test:e2e:with-backend
+    npm run test:e2e:with-backend
 
 Developers are expected to create new unit tests to validate any new features or behavior that they contribute and to verify that all unit tests pass before opening a Pull Request.
 To run the unit tests:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -109,17 +109,17 @@ To run the unit tests:
 
 This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please do the following:
 
-1. Ensure your [frontend dev server](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#6-start-front-end) is running
+1. Ensure your [frontend dev server](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#6-start-front-end) is running.
 
-2. Ensure your dev mode Flask server is stopped.
+2. Ensure your dev mode Flask server is stopped.  The test script starts its own backend using a test database.
 
 3. If your [env-dev.cfg](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#a-configuration-file-) is not in your project root or the directory above it, please specify it's location location using this command
 
-    export DIOPTRA_E2E_ENV_FILE=/path/to/env-dev.cfg
+        export DIOPTRA_E2E_ENV_FILE=/path/to/env-dev.cfg
 
 4. To run the tests, execute the following from `src/frontend`
 
-    npm run test:e2e:with-backend
+        npm run test:e2e:with-backend
 
 ### Cleanup
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -98,18 +98,28 @@ If you haven't done so yet, install `tox` as a uv tool:
 
     uv tool install --python 3.11 tox --with tox-uv
 
-### Running frontend end-to-end tests with Playwright
-
-This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please ensure your frontend is running and your dev mode Flask server is stopped, then run the following from `src/frontend`
-
-    npm run test:e2e:with-backend
-
 Developers are expected to create new unit tests to validate any new features or behavior that they contribute and to verify that all unit tests pass before opening a Pull Request.
 To run the unit tests:
 
     uvx tox run -e pytest -- tests/unit
     uvx tox run -e pytest-cookiecutter
     uvx tox run -e pytest-extra
+
+### Running frontend end-to-end tests with Playwright
+
+This project stores playwright tests in the `src/frontend/tests` folder.  To run them, please do the following:
+
+1. Ensure your [frontend dev server](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#6-start-front-end) is running
+
+2. Ensure your dev mode Flask server is stopped.
+
+3. If your [env-dev.cfg](https://github.com/usnistgov/dioptra/blob/main/dev-kb/local-setup/README.md#a-configuration-file-) is not in your project root or the directory above it, please specify it's location location using this command
+
+    export DIOPTRA_E2E_ENV_FILE=/path/to/env-dev.cfg
+
+4. To run the tests, execute the following from `src/frontend`
+
+    npm run test:e2e:with-backend
 
 ### Cleanup
 

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -17,6 +17,10 @@ coverage
 /cypress/videos/
 /cypress/screenshots/
 
+/playwright-report
+/test-results
+/.dioptra-e2e
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@quasar/vite-plugin": "^1.12.0",
         "@rushstack/eslint-patch": "^1.16.1",
         "@tsconfig/node18": "^18.2.6",
@@ -982,6 +983,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@quasar/extras": {
@@ -3792,6 +3809,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js-dist-min": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -16,7 +16,13 @@
     "lint": "eslint . --fix && prettier --write src/",
     "format": "prettier --write src/",
     "lint:check": "eslint .",
-    "format:check": "prettier --check src/ vite.config.ts eslint.config.js"
+    "format:check": "prettier --check src/ vite.config.ts eslint.config.js",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:with-backend": "bash ./scripts/run-e2e-with-backend.sh",
+    "test:e2e:with-backend:headed": "bash ./scripts/run-e2e-with-backend.sh --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
     "@codemirror/lang-python": "^6.2.1",
@@ -37,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@quasar/vite-plugin": "^1.12.0",
     "@rushstack/eslint-patch": "^1.16.1",
     "@tsconfig/node18": "^18.2.6",

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/frontend/scripts/run-e2e-with-backend.sh
+++ b/src/frontend/scripts/run-e2e-with-backend.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+FRONTEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(cd "${FRONTEND_DIR}/../.." && pwd)"
+
+if [ -n "${DIOPTRA_E2E_ENV_FILE:-}" ]; then
+  ENV_FILE="${DIOPTRA_E2E_ENV_FILE}"
+elif [ -f "${REPO_DIR}/env-dev.cfg" ]; then
+  ENV_FILE="${REPO_DIR}/env-dev.cfg"
+elif [ -f "${REPO_DIR}/../env-dev.cfg" ]; then
+  ENV_FILE="${REPO_DIR}/../env-dev.cfg"
+else
+  echo "Could not find env-dev.cfg."
+  echo "Set DIOPTRA_E2E_ENV_FILE=/path/to/env-dev.cfg and try again."
+  exit 1
+fi
+
+E2E_DEPLOY="${DIOPTRA_E2E_DEPLOY:-${FRONTEND_DIR}/.dioptra-e2e}"
+DB_PATH="${E2E_DEPLOY}/instance/dioptra-test.db"
+
+if curl --silent --fail http://localhost:5000/health >/dev/null 2>&1; then
+  echo "A backend is already running on http://localhost:5000."
+  echo "Stop it before running this command so tests do not write to the dev DB."
+  exit 1
+fi
+
+source "${REPO_DIR}/dev-kb/local-setup/dev-set.sh" --env "${ENV_FILE}"
+
+mkdir -p "${E2E_DEPLOY}/instance" "${E2E_DEPLOY}/workdir"
+
+export DIOPTRA_DEPLOY="${E2E_DEPLOY}"
+export DIOPTRA_RESTAPI_DEV_DATABASE_URI="sqlite:///${DB_PATH}"
+
+"${REPO_DIR}/dev-kb/local-setup/run-flask.sh" &
+FLASK_PID=$!
+
+cleanup() {
+  kill "${FLASK_PID}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Waiting for test backend at http://localhost:5000/health ..."
+for _ in {1..90}; do
+  if curl --silent --fail http://localhost:5000/health >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl --silent --fail http://localhost:5000/health >/dev/null 2>&1; then
+  echo "Test backend did not become healthy."
+  exit 1
+fi
+
+echo "Running Playwright against test database: ${DB_PATH}"
+cd "${FRONTEND_DIR}"
+npm run test:e2e -- "$@"

--- a/src/frontend/scripts/run-e2e-with-backend.sh
+++ b/src/frontend/scripts/run-e2e-with-backend.sh
@@ -18,6 +18,7 @@ fi
 
 E2E_DEPLOY="${DIOPTRA_E2E_DEPLOY:-${FRONTEND_DIR}/.dioptra-e2e}"
 DB_PATH="${E2E_DEPLOY}/instance/dioptra-test.db"
+FRONTEND_LOG="${E2E_DEPLOY}/frontend.log"
 
 if curl --silent --fail http://localhost:5000/health >/dev/null 2>&1; then
   echo "A backend is already running on http://localhost:5000."
@@ -34,9 +35,28 @@ export DIOPTRA_RESTAPI_DEV_DATABASE_URI="sqlite:///${DB_PATH}"
 
 "${REPO_DIR}/dev-kb/local-setup/run-flask.sh" &
 FLASK_PID=$!
+FRONTEND_PID=""
+
+kill_process_tree() {
+  local pid="${1:-}"
+  local child_pid
+
+  if [ -z "${pid}" ]; then
+    return
+  fi
+
+  for child_pid in $(pgrep -P "${pid}" 2>/dev/null || true); do
+    kill_process_tree "${child_pid}"
+  done
+
+  kill "${pid}" >/dev/null 2>&1 || true
+}
 
 cleanup() {
   kill "${FLASK_PID}" >/dev/null 2>&1 || true
+  if [ -n "${FRONTEND_PID}" ]; then
+    kill_process_tree "${FRONTEND_PID}"
+  fi
 }
 trap cleanup EXIT
 
@@ -53,6 +73,29 @@ if ! curl --silent --fail http://localhost:5000/health >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Running Playwright against test database: ${DB_PATH}"
 cd "${FRONTEND_DIR}"
+
+if curl --silent --fail http://localhost:5173 >/dev/null 2>&1; then
+  echo "Using existing frontend at http://localhost:5173."
+else
+  echo "Starting frontend at http://localhost:5173 ..."
+  echo "Frontend logs: ${FRONTEND_LOG}"
+  npm run dev >"${FRONTEND_LOG}" 2>&1 &
+  FRONTEND_PID=$!
+fi
+
+echo "Waiting for frontend at http://localhost:5173 ..."
+for _ in {1..90}; do
+  if curl --silent --fail http://localhost:5173 >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl --silent --fail http://localhost:5173 >/dev/null 2>&1; then
+  echo "Frontend did not become available."
+  exit 1
+fi
+
+echo "Running Playwright against test database: ${DB_PATH}"
 npm run test:e2e -- "$@"

--- a/src/frontend/tests/entrypoints.spec.ts
+++ b/src/frontend/tests/entrypoints.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+import { createEntrypoint, createQueue } from "./helpers/createResourceHelper";
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+test("create entrypoint", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  await createEntrypoint(page, entrypointName, queueName);
+});
+
+test("edit entrypoint", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+  const updatedEntrypointName = `${entrypointName}_update`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  const createdEntrypoint = await createEntrypoint(page, entrypointName, queueName);
+
+  await page.goto(`/entrypoints/${createdEntrypoint.id}`);
+  await page.getByRole("heading", { name: entrypointName }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(updatedEntrypointName);
+  await page.getByRole("button", { name: "Submit EntryPoint" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedEntrypointName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/entrypoints$/);
+});
+
+test("delete entrypoint", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  const createdEntrypoint = await createEntrypoint(page, entrypointName, queueName);
+
+  await page.goto(`/entrypoints/${createdEntrypoint.id}`);
+  await page.getByRole("heading", { name: entrypointName }).waitFor();
+  await page.getByRole("button", { name: "Delete Entrypoint" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${entrypointName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/entrypoints$/);
+});

--- a/src/frontend/tests/experiments.spec.ts
+++ b/src/frontend/tests/experiments.spec.ts
@@ -16,12 +16,15 @@ async function createExperiment(page: Page, experimentName: string, entrypointNa
   await page.getByRole("option", { name: entrypointName }).click();
 
   const createResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/v1/experiments") && response.request().method() === "POST" && response.ok(),
+    (response) => response.url().includes("/api/v1/experiments") && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit Experiment" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdExperiment = await createResponse.json();
 
   await expect(

--- a/src/frontend/tests/experiments.spec.ts
+++ b/src/frontend/tests/experiments.spec.ts
@@ -1,0 +1,100 @@
+import { expect, Page, test } from "@playwright/test";
+
+import { createEntrypoint, createQueue } from "./helpers/createResourceHelper";
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+async function createExperiment(page: Page, experimentName: string, entrypointName: string) {
+  await page.goto("/experiments/new");
+
+  await page.getByRole("heading", { name: "Create Experiment" }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(experimentName);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+
+  const entrypointSelect = page.getByRole("combobox", { name: "Entrypoints:" });
+  await entrypointSelect.click();
+  await entrypointSelect.fill(entrypointName);
+  await page.getByRole("option", { name: entrypointName }).click();
+
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/experiments") && response.request().method() === "POST" && response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit Experiment" }).click();
+  const createResponse = await createResponsePromise;
+  const createdExperiment = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${experimentName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/experiments$/);
+
+  return createdExperiment;
+}
+
+test("create experiment", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+  const experimentName = `e2e_experiment_${timestamp}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  await createEntrypoint(page, entrypointName, queueName);
+  await createExperiment(page, experimentName, entrypointName);
+});
+
+test("edit experiment", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+  const experimentName = `e2e_experiment_${timestamp}`;
+  const updatedExperimentName = `${experimentName}_update`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  await createEntrypoint(page, entrypointName, queueName);
+  const createdExperiment = await createExperiment(page, experimentName, entrypointName);
+
+  await page.goto(`/experiments/${createdExperiment.id}`);
+  await page.getByRole("heading", { name: experimentName }).waitFor();
+  await page.getByText(`Show "${experimentName}" Metadata`).click();
+
+  await page.locator("tr").filter({ hasText: "Name" }).getByRole("button").click();
+  await page.locator(".q-popup-edit input").fill(updatedExperimentName);
+  await page.keyboard.press("Enter");
+
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedExperimentName}'`,
+    }),
+  ).toBeVisible();
+});
+
+test("delete experiment", async ({ page }) => {
+  const timestamp = Date.now();
+  const queueName = `e2e_queue_${timestamp}`;
+  const entrypointName = `e2e_entrypoint_${timestamp}`;
+  const experimentName = `e2e_experiment_${timestamp}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+  await createEntrypoint(page, entrypointName, queueName);
+  const createdExperiment = await createExperiment(page, experimentName, entrypointName);
+
+  await page.goto(`/experiments/${createdExperiment.id}`);
+  await page.getByRole("heading", { name: experimentName }).waitFor();
+  await page.getByRole("button", { name: "Delete Experiment" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${experimentName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/experiments$/);
+});

--- a/src/frontend/tests/helpers/createResourceHelper.ts
+++ b/src/frontend/tests/helpers/createResourceHelper.ts
@@ -1,0 +1,85 @@
+import { expect, Page } from "@playwright/test";
+
+export async function createQueue(page: Page, queueName: string) {
+  await page.goto("/queues/new");
+
+  await page.getByRole("heading", { name: "Create Queue" }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(queueName);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+
+  const createResponsePromise = page.waitForResponse(
+    (response) => response.url().includes("/api/v1/queues") && response.request().method() === "POST" && response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit" }).click();
+  const createResponse = await createResponsePromise;
+  const createdQueue = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${queueName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/queues$/);
+
+  return createdQueue;
+}
+
+export async function createEntrypoint(page: Page, entrypointName: string, queueName: string) {
+  await page.goto("/entrypoints/new");
+
+  await page.getByRole("heading", { name: "Create Entrypoint" }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(entrypointName);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+
+  const queueSelect = page.getByRole("combobox", { name: "Queues:" });
+  await queueSelect.click();
+  await queueSelect.fill(queueName);
+  await page.getByRole("option", { name: queueName }).click();
+
+  await page.locator(".cm-content").first().click();
+  await page.keyboard.insertText("graph:\n");
+
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/entrypoints") && response.request().method() === "POST" && response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit EntryPoint" }).click();
+  const createResponse = await createResponsePromise;
+  const createdEntrypoint = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${entrypointName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/entrypoints$/);
+
+  return createdEntrypoint;
+}
+
+export async function createPlugin(page: Page, pluginName: string) {
+  await page.goto("/plugins/new");
+
+  await page.getByRole("heading", { name: "Create Plugin" }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(pluginName);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+
+  const createResponsePromise = page.waitForResponse(
+    (response) => response.url().includes("/api/v1/plugins") && response.request().method() === "POST" && response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit" }).click();
+  const createResponse = await createResponsePromise;
+  const createdPlugin = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${pluginName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/plugins$/);
+
+  return createdPlugin;
+}

--- a/src/frontend/tests/helpers/createResourceHelper.ts
+++ b/src/frontend/tests/helpers/createResourceHelper.ts
@@ -8,11 +8,15 @@ export async function createQueue(page: Page, queueName: string) {
   await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
 
   const createResponsePromise = page.waitForResponse(
-    (response) => response.url().includes("/api/v1/queues") && response.request().method() === "POST" && response.ok(),
+    (response) => response.url().includes("/api/v1/queues") && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdQueue = await createResponse.json();
 
   await expect(
@@ -41,12 +45,15 @@ export async function createEntrypoint(page: Page, entrypointName: string, queue
   await page.keyboard.insertText("graph:\n");
 
   const createResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/v1/entrypoints") && response.request().method() === "POST" && response.ok(),
+    (response) => response.url().includes("/api/v1/entrypoints") && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit EntryPoint" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdEntrypoint = await createResponse.json();
 
   await expect(
@@ -67,11 +74,15 @@ export async function createPlugin(page: Page, pluginName: string) {
   await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
 
   const createResponsePromise = page.waitForResponse(
-    (response) => response.url().includes("/api/v1/plugins") && response.request().method() === "POST" && response.ok(),
+    (response) => response.url().includes("/api/v1/plugins") && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdPlugin = await createResponse.json();
 
   await expect(

--- a/src/frontend/tests/helpers/testUserHelper.ts
+++ b/src/frontend/tests/helpers/testUserHelper.ts
@@ -1,0 +1,65 @@
+import { expect, Page } from "@playwright/test";
+
+const runId = Date.now();
+
+export const testUser = {
+  username: `e2e_user_${runId}`,
+  email: `e2e_user_${runId}@example.com`,
+  password: "Password123!",
+};
+
+export async function loginAsTestUser(page: Page): Promise<boolean> {
+  await page.goto("/login");
+
+  const alreadyLoggedIn = await page
+    .getByText(`You are currently logged in as ${testUser.username}`)
+    .isVisible({ timeout: 3_000 })
+    .catch(() => false);
+
+  if (alreadyLoggedIn) {
+    return true;
+  }
+
+  await page.getByRole("textbox", { name: "Username" }).fill(testUser.username);
+  await page.getByRole("textbox", { name: "Password", exact: true }).fill(testUser.password);
+  await page.getByRole("button", { name: "Login" }).click();
+
+  try {
+    await expect(
+      page.getByRole("alert").filter({
+        hasText: `Login successful for ${testUser.username}`,
+      }),
+    ).toBeVisible({ timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function registerTestUser(page: Page) {
+  await page.goto("/register");
+
+  await page.getByRole("textbox", { name: "Username" }).fill(testUser.username);
+  await page.getByRole("textbox", { name: "Email Address" }).fill(testUser.email);
+  await page.getByRole("textbox", { name: "Password", exact: true }).fill(testUser.password);
+  await page.getByRole("textbox", { name: "Confirm Password" }).fill(testUser.password);
+  await page.getByRole("button", { name: "Register" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created user '${testUser.username}'`,
+    }),
+  ).toBeVisible();
+  await page.waitForURL(/\/login$/);
+}
+
+export async function ensureLoggedInAsTestUser(page: Page) {
+  if (await loginAsTestUser(page)) {
+    return;
+  }
+
+  await registerTestUser(page);
+
+  const loggedIn = await loginAsTestUser(page);
+  expect(loggedIn).toBe(true);
+}

--- a/src/frontend/tests/helpers/testUserHelper.ts
+++ b/src/frontend/tests/helpers/testUserHelper.ts
@@ -8,6 +8,8 @@ export const testUser = {
   password: "Password123!",
 };
 
+let testUserRegistered = false;
+
 export async function loginAsTestUser(page: Page): Promise<boolean> {
   await page.goto("/login");
 
@@ -54,11 +56,10 @@ export async function registerTestUser(page: Page) {
 }
 
 export async function ensureLoggedInAsTestUser(page: Page) {
-  if (await loginAsTestUser(page)) {
-    return;
+  if (!testUserRegistered) {
+    await registerTestUser(page);
+    testUserRegistered = true;
   }
-
-  await registerTestUser(page);
 
   const loggedIn = await loginAsTestUser(page);
   expect(loggedIn).toBe(true);

--- a/src/frontend/tests/pluginFile.spec.ts
+++ b/src/frontend/tests/pluginFile.spec.ts
@@ -1,0 +1,90 @@
+import { expect, Page, test } from "@playwright/test";
+
+import { createPlugin } from "./helpers/createResourceHelper";
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+async function createPluginFile(page: Page, pluginId: number, filename: string) {
+  await page.goto(`/plugins/${pluginId}/files/new`);
+
+  await page.getByRole("heading", { name: "Create Plugin File" }).waitFor();
+  await page.getByRole("textbox", { name: "Filename:" }).fill(filename);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+  await page.locator(".cm-content").first().click();
+  await page.keyboard.insertText("def e2e_task():\n    return None\n");
+
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/v1/plugins/${pluginId}/files`) &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit File" }).click();
+  const createResponse = await createResponsePromise;
+  const createdPluginFile = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${filename}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/plugins/${pluginId}$`));
+
+  return createdPluginFile;
+}
+
+test("create pluginFile", async ({ page }) => {
+  const timestamp = Date.now();
+  const pluginName = `e2e_plugin_${timestamp}`;
+  const filename = `e2e_plugin_file_${timestamp}.py`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPlugin = await createPlugin(page, pluginName);
+  await createPluginFile(page, createdPlugin.id, filename);
+});
+
+test("edit pluginFile", async ({ page }) => {
+  const timestamp = Date.now();
+  const pluginName = `e2e_plugin_${timestamp}`;
+  const filenameBase = `e2e_plugin_file_${timestamp}`;
+  const filename = `${filenameBase}.py`;
+  const updatedFilename = `${filenameBase}_update.py`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPlugin = await createPlugin(page, pluginName);
+  const createdPluginFile = await createPluginFile(page, createdPlugin.id, filename);
+
+  await page.goto(`/plugins/${createdPlugin.id}/files/${createdPluginFile.id}`);
+  await page.getByRole("heading", { name: filename }).waitFor();
+  await page.getByRole("textbox", { name: "Filename:" }).fill(updatedFilename);
+  await page.getByRole("button", { name: "Submit File" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedFilename}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/plugins/${createdPlugin.id}$`));
+});
+
+test("delete pluginFile", async ({ page }) => {
+  const timestamp = Date.now();
+  const pluginName = `e2e_plugin_${timestamp}`;
+  const filename = `e2e_plugin_file_${timestamp}.py`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPlugin = await createPlugin(page, pluginName);
+  const createdPluginFile = await createPluginFile(page, createdPlugin.id, filename);
+
+  await page.goto(`/plugins/${createdPlugin.id}/files/${createdPluginFile.id}`);
+  await page.getByRole("heading", { name: filename }).waitFor();
+  await page.getByRole("button", { name: "Delete Plugin File" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${filename}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/plugins/${createdPlugin.id}$`));
+});

--- a/src/frontend/tests/pluginFile.spec.ts
+++ b/src/frontend/tests/pluginFile.spec.ts
@@ -14,13 +14,15 @@ async function createPluginFile(page: Page, pluginId: number, filename: string) 
 
   const createResponsePromise = page.waitForResponse(
     (response) =>
-      response.url().includes(`/api/v1/plugins/${pluginId}/files`) &&
-      response.request().method() === "POST" &&
-      response.ok(),
+      response.url().includes(`/api/v1/plugins/${pluginId}/files`) && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit File" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdPluginFile = await createResponse.json();
 
   await expect(

--- a/src/frontend/tests/pluginParam.spec.ts
+++ b/src/frontend/tests/pluginParam.spec.ts
@@ -1,0 +1,79 @@
+import { expect, Page, test } from "@playwright/test";
+
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+async function createPluginParam(page: Page, pluginParamName: string) {
+  await page.goto("/pluginParams/new");
+
+  await page.getByRole("heading", { name: "Create Plugin Parameter" }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(pluginParamName);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+  await page.locator(".cm-content").first().click();
+  await page.keyboard.insertText("{}");
+
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/pluginParameterTypes") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
+
+  await page.getByRole("button", { name: "Submit" }).click();
+  const createResponse = await createResponsePromise;
+  const createdPluginParam = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${pluginParamName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/pluginParams$/);
+
+  return createdPluginParam;
+}
+
+test("create pluginParam", async ({ page }) => {
+  const pluginParamName = `e2e_plugin_param_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createPluginParam(page, pluginParamName);
+});
+
+test("edit pluginParam", async ({ page }) => {
+  const pluginParamName = `e2e_plugin_param_${Date.now()}`;
+  const updatedPluginParamName = `${pluginParamName}_update`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPluginParam = await createPluginParam(page, pluginParamName);
+
+  await page.goto(`/pluginParams/${createdPluginParam.id}`);
+  await page.getByRole("heading", { name: pluginParamName }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(updatedPluginParamName);
+  await page.getByRole("button", { name: "Submit" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedPluginParamName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/pluginParams$/);
+});
+
+test("delete pluginParam", async ({ page }) => {
+  const pluginParamName = `e2e_plugin_param_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPluginParam = await createPluginParam(page, pluginParamName);
+
+  await page.goto(`/pluginParams/${createdPluginParam.id}`);
+  await page.getByRole("heading", { name: pluginParamName }).waitFor();
+  await page.getByRole("button", { name: "Delete Plugin Parameter" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${pluginParamName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/pluginParams$/);
+});

--- a/src/frontend/tests/pluginParam.spec.ts
+++ b/src/frontend/tests/pluginParam.spec.ts
@@ -12,14 +12,15 @@ async function createPluginParam(page: Page, pluginParamName: string) {
   await page.keyboard.insertText("{}");
 
   const createResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/v1/pluginParameterTypes") &&
-      response.request().method() === "POST" &&
-      response.ok(),
+    (response) => response.url().includes("/api/v1/pluginParameterTypes") && response.request().method() === "POST",
   );
 
   await page.getByRole("button", { name: "Submit" }).click();
   const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
   const createdPluginParam = await createResponse.json();
 
   await expect(

--- a/src/frontend/tests/plugins.spec.ts
+++ b/src/frontend/tests/plugins.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+import { createPlugin } from "./helpers/createResourceHelper";
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+test("create plugin", async ({ page }) => {
+  const pluginName = `e2e_plugin_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createPlugin(page, pluginName);
+});
+
+test("edit plugin", async ({ page }) => {
+  const pluginName = `e2e_plugin_${Date.now()}`;
+  const updatedPluginName = `${pluginName}_update`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPlugin = await createPlugin(page, pluginName);
+
+  await page.goto(`/plugins/${createdPlugin.id}`);
+  await page.getByRole("heading", { name: pluginName }).waitFor();
+  await page.getByText(`Show "${pluginName}" Metadata`).click();
+
+  await page.locator("tr").filter({ hasText: "Name" }).getByRole("button").click();
+  await page.locator(".q-popup-edit input").fill(updatedPluginName);
+  await page.keyboard.press("Enter");
+
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedPluginName}'`,
+    }),
+  ).toBeVisible();
+});
+
+test("delete plugin", async ({ page }) => {
+  const pluginName = `e2e_plugin_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdPlugin = await createPlugin(page, pluginName);
+
+  await page.goto(`/plugins/${createdPlugin.id}`);
+  await page.getByRole("heading", { name: pluginName }).waitFor();
+  await page.getByRole("button", { name: "Delete Plugin" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${pluginName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/plugins$/);
+});

--- a/src/frontend/tests/queues.spec.ts
+++ b/src/frontend/tests/queues.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { createQueue } from "./helpers/createResourceHelper";
+import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
+
+test("create queue", async ({ page }) => {
+  const queueName = `e2e_queue_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  await createQueue(page, queueName);
+});
+
+test("edit queue", async ({ page }) => {
+  const queueName = `e2e_queue_${Date.now()}`;
+  const updatedQueueName = `${queueName}_update`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdQueue = await createQueue(page, queueName);
+
+  await page.goto(`/queues/${createdQueue.id}`);
+  await page.getByRole("heading", { name: queueName }).waitFor();
+  await page.getByRole("textbox", { name: "Name:" }).fill(updatedQueueName);
+  await page.getByRole("button", { name: "Submit" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully updated '${updatedQueueName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/queues$/);
+});
+
+test("delete queue", async ({ page }) => {
+  const queueName = `e2e_queue_${Date.now()}`;
+
+  await ensureLoggedInAsTestUser(page);
+  const createdQueue = await createQueue(page, queueName);
+
+  await page.goto(`/queues/${createdQueue.id}`);
+  await page.getByRole("heading", { name: queueName }).waitFor();
+  await page.getByRole("button", { name: "Delete Queue" }).click();
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully deleted '${queueName}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/queues$/);
+});


### PR DESCRIPTION
Add playwright tests for frontend.  Basic tests for creating/editing/deleting resources.

- from the src/frontend folder, run `npm install` to install playwright
- Tests are under the src/frontend/tests folder
- Run tests manually with commands below from src/frontend using development mode db. `headed` allows you to see the browser when tests are running.
  - `npm run test:e2e`
  - `npm run test:e2e:headed`
- Run tests manually on a separate db just for testing. This may be the better option since your dev db doesnt get polluted.  Please stop your dev flask server before running this.
  - `npm run test:e2e:with-backend`
  - `npm run test:e2e:with-backend:headed`
- you can run an individual test file like this:
  - `npm run test:e2e:with-backend -- queues.spec.ts`
- Or you can run a specific test with the title:
  - `npm run test:e2e:with-backend -- -g "create queue"`
-  Added github workflow to run tests when submitting PR