### PR TITLE
Allow punctuation in unquoted search queries

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ cminiter
 pscemama-mitre
 alexb1200
 jsoref
+arpitjain099

--- a/src/dioptra/restapi/v1/shared/search_parser.py
+++ b/src/dioptra/restapi/v1/shared/search_parser.py
@@ -52,11 +52,17 @@ def _define_query_grammar() -> pp.ParserElement:
     # Spaces are allowed in unquoted searches, but not when a field is specified
     space = pp.Literal(" ")
 
-    # Unquoted searches are limited to words containing alphanumerics and underscores
-    unquoted_word = pp.Combine((escape | pp.Word(pp.alphanums + "_") + ~space)[1, ...])
-    unquoted_words = (
-        pp.Combine((escape | pp.Word(pp.alphanums + "_"))[1, ...]) | space
-    )[1, ...]
+    # Characters that carry meaning in the grammar: the escape character, the
+    # wildcards, the quote characters, the field separator (':') and the list
+    # delimiter (','). These must be quoted or escaped to appear literally.
+    grammar_chars = "\\?*\"':,"
+
+    # Unquoted searches may contain any printable character that is not
+    # grammar-significant, so ordinary punctuation (for example '.', '-' or '/')
+    # no longer causes the query to fail to parse.
+    unquoted_chars = pp.Word(pp.printables, exclude_chars=grammar_chars)
+    unquoted_word = pp.Combine((escape | unquoted_chars + ~space)[1, ...])
+    unquoted_words = (pp.Combine((escape | unquoted_chars)[1, ...]) | space)[1, ...]
     # quoted searches can include any printable characters
     sgl_quoted_words = pp.Combine(
         (escape | pp.Word(pp.printables + " ", exclude_chars="\\?*'\n"))[1, ...]

--- a/tests/unit/restapi/v1/shared/test_search_parser.py
+++ b/tests/unit/restapi/v1/shared/test_search_parser.py
@@ -67,8 +67,6 @@ def test_grammar() -> None:
         r"""
         # invalid multi word field search -- needs to be quoted
         field:search all for this
-        # incorrect assignment character used
-        bad=assignment
         # invalid characters in field name
         bad-name:classification
         # invalid delimiter between search terms
@@ -91,6 +89,20 @@ def test_parse_search_text() -> None:
         {"field": "tag", "value": ["something"]},
         {"field": "name", "value": ["else"]},
         {"field": None, "value": ["extra"]},
+    ]
+
+
+def test_parse_search_text_allows_punctuation() -> None:
+    # Ordinary punctuation in an unquoted search must not cause a parse failure
+    # (previously a '.' raised SearchParseError). See issue #1209.
+    assert parse_search_text(search_text="file.txt") == [
+        {"field": None, "value": ["file.txt"]},
+    ]
+    assert parse_search_text(search_text="name:dioptra.restapi") == [
+        {"field": "name", "value": ["dioptra.restapi"]},
+    ]
+    assert parse_search_text(search_text="some/path-to_file.log") == [
+        {"field": None, "value": ["some/path-to_file.log"]},
     ]
 
 


### PR DESCRIPTION
The search grammar limited unquoted search terms to alphanumerics and underscores, so any unquoted query containing other punctuation (most commonly a period) failed to parse and the job-logs search surfaced a "failed to fetch logs" error.

Unquoted searches now accept any printable character that is not grammar-significant (the escape character, the wildcards, the quote characters, the field separator and the list delimiter); those still need to be quoted or escaped. Quoted searches already allowed these characters, so this just brings unquoted searches in line.

Fixes #1209