### PR TITLE
Fix off-by-one in bounding-box cell index clamp

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ alexb1200
 jsoref
 arpitjain099
 ppcvote
+WatchTree-19

--- a/src/dioptra/sdk/object_detection/bounding_boxes/coordinates/numpy_backend.py
+++ b/src/dioptra/sdk/object_detection/bounding_boxes/coordinates/numpy_backend.py
@@ -74,8 +74,12 @@ class NumpyBoundingBoxCoordinates(BoundingBoxCoordinates):
     ) -> npt.NDArray:
         cell_h: float = self.cell_height
         cell_w: float = self.cell_width
-        max_i: int = self.cell_nrow
-        max_j: int = self.cell_ncol
+        # The largest valid cell index is one less than the number of cells
+        # along each axis.  Clamping to cell_nrow/cell_ncol (the counts) would
+        # allow an out-of-range index for boxes whose center lands on the far
+        # image edge (a normalized coordinate >= 1.0).
+        max_i: int = self.cell_nrow - 1
+        max_j: int = self.cell_ncol - 1
 
         i: npt.NDArray = np.min(
             np.stack(

--- a/src/dioptra/sdk/object_detection/bounding_boxes/coordinates/tensorflow_backend.py
+++ b/src/dioptra/sdk/object_detection/bounding_boxes/coordinates/tensorflow_backend.py
@@ -105,11 +105,15 @@ class TensorflowBoundingBoxCoordinates(BoundingBoxCoordinates):
     def find_bbox_cell_ij(self, x_center: Tensor, y_center: Tensor) -> Tensor:
         cell_h = tf.cast(self.cell_height, tf.float32)
         cell_w = tf.cast(self.cell_width, tf.float32)
+        # The largest valid cell index is one less than the number of cells
+        # along each axis.  Clamping to cell_nrow/cell_ncol (the counts) would
+        # allow an out-of-range index for boxes whose center lands on the far
+        # image edge (a normalized coordinate >= 1.0).
         max_i = tf.cast(
-            tf.fill(dims=tf.shape(y_center), value=self.cell_nrow), tf.int32
+            tf.fill(dims=tf.shape(y_center), value=self.cell_nrow - 1), tf.int32
         )
         max_j = tf.cast(
-            tf.fill(dims=tf.shape(x_center), value=self.cell_ncol), tf.int32
+            tf.fill(dims=tf.shape(x_center), value=self.cell_ncol - 1), tf.int32
         )
 
         i = tf.reduce_min(

--- a/tests/unit/sdk/object_detection/__init__.py
+++ b/tests/unit/sdk/object_detection/__init__.py
@@ -1,0 +1,16 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode

--- a/tests/unit/sdk/object_detection/bounding_boxes/__init__.py
+++ b/tests/unit/sdk/object_detection/bounding_boxes/__init__.py
@@ -1,0 +1,16 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode

--- a/tests/unit/sdk/object_detection/bounding_boxes/coordinates/__init__.py
+++ b/tests/unit/sdk/object_detection/bounding_boxes/coordinates/__init__.py
@@ -1,0 +1,16 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode

--- a/tests/unit/sdk/object_detection/bounding_boxes/coordinates/test_numpy_backend.py
+++ b/tests/unit/sdk/object_detection/bounding_boxes/coordinates/test_numpy_backend.py
@@ -1,0 +1,99 @@
+# This Software (Dioptra) is being made available as a public service by the
+# National Institute of Standards and Technology (NIST), an Agency of the United
+# States Department of Commerce. This software was developed in part by employees of
+# NIST and in part by NIST contractors. Copyright in portions of this software that
+# were developed by NIST contractors has been licensed or assigned to NIST. Pursuant
+# to Title 17 United States Code Section 105, works of NIST employees are not
+# subject to copyright protection in the United States. However, NIST may hold
+# international copyright in software created by its employees and domestic
+# copyright (or licensing rights) in portions of software that were assigned or
+# licensed to NIST. To the extent that NIST holds copyright in this software, it is
+# being made available under the Creative Commons Attribution 4.0 International
+# license (CC BY 4.0). The disclaimers of the CC BY 4.0 license apply to all parts
+# of the software developed or licensed by NIST.
+#
+# ACCESS THE FULL CC BY 4.0 LICENSE HERE:
+# https://creativecommons.org/licenses/by/4.0/legalcode
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Import numpy_backend by file path so the test does not pull in the
+# coordinates package __init__ (which imports the heavy tensorflow backend).
+_COORDS_DIR = (
+    Path(__file__).resolve().parents[6]
+    / "src"
+    / "dioptra"
+    / "sdk"
+    / "object_detection"
+    / "bounding_boxes"
+    / "coordinates"
+)
+
+
+def _load_numpy_backend():
+    pkg_name = "_dioptra_coords_test_pkg"
+    if pkg_name not in sys.modules:
+        pkg = types.ModuleType(pkg_name)
+        pkg.__path__ = [str(_COORDS_DIR)]
+        sys.modules[pkg_name] = pkg
+
+    def _load(modname, filename):
+        full = f"{pkg_name}.{modname}"
+        if full in sys.modules:
+            return sys.modules[full]
+        spec = importlib.util.spec_from_file_location(full, _COORDS_DIR / filename)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full] = module
+        spec.loader.exec_module(module)
+        return module
+
+    _load("bounding_box_coordinates", "bounding_box_coordinates.py")
+    return _load("numpy_backend", "numpy_backend.py")
+
+
+numpy_backend = _load_numpy_backend()
+NumpyBoundingBoxCoordinates = numpy_backend.NumpyBoundingBoxCoordinates
+
+
+@pytest.mark.parametrize("grid_shape", [(7, 7), (13, 13), (5, 9)])
+@pytest.mark.parametrize("center", [1.0, 1.25, 2.0])
+def test_find_bbox_cell_ij_edge_center_is_in_bounds(grid_shape, center) -> None:
+    """A bounding-box center on or past the far image edge must be clamped to a
+    valid cell index (0 .. n-1), never to the out-of-range index n."""
+    coords = NumpyBoundingBoxCoordinates(grid_shape=grid_shape)
+
+    cell_ij = coords.find_bbox_cell_ij(
+        x_center=np.array([center], dtype="float64"),
+        y_center=np.array([center], dtype="float64"),
+    )
+
+    i = int(cell_ij[0][0])
+    j = int(cell_ij[0][1])
+
+    assert 0 <= i <= coords.cell_nrow - 1
+    assert 0 <= j <= coords.cell_ncol - 1
+    # The far-edge center belongs in the last cell.
+    assert i == coords.cell_nrow - 1
+    assert j == coords.cell_ncol - 1
+
+
+def test_find_bbox_cell_ij_index_usable_as_grid_index() -> None:
+    """The returned indices must be valid indices into a (nrow, ncol, ...) grid,
+    exactly as NumpyBoundingBoxesBatchedGrid.embed() uses them."""
+    coords = NumpyBoundingBoxCoordinates(grid_shape=(7, 7))
+    cell_ij = coords.find_bbox_cell_ij(
+        x_center=np.array([1.0], dtype="float64"),
+        y_center=np.array([1.0], dtype="float64"),
+    )
+
+    grid = np.zeros((coords.cell_nrow, coords.cell_ncol, 4), dtype="float32")
+    grid_i = np.transpose(cell_ij)[0]
+    grid_j = np.transpose(cell_ij)[1]
+
+    # Must not raise IndexError.
+    grid[grid_i, grid_j] = np.array([0.0, 0.0, 0.0, 0.0], dtype="float32")


### PR DESCRIPTION
## Summary
`find_bbox_cell_ij` (in both `numpy_backend.py` and `tensorflow_backend.py`) clamps a bounding box's grid-cell index to `cell_nrow` / `cell_ncol` (the cell *counts*) instead of `cell_nrow - 1` / `cell_ncol - 1` (the largest valid index). A box whose center lands on the far image edge (a normalized coordinate `>= 1.0`) is therefore assigned an out-of-range cell index equal to the grid size.

The clamp exists specifically to keep the index in bounds, so bounding it to the count rather than the max index is an off-by-one.

## Impact
- numpy backend: `NumpyBoundingBoxesBatchedGrid.embed()` uses the index directly (`grid[grid_i, grid_j] = ...`), so this is an `IndexError`.
- tensorflow backend: `tensor_scatter_nd_update` silently drops the out-of-range index, so the ground-truth box is silently mislabeled/dropped.

Object-detection augmentation (translation/zoom) routinely produces box centers outside `[0, 1]`, and nothing upstream clamps centers before this call.

## Repro
```python
NumpyBoundingBoxCoordinates(grid_shape=(7, 7)).find_bbox_cell_ij(
    x_center=np.array([0.5]), y_center=np.array([1.0])
)  # returns i = 7 for a 7-row grid (valid range 0..6)
```

## Fix
Clamp to `cell_nrow - 1` / `cell_ncol - 1` in both backends.

## Test
Added `tests/unit/.../coordinates/test_numpy_backend.py` (numpy-only, imports the module by path to avoid the tensorflow-heavy package `__init__`): 10 parametrized cases asserting every returned index is a usable grid index. Fails on current main (`IndexError: index 7 is out of bounds`), passes with the fix. black/isort/ruff/flake8 clean on changed files.

found by reading the code, not the tracker.
