### PR TITLE
Entrypoint page swaps

### DIFF
--- a/src/frontend/src/components/AssignPluginsDropdown.vue
+++ b/src/frontend/src/components/AssignPluginsDropdown.vue
@@ -72,4 +72,10 @@ function removePlugin(plugin) {
   }
   pluginIDsToUpdate.value = pluginIDsToUpdate.value.filter((id) => id !== plugin.id);
 }
+
+function resetOriginalSelectedPlugins() {
+  originalSelectedPluginIds.value = selectedPlugins.value.map((plugin) => plugin.id);
+}
+
+defineExpose({ resetOriginalSelectedPlugins });
 </script>

--- a/src/frontend/src/components/CodeEditor.vue
+++ b/src/frontend/src/components/CodeEditor.vue
@@ -131,30 +131,26 @@ function highlightPlaceholder(update) {
   const to = view.value.state.selection.ranges[0].to;
   if (from !== to) return; // short circut if user is dragging cursor
 
-  const placeholders = ["<input-value>", "<step-name>", "<swap-name>", "<task-alias>", "<output-name>", "<contents>"];
-  placeholders.forEach((placeholder) => {
-    let startIndex = code.value.indexOf(placeholder);
-    while (startIndex !== -1) {
-      const endIndex = startIndex + placeholder.length;
+  const placeholderPattern =
+    /<(?:input-value|step-name(?:-\d+)?|swap-name(?:-\d+)?|task-alias(?:-\d+)?|output-name|contents)>/g;
+  for (const match of code.value.matchAll(placeholderPattern)) {
+    const placeholder = match[0];
+    const startIndex = match.index;
+    const endIndex = startIndex + placeholder.length;
 
-      // Check if the cursor position is within the bounds of the current placeholder instance
-      if (from >= startIndex && from <= endIndex && from !== startIndex && from !== endIndex) {
-        console.log(
-          `Cursor is at position ${from}, within the substring '${placeholder}' from index ${startIndex} to ${endIndex}`,
-        );
-        view.value.dispatch({
-          selection: { anchor: startIndex, head: endIndex },
-        });
-        if (placeholder === "<input-value>" || placeholder === "<contents>") {
-          startCompletion(view.value);
-        }
-        return; // Break after the first match to avoid overlapping selection conflicts
+    if (from > startIndex && from < endIndex) {
+      console.log(
+        `Cursor is at position ${from}, within the substring '${placeholder}' from index ${startIndex} to ${endIndex}`,
+      );
+      view.value.dispatch({
+        selection: { anchor: startIndex, head: endIndex },
+      });
+      if (placeholder === "<input-value>" || placeholder === "<contents>") {
+        startCompletion(view.value);
       }
-
-      // Move to the next possible start index to continue searching
-      startIndex = code.value.indexOf(placeholder, startIndex + placeholder.length);
+      break;
     }
-  });
+  }
 }
 
 const yamlLinter = linter((view) => {
@@ -182,7 +178,7 @@ function getTopLevelKeys(code) {
   try {
     if (code) {
       const output = [];
-      const keys = Object.keys(YAML.parse(code)).filter((key) => key !== "<step-name>");
+      const keys = Object.keys(YAML.parse(code)).filter((key) => !/^<step-name(?:-\d+)?>$/.test(key));
       keys.forEach((key) => {
         output.push({
           label: `$${key}`,

--- a/src/frontend/src/components/CodeEditor.vue
+++ b/src/frontend/src/components/CodeEditor.vue
@@ -131,7 +131,7 @@ function highlightPlaceholder(update) {
   const to = view.value.state.selection.ranges[0].to;
   if (from !== to) return; // short circut if user is dragging cursor
 
-  const placeholders = ["<input-value>", "<step-name>", "<output-name>", "<contents>"];
+  const placeholders = ["<input-value>", "<step-name>", "<swap-name>", "<task-alias>", "<output-name>", "<contents>"];
   placeholders.forEach((placeholder) => {
     let startIndex = code.value.indexOf(placeholder);
     while (startIndex !== -1) {

--- a/src/frontend/src/dialogs/AddSwappableTaskDialog.vue
+++ b/src/frontend/src/dialogs/AddSwappableTaskDialog.vue
@@ -1,0 +1,117 @@
+<template>
+  <q-dialog
+    v-model="showDialog"
+    aria-labelledby="addSwappableTaskDialogTitle"
+    :persistent="true"
+  >
+    <q-card style="width: 500px; max-width: 90vw">
+      <q-card-section class="bg-primary text-white">
+        <div
+          id="addSwappableTaskDialogTitle"
+          class="text-h6"
+        >
+          Add Swappable Task
+        </div>
+      </q-card-section>
+
+      <q-card-section>
+        <q-form
+          id="addSwappableTaskForm"
+          @submit.prevent="submit"
+        >
+          <q-select
+            v-model="selectedSwapStep"
+            :options="swapStepOptions"
+            option-label="label"
+            label="Step"
+            outlined
+            dense
+            @update:model-value="$emit('stepChanged')"
+          />
+
+          <q-list
+            dense
+            class="q-mt-md"
+          >
+            <q-item
+              v-if="selectedSwapStep?.createNew"
+              tag="label"
+            >
+              <q-item-section avatar>
+                <q-checkbox
+                  :model-value="true"
+                  disable
+                />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ selectedSwapTask?.name }}</q-item-label>
+                <q-item-label caption>{{ selectedSwapTask?.plugin?.name }}</q-item-label>
+              </q-item-section>
+            </q-item>
+
+            <q-item
+              v-for="task in selectableSwappableTasks"
+              :key="`${task.plugin.id}-${task.id || task.name}`"
+              tag="label"
+            >
+              <q-item-section avatar>
+                <q-checkbox
+                  v-model="selectedSwappableTasks"
+                  :val="task"
+                />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ task.name }}</q-item-label>
+                <q-item-label caption>{{ task.plugin.name }}</q-item-label>
+              </q-item-section>
+            </q-item>
+
+            <q-item v-if="selectableSwappableTasks.length === 0">
+              <q-item-section class="text-grey-7">
+                {{
+                  selectedSwapStep?.createNew
+                    ? "No other tasks with same output parameter types."
+                    : "No compatible tasks available to add."
+                }}
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-form>
+      </q-card-section>
+
+      <q-separator />
+
+      <q-card-actions align="right">
+        <q-btn
+          v-close-popup
+          outline
+          color="primary cancel-btn"
+          label="Cancel"
+          class="q-mr-xs"
+        />
+        <q-btn
+          color="primary"
+          label="Confirm"
+          type="submit"
+          form="addSwappableTaskForm"
+          :disable="!canSubmit"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+defineProps(["selectedSwapTask", "swapStepOptions", "selectableSwappableTasks", "canSubmit"]);
+
+const emit = defineEmits(["stepChanged", "submit"]);
+
+const showDialog = defineModel();
+const selectedSwapStep = defineModel("selectedSwapStep");
+const selectedSwappableTasks = defineModel("selectedSwappableTasks");
+
+function submit() {
+  emit("submit");
+  showDialog.value = false;
+}
+</script>

--- a/src/frontend/src/dialogs/InfoPopupDialog.vue
+++ b/src/frontend/src/dialogs/InfoPopupDialog.vue
@@ -4,7 +4,7 @@
     aria-labelledby="modalTitle"
   >
     <q-card
-      style="width: 95%; max-height: 80vh"
+      style="width: 900px; max-width: 90vw; max-height: 80vh"
       flat
     >
       <q-card-section class="bg-primary text-white q-mb-md">

--- a/src/frontend/src/services/dataApi.ts
+++ b/src/frontend/src/services/dataApi.ts
@@ -294,12 +294,21 @@ export async function getResourceDraft<T extends ResourceType>(type: T, id: numb
   return res;
 }
 
-export async function updateItem<T extends keyof UpdateParams>(type: T, id: number, params: UpdateParams[T]) {
-  return await axios.put(`/api/${type}/${id}`, params);
+export async function updateItem<T extends keyof UpdateParams>(
+  type: T,
+  id: number,
+  params: UpdateParams[T],
+  validateOnly = false,
+) {
+  return await axios.put(`/api/${type}/${id}`, params, {
+    params: { validateOnly },
+  });
 }
 
-export async function addItem<T extends keyof CreateParams>(type: T, params: CreateParams[T]) {
-  return await axios.post(`/api/${type}/`, params);
+export async function addItem<T extends keyof CreateParams>(type: T, params: CreateParams[T], validateOnly = false) {
+  return await axios.post(`/api/${type}/`, params, {
+    params: { validateOnly },
+  });
 }
 
 interface JobParams {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -714,15 +714,17 @@
   />
   <InfoPopupDialog v-model="displayErrorDialog">
     <template #title>
-      <label id="modalTitle"> Entrypoint Input Errors </label>
+      <label id="modalTitle"> Entrypoint Validation Errors </label>
     </template>
-    Errors found: {{ inputErrors.length }}
+    Errors found: {{ validationIssues.length }}
     <ul>
       <li
-        v-for="(error, i) in inputErrors"
+        v-for="(issue, i) in validationIssues"
         :key="i"
+        class="q-mb-md"
+        style="white-space: pre-wrap"
       >
-        {{ error.message }}
+        {{ issue }}
       </li>
     </ul>
   </InfoPopupDialog>
@@ -1397,7 +1399,7 @@ async function deleteEntrypoint() {
   }
 }
 
-const inputErrors = ref([]);
+const validationIssues = ref([]);
 const displayErrorDialog = ref(false);
 
 async function validateEntrypoint() {
@@ -1411,7 +1413,6 @@ async function validateEntrypoint() {
   }
 
   const submitObject = prepareEntrypointPayload();
-  console.log("payload = ", JSON.parse(JSON.stringify(entryPoint.value)));
   try {
     if (route.params.id === "new") {
       await api.addItem("entrypoints", submitObject, true);
@@ -1423,7 +1424,17 @@ async function validateEntrypoint() {
       notify.success(`Entrypoint is valid!`);
     }
   } catch (err) {
-    notify.error(err.response.data.message);
+    const reason = err.response?.data?.detail?.reason;
+    const responseValidationIssues = [
+      ...(Array.isArray(reason?.schema_issues) ? reason.schema_issues : []),
+      ...(Array.isArray(reason?.swap_issues) ? reason.swap_issues : []),
+    ];
+    if (responseValidationIssues.length > 0) {
+      validationIssues.value = responseValidationIssues;
+      displayErrorDialog.value = true;
+    } else {
+      notify.error(err.response?.data?.message ?? "Failed to validate Entrypoint");
+    }
   }
 }
 

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -448,11 +448,24 @@
                       @before-show="prepareSwappableTaskSelection(cellProps.row)"
                     >
                       <q-card style="min-width: 320px">
-                        <q-card-section class="text-subtitle2"> Select tasks to include </q-card-section>
+                        <q-card-section>
+                          <q-select
+                            v-model="selectedSwapStep"
+                            :options="swapStepOptions"
+                            option-label="label"
+                            label="Step"
+                            outlined
+                            dense
+                            @update:model-value="resetSelectedSwappableTasks"
+                          />
+                        </q-card-section>
                         <q-separator />
 
                         <q-list dense>
-                          <q-item tag="label">
+                          <q-item
+                            v-if="selectedSwapStep?.createNew"
+                            tag="label"
+                          >
                             <q-item-section avatar>
                               <q-checkbox
                                 :model-value="true"
@@ -466,7 +479,7 @@
                           </q-item>
 
                           <q-item
-                            v-for="task in eligibleSwappableTasks"
+                            v-for="task in selectableSwappableTasks"
                             :key="`${task.plugin.id}-${task.id || task.name}`"
                             tag="label"
                           >
@@ -482,9 +495,13 @@
                             </q-item-section>
                           </q-item>
 
-                          <q-item v-if="eligibleSwappableTasks.length === 0">
+                          <q-item v-if="selectableSwappableTasks.length === 0">
                             <q-item-section class="text-grey-7">
-                              No other tasks with same output parameter types.
+                              {{
+                                selectedSwapStep?.createNew
+                                  ? "No other tasks with same output parameter types."
+                                  : "No compatible tasks available to add."
+                              }}
                             </q-item-section>
                           </q-item>
                         </q-list>
@@ -501,72 +518,8 @@
                             v-close-popup="2"
                             color="primary"
                             label="Submit"
-                            :disable="selectedSwappableTasks.length < 2"
-                            @click="addSwappableTaskToGraph"
-                          />
-                        </q-card-actions>
-                      </q-card>
-                    </q-menu>
-                  </q-item>
-
-                  <q-item clickable>
-                    <q-item-section>Add to existing Swap Group</q-item-section>
-                    <q-item-section side>
-                      <q-icon name="keyboard_arrow_right" />
-                    </q-item-section>
-
-                    <q-menu
-                      anchor="top end"
-                      self="top start"
-                      @before-show="prepareSwappableTaskSelection(cellProps.row)"
-                    >
-                      <q-card style="min-width: 320px">
-                        <q-card-section class="text-subtitle2"> Select Swap Group </q-card-section>
-                        <q-separator />
-
-                        <q-list dense>
-                          <q-item v-if="taskGraphError || !taskGraphObject">
-                            <q-item-section class="text-grey-7"> Please resolve task graph errors. </q-item-section>
-                          </q-item>
-
-                          <template v-else>
-                            <q-item
-                              v-for="swapGroup in eligibleSwapGroups"
-                              :key="`${swapGroup.stepName}-${swapGroup.swapName}`"
-                              tag="label"
-                            >
-                              <q-item-section avatar>
-                                <q-checkbox
-                                  v-model="selectedEligibleSwapGroups"
-                                  :val="swapGroup"
-                                />
-                              </q-item-section>
-                              <q-item-section>
-                                <q-item-label>{{ swapGroup.swapName.slice(1) }}</q-item-label>
-                                <q-item-label caption>{{ swapGroup.taskNames.join(", ") }}</q-item-label>
-                              </q-item-section>
-                            </q-item>
-
-                            <q-item v-if="eligibleSwapGroups.length === 0">
-                              <q-item-section class="text-grey-7"> No compatible swap groups found. </q-item-section>
-                            </q-item>
-                          </template>
-                        </q-list>
-
-                        <q-separator />
-                        <q-card-actions align="right">
-                          <q-btn
-                            v-close-popup
-                            flat
-                            color="primary"
-                            label="Cancel"
-                          />
-                          <q-btn
-                            v-close-popup="2"
-                            color="primary"
-                            label="Submit"
-                            :disable="selectedEligibleSwapGroups.length === 0"
-                            @click="addTaskToExistingSwapGroups"
+                            :disable="!canSubmitSwappableTasks"
+                            @click="addSelectedSwappableTasks"
                           />
                         </q-card-actions>
                       </q-card>
@@ -1067,10 +1020,19 @@ async function checkIfStillValid(type) {
 const taskGraphError = ref("");
 
 const taskGraphPlaceholderError = computed(() => {
-  const placeholders = entryPoint.value.taskGraph.match(/<(?:step-name|swap-name|task-alias|input-value)>/g);
+  const placeholders = entryPoint.value.taskGraph.match(
+    /<(?:step-name(?:-\d+)?|swap-name(?:-\d+)?|task-alias(?:-\d+)?|input-value)>/g,
+  );
   if (!placeholders) return "";
 
-  return `Replace ${[...new Set(placeholders)].join(", ")} placeholders`;
+  const normalizedPlaceholders = placeholders.map((placeholder) => {
+    if (/^<step-name(?:-\d+)?>$/.test(placeholder)) return "<step-name>";
+    if (/^<swap-name(?:-\d+)?>$/.test(placeholder)) return "<swap-name>";
+    if (/^<task-alias(?:-\d+)?>$/.test(placeholder)) return "<task-alias>";
+    return placeholder;
+  });
+
+  return `Replace ${[...new Set(normalizedPlaceholders)].join(", ")} placeholders`;
 });
 
 function submit() {
@@ -1216,10 +1178,31 @@ async function getQueues(val = "", update) {
   });
 }
 
+function getNextStepNamePlaceholder() {
+  let highestStepNumber = 0;
+
+  for (const match of entryPoint.value.taskGraph.matchAll(/^<step-name-(\d+)>:/gm)) {
+    highestStepNumber = Math.max(highestStepNumber, Number(match[1]));
+  }
+
+  return `<step-name-${highestStepNumber + 1}>`;
+}
+
+function getNextSwapNamePlaceholder() {
+  let highestSwapNumber = 0;
+
+  for (const match of entryPoint.value.taskGraph.matchAll(/<swap-name-(\d+)>/g)) {
+    highestSwapNumber = Math.max(highestSwapNumber, Number(match[1]));
+  }
+
+  return `<swap-name-${highestSwapNumber + 1}>`;
+}
+
 function addToTaskGraph(task) {
   console.log("task = ", task);
   // always use Mixed Style Invocation
-  let string = `<step-name>:\n  task: ${task.name}`;
+  const stepNamePlaceholder = getNextStepNamePlaceholder();
+  let string = `${stepNamePlaceholder}:\n  task: ${task.name}`;
   if (task.inputParams.length > 0) {
     string += `\n  kwargs:`;
     task.inputParams.forEach((param) => {
@@ -1237,7 +1220,8 @@ const selectedSwapTask = ref(null);
 const eligibleSwappableTasks = ref([]);
 const selectedSwappableTasks = ref([]);
 const eligibleSwapGroups = ref([]);
-const selectedEligibleSwapGroups = ref([]);
+const swapStepOptions = ref([]);
+const selectedSwapStep = ref(null);
 
 function getOutputParameterTypes(task) {
   return task.outputParams.map(
@@ -1281,38 +1265,71 @@ function findEligibleSwapGroups() {
   Object.entries(taskGraphObject.value).forEach(([stepName, step]) => {
     if (!step || typeof step !== "object" || Array.isArray(step)) return;
 
-    Object.entries(step).forEach(([swapName, swapGroup]) => {
-      if (!swapName.startsWith("?") || !swapGroup || typeof swapGroup !== "object" || Array.isArray(swapGroup)) {
-        return;
-      }
+    const swapEntries = Object.entries(step).filter(
+      ([swapName, swapGroup]) =>
+        swapName.startsWith("?") && swapGroup && typeof swapGroup === "object" && !Array.isArray(swapGroup),
+    );
+    if (swapEntries.length !== 1) return;
 
-      const taskAliases = Object.entries(swapGroup);
-      const taskNames = taskAliases.map(([, taskDefinition]) => taskDefinition?.task);
-      const allTasksAreSwappable =
-        taskAliases.length > 0 && taskNames.every((taskName) => eligibleTaskNames.has(taskName));
+    const [swapName, swapGroup] = swapEntries[0];
+    const taskAliases = Object.entries(swapGroup);
+    const taskNames = taskAliases.map(([, taskDefinition]) => taskDefinition?.task);
+    const allTasksAreSwappable =
+      taskAliases.length > 0 &&
+      taskNames.every(
+        (taskName) => eligibleTaskNames.has(taskName) || (typeof taskName === "string" && /^<[^>]+>$/.test(taskName)),
+      );
 
-      if (allTasksAreSwappable) {
-        swapGroups.push({ stepName, swapName, taskNames });
-      }
-    });
+    if (allTasksAreSwappable) {
+      swapGroups.push({ stepName, swapName, taskNames, label: stepName, createNew: false });
+    }
   });
 
   return swapGroups;
 }
 
+function resetSelectedSwappableTasks() {
+  selectedSwappableTasks.value = [selectedSwapTask.value];
+}
+
 function prepareSwappableTaskSelection(task) {
   selectedSwapTask.value = task;
   eligibleSwappableTasks.value = findSwappableTasks(task);
-  selectedSwappableTasks.value = [task];
   eligibleSwapGroups.value = findEligibleSwapGroups();
-  selectedEligibleSwapGroups.value = [];
+  const newStepName = getNextStepNamePlaceholder();
+  swapStepOptions.value = [
+    {
+      stepName: newStepName,
+      swapName: null,
+      taskNames: [],
+      label: newStepName,
+      createNew: true,
+    },
+    ...eligibleSwapGroups.value,
+  ];
+  selectedSwapStep.value = swapStepOptions.value[0];
+  resetSelectedSwappableTasks();
 }
 
-function addSwappableTaskToGraph() {
-  let string = `<step-name>:\n  ?<swap-name>:`;
+const selectableSwappableTasks = computed(() =>
+  selectedSwapStep.value?.createNew
+    ? eligibleSwappableTasks.value
+    : [selectedSwapTask.value, ...eligibleSwappableTasks.value].filter(Boolean),
+);
 
-  selectedSwappableTasks.value.forEach((task) => {
-    string += `\n    <task-alias>:\n      task: ${task.name}`;
+const canSubmitSwappableTasks = computed(() =>
+  selectedSwapStep.value?.createNew
+    ? selectedSwappableTasks.value.length >= 2
+    : selectedSwappableTasks.value.length >= 1,
+);
+
+function addSwappableTaskToGraph() {
+  const stepNamePlaceholder = getNextStepNamePlaceholder();
+  const swapNamePlaceholder = getNextSwapNamePlaceholder();
+  let string = `${stepNamePlaceholder}:\n  ?${swapNamePlaceholder}:`;
+
+  selectedSwappableTasks.value.forEach((task, index) => {
+    string += `\n    <task-alias-${index + 1}>:\n      task: ${task.name}`;
     if (task.inputParams.length > 0) {
       string += `\n      kwargs:`;
       task.inputParams.forEach((parameter) => {
@@ -1328,24 +1345,46 @@ function addSwappableTaskToGraph() {
   }
 }
 
-function addTaskToExistingSwapGroups() {
-  if (taskGraphError.value || !taskGraphObject.value || !selectedSwapTask.value) return;
+function getNextTaskAliasPlaceholder(swapGroup) {
+  let highestAliasNumber = 0;
 
-  selectedEligibleSwapGroups.value.forEach(({ stepName, swapName }) => {
-    const swapGroup = taskGraphObject.value[stepName]?.[swapName];
-    if (!swapGroup) return;
+  Object.keys(swapGroup).forEach((alias) => {
+    const match = alias.match(/^<task-alias-(\d+)>$/);
+    if (match) {
+      highestAliasNumber = Math.max(highestAliasNumber, Number(match[1]));
+    }
+  });
 
-    const taskDefinition = { task: selectedSwapTask.value.name };
-    if (selectedSwapTask.value.inputParams.length > 0) {
+  return `<task-alias-${highestAliasNumber + 1}>`;
+}
+
+function addTasksToExistingSwapGroup() {
+  if (!taskGraphObject.value || !selectedSwapStep.value) return;
+
+  const { stepName, swapName } = selectedSwapStep.value;
+  const swapGroup = taskGraphObject.value[stepName]?.[swapName];
+  if (!swapGroup) return;
+
+  selectedSwappableTasks.value.forEach((task) => {
+    const taskDefinition = { task: task.name };
+    if (task.inputParams.length > 0) {
       taskDefinition.kwargs = Object.fromEntries(
-        selectedSwapTask.value.inputParams.map((parameter) => [parameter.name, "<input-value>"]),
+        task.inputParams.map((parameter) => [parameter.name, "<input-value>"]),
       );
     }
 
-    swapGroup["<task-alias>"] = taskDefinition;
+    swapGroup[getNextTaskAliasPlaceholder(swapGroup)] = taskDefinition;
   });
 
   entryPoint.value.taskGraph = YAML.stringify(taskGraphObject.value).trimEnd();
+}
+
+function addSelectedSwappableTasks() {
+  if (selectedSwapStep.value?.createNew) {
+    addSwappableTaskToGraph();
+  } else {
+    addTasksToExistingSwapGroup();
+  }
 }
 
 function addToArtifactGraph(task) {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -348,6 +348,28 @@
           :hideCreateBtn="true"
           @syncResource="({ resource }) => syncPlugin(resource)"
         >
+          <template #body-cell-taskName="cellProps">
+            <span>{{ cellProps.row.name }}</span>
+            <q-icon
+              v-if="swappableTasksByTask.get(cellProps.row)?.length"
+              name="sym_o_sync_alt"
+              size="sm"
+              color="primary"
+              class="q-ml-sm q-mb-xs"
+            >
+              <q-tooltip>
+                <div>Swappable with:</div>
+                <ul class="q-my-none q-pl-md">
+                  <li
+                    v-for="task in swappableTasksByTask.get(cellProps.row)"
+                    :key="`${task.plugin.id}-${task.id || task.name}`"
+                  >
+                    {{ task.name }}
+                  </li>
+                </ul>
+              </q-tooltip>
+            </q-icon>
+          </template>
           <template #body-cell-inputParams="cellProps">
             <div
               v-for="(param, i) in cellProps.row.inputParams"
@@ -1236,6 +1258,8 @@ function findSwappableTasks(task) {
     );
   });
 }
+
+const swappableTasksByTask = computed(() => new Map(tasks.value.map((task) => [task, findSwappableTasks(task)])));
 
 const taskGraphObject = computed(() => {
   try {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -348,28 +348,6 @@
           :hideCreateBtn="true"
           @syncResource="({ resource }) => syncPlugin(resource)"
         >
-          <template #body-cell-taskName="cellProps">
-            <span>{{ cellProps.row.name }}</span>
-            <q-icon
-              v-if="swappableTasksByTask.get(cellProps.row)?.length"
-              name="sym_o_sync_alt"
-              size="sm"
-              color="primary"
-              class="q-ml-sm q-mb-xs"
-            >
-              <q-tooltip>
-                <div>Swappable with:</div>
-                <ul class="q-my-none q-pl-md">
-                  <li
-                    v-for="task in swappableTasksByTask.get(cellProps.row)"
-                    :key="`${task.plugin.id}-${task.id || task.name}`"
-                  >
-                    {{ task.name }}
-                  </li>
-                </ul>
-              </q-tooltip>
-            </q-icon>
-          </template>
           <template #body-cell-inputParams="cellProps">
             <div
               v-for="(param, i) in cellProps.row.inputParams"
@@ -415,40 +393,49 @@
             </div>
           </template>
           <template #body-cell-add="cellProps">
-            <q-btn
-              icon="add"
-              round
-              size="xs"
-              color="grey-5"
-              text-color="black"
-              aria-label="Add to task graph"
+            <div
+              class="row items-center justify-center no-wrap"
+              style="gap: 4px"
             >
-              <q-menu>
-                <q-list
-                  style="min-width: 240px"
-                  dense
+              <div class="row items-center justify-center action-button-slot">
+                <q-btn
+                  icon="add"
+                  round
+                  size="xs"
+                  color="grey-5"
+                  text-color="black"
+                  aria-label="Add Task"
+                  @click="addToTaskGraph(cellProps.row)"
                 >
-                  <q-item
-                    v-close-popup
-                    clickable
-                    @click="addToTaskGraph(cellProps.row)"
-                  >
-                    <q-item-section>Add Task</q-item-section>
-                  </q-item>
+                  <q-tooltip>Add Task</q-tooltip>
+                </q-btn>
+              </div>
 
-                  <q-item
-                    v-close-popup
-                    clickable
-                    @click="openAddSwappableTaskDialog(cellProps.row)"
-                  >
-                    <q-item-section>Add Swappable Task</q-item-section>
-                    <q-item-section side>
-                      <q-icon name="more_horiz" />
-                    </q-item-section>
-                  </q-item>
-                </q-list>
-              </q-menu>
-            </q-btn>
+              <div class="row items-center justify-center action-button-slot">
+                <q-btn
+                  v-if="swappableTasksByTask.get(cellProps.row)?.length"
+                  icon="sym_o_sync_alt"
+                  round
+                  size="xs"
+                  color="primary"
+                  aria-label="Add Swappable Task"
+                  @click="openAddSwappableTaskDialog(cellProps.row)"
+                >
+                  <q-tooltip>
+                    <div class="q-mb-sm">Add Swappable Task</div>
+                    <div>Swappable with:</div>
+                    <ul class="q-my-none q-pl-md">
+                      <li
+                        v-for="task in swappableTasksByTask.get(cellProps.row)"
+                        :key="`${task.plugin.id}-${task.id || task.name}`"
+                      >
+                        {{ task.name }}
+                      </li>
+                    </ul>
+                  </q-tooltip>
+                </q-btn>
+              </div>
+            </div>
           </template>
         </TableComponent>
       </div>
@@ -1503,3 +1490,10 @@ async function syncPlugin(plugin, type = "plugins") {
   }
 }
 </script>
+
+<style scoped>
+.action-button-slot {
+  width: 24px;
+  height: 24px;
+}
+</style>

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -436,94 +436,15 @@
                     <q-item-section>Add Task</q-item-section>
                   </q-item>
 
-                  <q-item clickable>
+                  <q-item
+                    v-close-popup
+                    clickable
+                    @click="openAddSwappableTaskDialog(cellProps.row)"
+                  >
                     <q-item-section>Add Swappable Task</q-item-section>
                     <q-item-section side>
-                      <q-icon name="keyboard_arrow_right" />
+                      <q-icon name="more_horiz" />
                     </q-item-section>
-
-                    <q-menu
-                      anchor="top end"
-                      self="top start"
-                      @before-show="prepareSwappableTaskSelection(cellProps.row)"
-                    >
-                      <q-card style="min-width: 320px">
-                        <q-card-section>
-                          <q-select
-                            v-model="selectedSwapStep"
-                            :options="swapStepOptions"
-                            option-label="label"
-                            label="Step"
-                            outlined
-                            dense
-                            @update:model-value="resetSelectedSwappableTasks"
-                          />
-                        </q-card-section>
-                        <q-separator />
-
-                        <q-list dense>
-                          <q-item
-                            v-if="selectedSwapStep?.createNew"
-                            tag="label"
-                          >
-                            <q-item-section avatar>
-                              <q-checkbox
-                                :model-value="true"
-                                disable
-                              />
-                            </q-item-section>
-                            <q-item-section>
-                              <q-item-label>{{ selectedSwapTask?.name }}</q-item-label>
-                              <q-item-label caption>{{ selectedSwapTask?.plugin?.name }}</q-item-label>
-                            </q-item-section>
-                          </q-item>
-
-                          <q-item
-                            v-for="task in selectableSwappableTasks"
-                            :key="`${task.plugin.id}-${task.id || task.name}`"
-                            tag="label"
-                          >
-                            <q-item-section avatar>
-                              <q-checkbox
-                                v-model="selectedSwappableTasks"
-                                :val="task"
-                              />
-                            </q-item-section>
-                            <q-item-section>
-                              <q-item-label>{{ task.name }}</q-item-label>
-                              <q-item-label caption>{{ task.plugin.name }}</q-item-label>
-                            </q-item-section>
-                          </q-item>
-
-                          <q-item v-if="selectableSwappableTasks.length === 0">
-                            <q-item-section class="text-grey-7">
-                              {{
-                                selectedSwapStep?.createNew
-                                  ? "No other tasks with same output parameter types."
-                                  : "No compatible tasks available to add."
-                              }}
-                            </q-item-section>
-                          </q-item>
-                        </q-list>
-
-                        <q-separator />
-                        <q-card-actions align="right">
-                          <q-btn
-                            v-close-popup
-                            flat
-                            color="primary"
-                            label="Cancel"
-                          />
-                          <q-btn
-                            v-close-popup="2"
-                            color="primary"
-                            label="Submit"
-                            :disable="!canSubmitSwappableTasks"
-                            @click="addSelectedSwappableTasks"
-                          />
-                        </q-card-actions>
-                      </q-card>
-                    </q-menu>
                   </q-item>
                 </q-list>
               </q-menu>
@@ -683,6 +604,17 @@
     v-model="showArtifactParamDialog"
     @submit="addArtifactParam"
   />
+  <AddSwappableTaskDialog
+    v-model="showAddSwappableTaskDialog"
+    v-model:selectedSwapStep="selectedSwapStep"
+    v-model:selectedSwappableTasks="selectedSwappableTasks"
+    :selectedSwapTask="selectedSwapTask"
+    :swapStepOptions="swapStepOptions"
+    :selectableSwappableTasks="selectableSwappableTasks"
+    :canSubmit="canSubmitSwappableTasks"
+    @stepChanged="resetSelectedSwappableTasks"
+    @submit="addSelectedSwappableTasks"
+  />
   <LeaveFormDialog
     v-model="showLeaveDialog"
     type="entrypoint"
@@ -735,6 +667,7 @@ import LeaveFormDialog from "@/dialogs/LeaveFormDialog.vue";
 import ReturnToFormDialog from "@/dialogs/ReturnToFormDialog.vue";
 import InfoPopupDialog from "@/dialogs/InfoPopupDialog.vue";
 import ArtifactParamDialog from "@/dialogs/ArtifactParamDialog.vue";
+import AddSwappableTaskDialog from "@/dialogs/AddSwappableTaskDialog.vue";
 import EditPluginTaskParamDialog from "@/dialogs/EditPluginTaskParamDialog.vue";
 import AssignPluginsDropdown from "@/components/AssignPluginsDropdown.vue";
 import ResourcePicker from "@/components/ResourcePicker.vue";
@@ -1231,6 +1164,7 @@ const selectedSwappableTasks = ref([]);
 const eligibleSwapGroups = ref([]);
 const swapStepOptions = ref([]);
 const selectedSwapStep = ref(null);
+const showAddSwappableTaskDialog = ref(false);
 
 function getOutputParameterTypes(task) {
   return task.outputParams.map(
@@ -1318,6 +1252,11 @@ function prepareSwappableTaskSelection(task) {
   ];
   selectedSwapStep.value = swapStepOptions.value[0];
   resetSelectedSwappableTasks();
+}
+
+function openAddSwappableTaskDialog(task) {
+  prepareSwappableTaskSelection(task);
+  showAddSwappableTaskDialog.value = true;
 }
 
 const selectableSwappableTasks = computed(() =>

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -402,7 +402,10 @@
               aria-label="Add to task graph"
             >
               <q-menu>
-                <q-list style="min-width: 240px" dense>
+                <q-list
+                  style="min-width: 240px"
+                  dense
+                >
                   <q-item
                     v-close-popup
                     clickable
@@ -484,8 +487,68 @@
                     </q-menu>
                   </q-item>
 
-                  <q-item disable>
-                    <q-item-section>Add to Existing Swappable Task</q-item-section>
+                  <q-item clickable>
+                    <q-item-section>Add to existing Swap Group</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+
+                    <q-menu
+                      anchor="top end"
+                      self="top start"
+                      @before-show="prepareSwappableTaskSelection(cellProps.row)"
+                    >
+                      <q-card style="min-width: 320px">
+                        <q-card-section class="text-subtitle2"> Select Swap Group </q-card-section>
+                        <q-separator />
+
+                        <q-list dense>
+                          <q-item v-if="taskGraphError || !taskGraphObject">
+                            <q-item-section class="text-grey-7"> Please resolve task graph errors. </q-item-section>
+                          </q-item>
+
+                          <template v-else>
+                            <q-item
+                              v-for="swapGroup in eligibleSwapGroups"
+                              :key="`${swapGroup.stepName}-${swapGroup.swapName}`"
+                              tag="label"
+                            >
+                              <q-item-section avatar>
+                                <q-checkbox
+                                  v-model="selectedEligibleSwapGroups"
+                                  :val="swapGroup"
+                                />
+                              </q-item-section>
+                              <q-item-section>
+                                <q-item-label>{{ swapGroup.swapName.slice(1) }}</q-item-label>
+                                <q-item-label caption>{{ swapGroup.taskNames.join(", ") }}</q-item-label>
+                              </q-item-section>
+                            </q-item>
+
+                            <q-item v-if="eligibleSwapGroups.length === 0">
+                              <q-item-section class="text-grey-7"> No compatible swap groups found. </q-item-section>
+                            </q-item>
+                          </template>
+                        </q-list>
+
+                        <q-separator />
+                        <q-card-actions align="right">
+                          <q-btn
+                            v-close-popup
+                            flat
+                            color="primary"
+                            label="Cancel"
+                          />
+                          <q-btn
+                            v-close-popup="2"
+                            color="primary"
+                            label="Submit"
+                            :disable="selectedEligibleSwapGroups.length === 0"
+                            @click="addTaskToExistingSwapGroups"
+                          />
+                        </q-card-actions>
+                      </q-card>
+                    </q-menu>
                   </q-item>
                 </q-list>
               </q-menu>
@@ -693,6 +756,7 @@ import ArtifactParamDialog from "@/dialogs/ArtifactParamDialog.vue";
 import EditPluginTaskParamDialog from "@/dialogs/EditPluginTaskParamDialog.vue";
 import AssignPluginsDropdown from "@/components/AssignPluginsDropdown.vue";
 import ResourcePicker from "@/components/ResourcePicker.vue";
+import YAML from "yaml";
 
 const route = useRoute();
 
@@ -1148,6 +1212,8 @@ function addToTaskGraph(task) {
 const selectedSwapTask = ref(null);
 const eligibleSwappableTasks = ref([]);
 const selectedSwappableTasks = ref([]);
+const eligibleSwapGroups = ref([]);
+const selectedEligibleSwapGroups = ref([]);
 
 function getOutputParameterTypes(task) {
   return task.outputParams.map(
@@ -1169,10 +1235,51 @@ function findSwappableTasks(task) {
   });
 }
 
+const taskGraphObject = computed(() => {
+  try {
+    return YAML.parse(entryPoint.value.taskGraph);
+  } catch {
+    return null;
+  }
+});
+
+function findEligibleSwapGroups() {
+  if (!taskGraphObject.value || typeof taskGraphObject.value !== "object") return [];
+
+  const eligibleTaskNames = new Set(eligibleSwappableTasks.value.map((task) => task.name));
+  if (selectedSwapTask.value) {
+    eligibleTaskNames.add(selectedSwapTask.value.name);
+  }
+  const swapGroups = [];
+
+  Object.entries(taskGraphObject.value).forEach(([stepName, step]) => {
+    if (!step || typeof step !== "object" || Array.isArray(step)) return;
+
+    Object.entries(step).forEach(([swapName, swapGroup]) => {
+      if (!swapName.startsWith("?") || !swapGroup || typeof swapGroup !== "object" || Array.isArray(swapGroup)) {
+        return;
+      }
+
+      const taskAliases = Object.entries(swapGroup);
+      const taskNames = taskAliases.map(([, taskDefinition]) => taskDefinition?.task);
+      const allTasksAreSwappable =
+        taskAliases.length > 0 && taskNames.every((taskName) => eligibleTaskNames.has(taskName));
+
+      if (allTasksAreSwappable) {
+        swapGroups.push({ stepName, swapName, taskNames });
+      }
+    });
+  });
+
+  return swapGroups;
+}
+
 function prepareSwappableTaskSelection(task) {
   selectedSwapTask.value = task;
   eligibleSwappableTasks.value = findSwappableTasks(task);
   selectedSwappableTasks.value = [task];
+  eligibleSwapGroups.value = findEligibleSwapGroups();
+  selectedEligibleSwapGroups.value = [];
 }
 
 function addSwappableTaskToGraph() {
@@ -1193,6 +1300,26 @@ function addSwappableTaskToGraph() {
   } else {
     entryPoint.value.taskGraph += `\n${string}`;
   }
+}
+
+function addTaskToExistingSwapGroups() {
+  if (taskGraphError.value || !taskGraphObject.value || !selectedSwapTask.value) return;
+
+  selectedEligibleSwapGroups.value.forEach(({ stepName, swapName }) => {
+    const swapGroup = taskGraphObject.value[stepName]?.[swapName];
+    if (!swapGroup) return;
+
+    const taskDefinition = { task: selectedSwapTask.value.name };
+    if (selectedSwapTask.value.inputParams.length > 0) {
+      taskDefinition.kwargs = Object.fromEntries(
+        selectedSwapTask.value.inputParams.map((parameter) => [parameter.name, "<input-value>"]),
+      );
+    }
+
+    swapGroup["<task-alias>"] = taskDefinition;
+  });
+
+  entryPoint.value.taskGraph = YAML.stringify(taskGraphObject.value).trimEnd();
 }
 
 function addToArtifactGraph(task) {

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -329,13 +329,24 @@
 
       <div class="col">
         <h2>Task Plugins</h2>
-        <AssignPluginsDropdown
-          v-model:selectedPlugins="entryPoint.plugins"
-          v-model:pluginIDsToUpdate="pluginIDsToUpdate"
-          v-model:pluginIDsToRemove="pluginIDsToRemove"
-          class="q-mt-lg"
-          :disable="entryPoint.deleted"
-        />
+        <div class="row items-start no-wrap q-mt-lg">
+          <AssignPluginsDropdown
+            ref="taskPluginsDropdown"
+            v-model:selectedPlugins="entryPoint.plugins"
+            v-model:pluginIDsToUpdate="pluginIDsToUpdate"
+            v-model:pluginIDsToRemove="pluginIDsToRemove"
+            class="col"
+            :disable="entryPoint.deleted"
+          />
+          <q-btn
+            label="Save Plugin Selection"
+            color="primary"
+            class="q-ml-sm"
+            :loading="savingPluginType === 'plugins'"
+            :disable="route.params.id === 'new' || history || entryPoint.deleted || !taskPluginChangesPending"
+            @click="savePluginChanges('plugins')"
+          />
+        </div>
         <TableComponent
           :rows="tasks"
           :columns="taskColumns"
@@ -470,13 +481,24 @@
 
       <div class="col">
         <h2>Artifact Task Plugins</h2>
-        <AssignPluginsDropdown
-          v-model:selectedPlugins="entryPoint.artifactPlugins"
-          v-model:pluginIDsToUpdate="artifactPluginIDsToUpdate"
-          v-model:pluginIDsToRemove="artifactPluginIDsToRemove"
-          class="q-mt-lg"
-          :disable="entryPoint.deleted"
-        />
+        <div class="row items-start no-wrap q-mt-lg">
+          <AssignPluginsDropdown
+            ref="artifactTaskPluginsDropdown"
+            v-model:selectedPlugins="entryPoint.artifactPlugins"
+            v-model:pluginIDsToUpdate="artifactPluginIDsToUpdate"
+            v-model:pluginIDsToRemove="artifactPluginIDsToRemove"
+            class="col"
+            :disable="entryPoint.deleted"
+          />
+          <q-btn
+            label="Save Plugin Selection"
+            color="primary"
+            class="q-ml-sm"
+            :loading="savingPluginType === 'artifactPlugins'"
+            :disable="route.params.id === 'new' || history || entryPoint.deleted || !artifactPluginChangesPending"
+            @click="savePluginChanges('artifactPlugins')"
+          />
+        </div>
         <TableComponent
           :rows="artifactTasks"
           :columns="artifactTaskColumns"
@@ -1383,6 +1405,48 @@ const pluginIDsToUpdate = ref([]);
 const artifactPluginIDsToUpdate = ref([]);
 const pluginIDsToRemove = ref([]);
 const artifactPluginIDsToRemove = ref([]);
+const taskPluginsDropdown = ref(null);
+const artifactTaskPluginsDropdown = ref(null);
+const savingPluginType = ref(null);
+
+const taskPluginChangesPending = computed(
+  () => pluginIDsToUpdate.value.length > 0 || pluginIDsToRemove.value.length > 0,
+);
+const artifactPluginChangesPending = computed(
+  () => artifactPluginIDsToUpdate.value.length > 0 || artifactPluginIDsToRemove.value.length > 0,
+);
+
+async function savePluginChanges(pluginType) {
+  const isArtifactPlugin = pluginType === "artifactPlugins";
+  const pluginIDsToSave = isArtifactPlugin ? artifactPluginIDsToUpdate : pluginIDsToUpdate;
+  const pluginIDsToDelete = isArtifactPlugin ? artifactPluginIDsToRemove : pluginIDsToRemove;
+  const dropdown = isArtifactPlugin ? artifactTaskPluginsDropdown : taskPluginsDropdown;
+  const pluginLabel = isArtifactPlugin ? "artifact task plugins" : "task plugins";
+
+  if (route.params.id === "new" || (pluginIDsToSave.value.length === 0 && pluginIDsToDelete.value.length === 0)) {
+    return;
+  }
+
+  savingPluginType.value = pluginType;
+  try {
+    if (pluginIDsToSave.value.length > 0) {
+      await api.addPluginsToEntrypoint(route.params.id, pluginIDsToSave.value, pluginType);
+    }
+    for (const pluginId of pluginIDsToDelete.value) {
+      await api.removePluginFromEntrypoint(route.params.id, pluginId, pluginType);
+    }
+
+    pluginIDsToSave.value = [];
+    pluginIDsToDelete.value = [];
+    copyAtEditStart.value[pluginType] = JSON.parse(JSON.stringify(entryPoint.value[pluginType]));
+    dropdown.value?.resetOriginalSelectedPlugins();
+    notify.success(`Successfully saved ${pluginLabel}`);
+  } catch (err) {
+    notify.error(err.response?.data?.message ?? `Failed to save ${pluginLabel}`);
+  } finally {
+    savingPluginType.value = null;
+  }
+}
 
 const objectForDeletion = ref();
 

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -399,8 +399,97 @@
               size="xs"
               color="grey-5"
               text-color="black"
-              @click="addToTaskGraph(cellProps.row)"
-            />
+              aria-label="Add to task graph"
+            >
+              <q-menu>
+                <q-list style="min-width: 240px" dense>
+                  <q-item
+                    v-close-popup
+                    clickable
+                    @click="addToTaskGraph(cellProps.row)"
+                  >
+                    <q-item-section>Add Task</q-item-section>
+                  </q-item>
+
+                  <q-item clickable>
+                    <q-item-section>Add Swappable Task</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+
+                    <q-menu
+                      anchor="top end"
+                      self="top start"
+                      @before-show="prepareSwappableTaskSelection(cellProps.row)"
+                    >
+                      <q-card style="min-width: 320px">
+                        <q-card-section class="text-subtitle2"> Select tasks to include </q-card-section>
+                        <q-separator />
+
+                        <q-list dense>
+                          <q-item tag="label">
+                            <q-item-section avatar>
+                              <q-checkbox
+                                :model-value="true"
+                                disable
+                              />
+                            </q-item-section>
+                            <q-item-section>
+                              <q-item-label>{{ selectedSwapTask?.name }}</q-item-label>
+                              <q-item-label caption>{{ selectedSwapTask?.plugin?.name }}</q-item-label>
+                            </q-item-section>
+                          </q-item>
+
+                          <q-item
+                            v-for="task in eligibleSwappableTasks"
+                            :key="`${task.plugin.id}-${task.id || task.name}`"
+                            tag="label"
+                          >
+                            <q-item-section avatar>
+                              <q-checkbox
+                                v-model="selectedSwappableTasks"
+                                :val="task"
+                              />
+                            </q-item-section>
+                            <q-item-section>
+                              <q-item-label>{{ task.name }}</q-item-label>
+                              <q-item-label caption>{{ task.plugin.name }}</q-item-label>
+                            </q-item-section>
+                          </q-item>
+
+                          <q-item v-if="eligibleSwappableTasks.length === 0">
+                            <q-item-section class="text-grey-7">
+                              No other tasks with same output parameter types.
+                            </q-item-section>
+                          </q-item>
+                        </q-list>
+
+                        <q-separator />
+                        <q-card-actions align="right">
+                          <q-btn
+                            v-close-popup
+                            flat
+                            color="primary"
+                            label="Cancel"
+                          />
+                          <q-btn
+                            v-close-popup="2"
+                            color="primary"
+                            label="Submit"
+                            :disable="selectedSwappableTasks.length < 2"
+                            @click="addSwappableTaskToGraph"
+                          />
+                        </q-card-actions>
+                      </q-card>
+                    </q-menu>
+                  </q-item>
+
+                  <q-item disable>
+                    <q-item-section>Add to Existing Swappable Task</q-item-section>
+                  </q-item>
+                </q-list>
+              </q-menu>
+            </q-btn>
           </template>
         </TableComponent>
       </div>
@@ -890,14 +979,10 @@ async function checkIfStillValid(type) {
 const taskGraphError = ref("");
 
 const taskGraphPlaceholderError = computed(() => {
-  if (entryPoint.value.taskGraph.includes("<step-name>") && entryPoint.value.taskGraph.includes("<input-value>")) {
-    return "Replace <step-name> and <input-value> placeholders";
-  } else if (entryPoint.value.taskGraph.includes("<step-name>")) {
-    return "Replace <step-name> placeholders";
-  } else if (entryPoint.value.taskGraph.includes("<input-value>")) {
-    return "Replace <input-value> placeholders";
-  }
-  return "";
+  const placeholders = entryPoint.value.taskGraph.match(/<(?:step-name|swap-name|task-alias|input-value)>/g);
+  if (!placeholders) return "";
+
+  return `Replace ${[...new Set(placeholders)].join(", ")} placeholders`;
 });
 
 function submit() {
@@ -1060,6 +1145,56 @@ function addToTaskGraph(task) {
   }
 }
 
+const selectedSwapTask = ref(null);
+const eligibleSwappableTasks = ref([]);
+const selectedSwappableTasks = ref([]);
+
+function getOutputParameterTypes(task) {
+  return task.outputParams.map(
+    (parameter) => parameter.parameterType?.id ?? parameter.parameterType?.name ?? parameter.parameterType,
+  );
+}
+
+function findSwappableTasks(task) {
+  const outputParameterTypes = getOutputParameterTypes(task);
+
+  return tasks.value.filter((candidate) => {
+    if (candidate === task) return false;
+
+    const candidateOutputParameterTypes = getOutputParameterTypes(candidate);
+    return (
+      candidateOutputParameterTypes.length === outputParameterTypes.length &&
+      candidateOutputParameterTypes.every((type, index) => type === outputParameterTypes[index])
+    );
+  });
+}
+
+function prepareSwappableTaskSelection(task) {
+  selectedSwapTask.value = task;
+  eligibleSwappableTasks.value = findSwappableTasks(task);
+  selectedSwappableTasks.value = [task];
+}
+
+function addSwappableTaskToGraph() {
+  let string = `<step-name>:\n  ?<swap-name>:`;
+
+  selectedSwappableTasks.value.forEach((task) => {
+    string += `\n    <task-alias>:\n      task: ${task.name}`;
+    if (task.inputParams.length > 0) {
+      string += `\n      kwargs:`;
+      task.inputParams.forEach((parameter) => {
+        string += `\n        ${parameter.name}: <input-value>`;
+      });
+    }
+  });
+
+  if (entryPoint.value.taskGraph.trim().length === 0) {
+    entryPoint.value.taskGraph = string;
+  } else {
+    entryPoint.value.taskGraph += `\n${string}`;
+  }
+}
+
 function addToArtifactGraph(task) {
   const string = `<output-name>:\n  contents: <contents>\n  task:\n    name: ${task.name}`;
   if (entryPoint.value.artifactGraph.trim().length === 0) {
@@ -1149,7 +1284,7 @@ async function validateEntrypoint() {
   }
 
   const submitObject = prepareEntrypointPayload();
-  console.log('payload = ', JSON.parse(JSON.stringify(entryPoint.value)))
+  console.log("payload = ", JSON.parse(JSON.stringify(entryPoint.value)));
   try {
     if (route.params.id === "new") {
       await api.addItem("entrypoints", submitObject, true);

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -630,12 +630,17 @@
       "
     />
 
-    <q-btn
-      label="Validate"
-      color="primary"
-      class="q-mr-lg"
-      @click="validateEntrypoint()"
-    />
+    <span class="q-mr-lg">
+      <q-btn
+        label="Validate"
+        color="primary"
+        :disable="taskPluginsChanged"
+        @click="validateEntrypoint()"
+      />
+      <q-tooltip v-if="taskPluginsChanged">
+        The task plugin selection has changed. Save your changes before validating.
+      </q-tooltip>
+    </span>
 
     <q-btn
       :color="history ? 'blue-2' : 'primary'"
@@ -798,6 +803,10 @@ const enableSubmit = computed(() => {
 });
 
 const copyAtEditStart = ref({});
+
+const taskPluginsChanged = computed(() => {
+  return JSON.stringify(copyAtEditStart.value.plugins) !== JSON.stringify(entryPoint.value.plugins);
+});
 
 onMounted(() => {
   if (route.query.snapshotId && !store.showRightDrawer) {
@@ -1093,11 +1102,6 @@ async function addOrModifyEntrypoint() {
       store.savedForms.entryPoint = null;
       notify.success(`Successfully created '${entryPoint.value.name}'`);
     } else {
-      if (valuesChangedFromEditStartBesidesPlugins.value) {
-        const keysToRemove = ["group", "plugins", "artifactPlugins"];
-        keysToRemove.forEach((key) => delete submitObject[key]);
-        await api.updateItem("entrypoints", route.params.id, submitObject);
-      }
       if (pluginIDsToUpdate.value.length > 0) {
         await api.addPluginsToEntrypoint(route.params.id, pluginIDsToUpdate.value, "plugins");
       }
@@ -1109,6 +1113,11 @@ async function addOrModifyEntrypoint() {
       }
       for (const pluginId of artifactPluginIDsToRemove.value) {
         await api.removePluginFromEntrypoint(route.params.id, pluginId, "artifactPlugins");
+      }
+      if (valuesChangedFromEditStartBesidesPlugins.value) {
+        const keysToRemove = ["group", "plugins", "artifactPlugins"];
+        keysToRemove.forEach((key) => delete submitObject[key]);
+        await api.updateItem("entrypoints", route.params.id, submitObject);
       }
       notify.success(`Successfully updated '${entryPoint.value.name}'`);
     }
@@ -1408,6 +1417,7 @@ onBeforeRouteLeave((to) => {
     leaveForm();
   } else {
     showLeaveDialog.value = true;
+    return false;
   }
 });
 

--- a/src/frontend/src/views/CreateEntryPoint.vue
+++ b/src/frontend/src/views/CreateEntryPoint.vue
@@ -325,12 +325,6 @@
           :readOnly="history || entryPoint.deleted"
           style="min-height: 200px"
         />
-        <q-btn
-          label="Validate Inputs"
-          color="primary"
-          class="self-start"
-          @click="validateInputs()"
-        />
       </div>
 
       <div class="col">
@@ -508,6 +502,14 @@
         store.initialPage ? router.push('/entrypoints') : router.back();
       "
     />
+
+    <q-btn
+      label="Validate"
+      color="primary"
+      class="q-mr-lg"
+      @click="validateEntrypoint()"
+    />
+
     <q-btn
       :color="history ? 'blue-2' : 'primary'"
       label="Submit EntryPoint"
@@ -912,8 +914,8 @@ function submit() {
   });
 }
 
-async function addOrModifyEntrypoint() {
-  const submitObject = JSON.parse(JSON.stringify(entryPoint.value));
+function prepareEntrypointPayload() {
+  const payload = JSON.parse(JSON.stringify(entryPoint.value));
   const keysToKeep = [
     "group",
     "name",
@@ -926,23 +928,30 @@ async function addOrModifyEntrypoint() {
     "plugins",
     "artifactPlugins",
   ];
-  for (const key of Object.keys(submitObject)) {
+  for (const key of Object.keys(payload)) {
     if (!keysToKeep.includes(key)) {
-      delete submitObject[key];
+      delete payload[key];
     }
   }
-  // turn objects into ids
-  submitObject.queues = submitObject.queues.map((q) => q.id);
-  submitObject.plugins = submitObject.plugins.map((p) => p.id);
-  submitObject.artifactPlugins = submitObject.artifactPlugins.map((p) => p.id);
 
-  submitObject.artifactParameters = submitObject.artifactParameters.map((param) => ({
+  // turn objects into ids
+  payload.queues = payload.queues.map((queue) => queue.id);
+  payload.plugins = payload.plugins.map((plugin) => plugin.id);
+  payload.artifactPlugins = payload.artifactPlugins.map((plugin) => plugin.id);
+
+  payload.artifactParameters = payload.artifactParameters.map((param) => ({
     ...param,
     outputParams: param.outputParams.map((oParam) => ({
       ...oParam,
       parameterType: oParam.parameterType.id,
     })),
   }));
+
+  return payload;
+}
+
+async function addOrModifyEntrypoint() {
+  const submitObject = prepareEntrypointPayload();
   try {
     if (route.params.id === "new") {
       await api.addItem("entrypoints", submitObject);
@@ -1129,29 +1138,27 @@ async function deleteEntrypoint() {
 const inputErrors = ref([]);
 const displayErrorDialog = ref(false);
 
-async function validateInputs() {
+async function validateEntrypoint() {
+  if (taskGraphError.value) {
+    notify.error(taskGraphError.value);
+    return;
+  }
+  if (!entryPoint.value.name) {
+    notify.error("Please provide an Entrypoint name");
+    return;
+  }
+
+  const submitObject = prepareEntrypointPayload();
+  console.log('payload = ', JSON.parse(JSON.stringify(entryPoint.value)))
   try {
-    const res = await api.validateEntrypoint({
-      group: entryPoint.value.group.id || entryPoint.value.group,
-      taskGraph: entryPoint.value.taskGraph,
-      pluginSnapshots: entryPoint.value.plugins.map((plugin) => plugin.snapshotId || plugin.snapshot),
-      parameters: entryPoint.value.parameters,
-      artifacts: entryPoint.value.artifactParameters.map((param) => ({
-        ...param,
-        outputParams: param.outputParams.map((oParam) => ({
-          ...oParam,
-          parameterType: oParam.parameterType.id,
-        })),
-      })),
-    });
-    if (res?.data?.schemaValid && !taskGraphPlaceholderError.value) {
-      notify.success(`Entrypoint inputs are valid!`);
-    } else if (res?.data?.schemaIssues.length > 0 || taskGraphPlaceholderError.value) {
-      inputErrors.value = res.data.schemaIssues;
-      if (taskGraphPlaceholderError.value) {
-        inputErrors.value.push({ message: taskGraphPlaceholderError.value });
-      }
-      displayErrorDialog.value = true;
+    if (route.params.id === "new") {
+      await api.addItem("entrypoints", submitObject, true);
+      notify.success(`Entrypoint is valid!`);
+    } else {
+      const keysToRemove = ["group", "plugins", "artifactPlugins"];
+      keysToRemove.forEach((key) => delete submitObject[key]);
+      await api.updateItem("entrypoints", route.params.id, submitObject, true);
+      notify.success(`Entrypoint is valid!`);
     }
   } catch (err) {
     notify.error(err.response.data.message);

--- a/src/frontend/tests/helpers/createResourceHelper.ts
+++ b/src/frontend/tests/helpers/createResourceHelper.ts
@@ -30,6 +30,11 @@ export async function createQueue(page: Page, queueName: string) {
 }
 
 export async function createEntrypoint(page: Page, entrypointName: string, queueName: string) {
+  const pluginName = `${entrypointName}_plugin`;
+  const pluginFilename = `${entrypointName}_tasks.py`;
+  const createdPlugin = await createPlugin(page, pluginName);
+  await createPluginFile(page, createdPlugin.id, pluginFilename);
+
   await page.goto("/entrypoints/new");
 
   await page.getByRole("heading", { name: "Create Entrypoint" }).waitFor();
@@ -41,8 +46,13 @@ export async function createEntrypoint(page: Page, entrypointName: string, queue
   await queueSelect.fill(queueName);
   await page.getByRole("option", { name: queueName }).click();
 
+  const pluginSelect = page.getByRole("combobox", { name: "Plugins:" }).first();
+  await pluginSelect.click();
+  await pluginSelect.fill(pluginName);
+  await page.getByRole("option", { name: pluginName }).click();
+
   await page.locator(".cm-content").first().click();
-  await page.keyboard.insertText("graph:\n");
+  await page.keyboard.insertText("e2e_step:\n  task: e2e_task\n");
 
   const createResponsePromise = page.waitForResponse(
     (response) => response.url().includes("/api/v1/entrypoints") && response.request().method() === "POST",
@@ -50,11 +60,11 @@ export async function createEntrypoint(page: Page, entrypointName: string, queue
 
   await page.getByRole("button", { name: "Submit EntryPoint" }).click();
   const createResponse = await createResponsePromise;
+  const createdEntrypoint = await createResponse.json();
   expect(
     createResponse.ok(),
-    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}: ${JSON.stringify(createdEntrypoint)}`,
   ).toBe(true);
-  const createdEntrypoint = await createResponse.json();
 
   await expect(
     page.getByRole("alert").filter({
@@ -93,4 +103,44 @@ export async function createPlugin(page: Page, pluginName: string) {
   await expect(page).toHaveURL(/\/plugins$/);
 
   return createdPlugin;
+}
+
+export async function createPluginFile(page: Page, pluginId: number, filename: string) {
+  await page.goto(`/plugins/${pluginId}/files/new`);
+
+  await page.getByRole("heading", { name: "Create Plugin File" }).waitFor();
+  await page.getByRole("textbox", { name: "Filename:" }).fill(filename);
+  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
+  await page.locator(".cm-content").first().click();
+  await page.keyboard.insertText(
+    "from dioptra import pyplugs\n\n@pyplugs.register\ndef e2e_task() -> None:\n    return None\n",
+  );
+
+  await page.getByRole("button", { name: "Import Function Tasks" }).click();
+  const importTasksDialog = page.getByRole("dialog");
+  await expect(importTasksDialog.getByText("Import Plugin Function Tasks", { exact: true })).toBeVisible();
+  await expect(importTasksDialog.getByText("e2e_task", { exact: true })).toBeVisible();
+  await importTasksDialog.getByRole("button", { name: "Import", exact: true }).click();
+
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/v1/plugins/${pluginId}/files`) && response.request().method() === "POST",
+  );
+
+  await page.getByRole("button", { name: "Submit File" }).click();
+  const createResponse = await createResponsePromise;
+  expect(
+    createResponse.ok(),
+    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
+  ).toBe(true);
+  const createdPluginFile = await createResponse.json();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: `Successfully created '${filename}'`,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/plugins/${pluginId}$`));
+
+  return createdPluginFile;
 }

--- a/src/frontend/tests/pluginFile.spec.ts
+++ b/src/frontend/tests/pluginFile.spec.ts
@@ -1,39 +1,7 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-import { createPlugin } from "./helpers/createResourceHelper";
+import { createPlugin, createPluginFile } from "./helpers/createResourceHelper";
 import { ensureLoggedInAsTestUser } from "./helpers/testUserHelper";
-
-async function createPluginFile(page: Page, pluginId: number, filename: string) {
-  await page.goto(`/plugins/${pluginId}/files/new`);
-
-  await page.getByRole("heading", { name: "Create Plugin File" }).waitFor();
-  await page.getByRole("textbox", { name: "Filename:" }).fill(filename);
-  await page.getByRole("textbox", { name: "Description:" }).fill("Created by Playwright");
-  await page.locator(".cm-content").first().click();
-  await page.keyboard.insertText("def e2e_task():\n    return None\n");
-
-  const createResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes(`/api/v1/plugins/${pluginId}/files`) && response.request().method() === "POST",
-  );
-
-  await page.getByRole("button", { name: "Submit File" }).click();
-  const createResponse = await createResponsePromise;
-  expect(
-    createResponse.ok(),
-    `Expected POST ${createResponse.url()} to succeed, got ${createResponse.status()} ${createResponse.statusText()}`,
-  ).toBe(true);
-  const createdPluginFile = await createResponse.json();
-
-  await expect(
-    page.getByRole("alert").filter({
-      hasText: `Successfully created '${filename}'`,
-    }),
-  ).toBeVisible();
-  await expect(page).toHaveURL(new RegExp(`/plugins/${pluginId}$`));
-
-  return createdPluginFile;
-}
 
 test("create pluginFile", async ({ page }) => {
   const timestamp = Date.now();


### PR DESCRIPTION
Closes #827 

- "Add swappable task" lets you group swappable tasks
- "Add to existing swap group" lets you add to an existing group (task graph must be valid for options to show)
- Swappable icon next to task name with tooltip
- Move validate button next to submit since it's validating the whole entrypoint